### PR TITLE
Notifications

### DIFF
--- a/app/Exceptions/ShouldDeleteNotificationException.php
+++ b/app/Exceptions/ShouldDeleteNotificationException.php
@@ -4,7 +4,9 @@ namespace App\Exceptions;
 
 use Exception;
 
-class ShouldDeleteNotificationException extends Exception
-{
-    //
-}
+/**
+ * Exception that a notification instance can throw towards the NotificationController if it thinks
+ * that it has become useless (e.g. The like doesn't exist anymore or the other person removed 
+ * their check-in).
+ */
+class ShouldDeleteNotificationException extends Exception { }

--- a/app/Exceptions/ShouldDeleteNotificationException.php
+++ b/app/Exceptions/ShouldDeleteNotificationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class ShouldDeleteNotificationException extends Exception
+{
+    //
+}

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Response;
+
+class NotificationController extends Controller {
+    
+    public function latest() {
+        return Auth::user()->notifications
+            ->take(10)
+            ->map(function($notification) {
+                $notification->html = $notification->type::render($notification);
+                return $notification;
+            });
+    }
+}

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -22,6 +22,7 @@ class NotificationController extends Controller {
                 }
             })
             // We don't need empty notifications
-            ->filter(function($notification_or_null) { return $notification_or_null != null; });
+            ->filter(function($notification_or_null) { return $notification_or_null != null; })
+            ->values();
     }
 }

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -29,7 +29,8 @@ class NotificationController extends Controller {
     public static function toggleReadState($id) {
         $notification = Auth::user()->notifications->where('id', $id)->first();
         
-        // Might have cached the html property and would then try to shove it in the DB
+        // Might have cached the html property and would then try to shove it in the DB, mostly
+        // happened during tests.
         if(isset($notification->html)) unset($notification->html);
 
         if($notification->read_at == null) { // old state = unread

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -25,4 +25,16 @@ class NotificationController extends Controller {
             ->filter(function($notification_or_null) { return $notification_or_null != null; })
             ->values();
     }
+
+    public static function toggleReadState($id) {
+        $notification = Auth::user()->notifications->where('id', $id)->first();
+
+        if($notification->read_at == null) { // old state = unread
+            $notification->markAsRead();
+            return response("", 201); // new state = read, 201=created
+        } else { // old state = read
+            $notification->markAsUnread();
+            return response("", 202); // new state = unread, 202=accepted
+        }
+    }
 }

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -28,6 +28,9 @@ class NotificationController extends Controller {
 
     public static function toggleReadState($id) {
         $notification = Auth::user()->notifications->where('id', $id)->first();
+        
+        // Might have cached the html property and would then try to shove it in the DB
+        if(isset($notification->html)) unset($notification->html);
 
         if($notification->read_at == null) { // old state = unread
             $notification->markAsRead();
@@ -36,5 +39,9 @@ class NotificationController extends Controller {
             $notification->markAsUnread();
             return response("", 202); // new state = unread, 202=accepted
         }
+    }
+
+    public function readAll() {
+        Auth::user()->unreadNotifications->markAsRead();
     }
 }

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -35,10 +35,10 @@ class NotificationController extends Controller {
 
         if($notification->read_at == null) { // old state = unread
             $notification->markAsRead();
-            return response("", 201); // new state = read, 201=created
+            return Response::json($notification, 201); // new state = read, 201=created
         } else { // old state = read
             $notification->markAsUnread();
-            return response("", 202); // new state = unread, 202=accepted
+            return Response::json($notification, 202); // new state = unread, 202=accepted
         }
     }
 

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Exceptions\ShouldDeleteNotificationException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Response;
@@ -12,8 +13,15 @@ class NotificationController extends Controller {
         return Auth::user()->notifications
             ->take(10)
             ->map(function($notification) {
-                $notification->html = $notification->type::render($notification);
-                return $notification;
-            });
+                try {
+                    $notification->html = $notification->type::render($notification);
+                    return $notification;
+                } catch (ShouldDeleteNotificationException $e) {
+                    $notification->delete();
+                    return null;
+                }
+            })
+            // We don't need empty notifications
+            ->filter(function($notification_or_null) { return $notification_or_null != null; });
     }
 }

--- a/app/Http/Controllers/SocialController.php
+++ b/app/Http/Controllers/SocialController.php
@@ -44,7 +44,7 @@ class SocialController extends Controller
             if (empty($server)) {
                 try {
                     //create new app
-                    $info = Mastodon::domain($domain)->createApp(config('trwl.mastodon_appname'), config('mastodon_redirect'), 'write read');
+                    $info = Mastodon::domain($domain)->createApp(config('trwl.mastodon_appname'), config('trwl.mastodon_redirect'), 'write read');
 
                     //save app info
                     $server = MastodonServer::create([

--- a/app/Http/Controllers/SocialController.php
+++ b/app/Http/Controllers/SocialController.php
@@ -44,7 +44,7 @@ class SocialController extends Controller
             if (empty($server)) {
                 try {
                     //create new app
-                    $info = Mastodon::domain($domain)->createApp(config('trwl.mastodon_appname'), config('trwl.mastodon_redirect'), 'write read');
+                    $info = Mastodon::domain($domain)->createApp(config('trwl.mastodon_appname'), config('mastodon_redirect'), 'write read');
 
                     //save app info
                     $server = MastodonServer::create([

--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -100,7 +100,7 @@ class StatusController extends Controller
         $like->user_id = $user->id;
         $like->status_id = $status->id;
         $like->save();
-        $status->user->notify(new StatusLiked($user, $status));
+        $status->user->notify(new StatusLiked($like));
         return true;
     }
 

--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -7,6 +7,7 @@ use App\Like;
 use App\Status;
 use App\TrainCheckin;
 use App\TrainStations;
+use App\Notifications\StatusLiked;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -99,6 +100,7 @@ class StatusController extends Controller
         $like->user_id = $user->id;
         $like->status_id = $status->id;
         $like->save();
+        $status->user->notify(new StatusLiked($user, $status));
         return true;
     }
 

--- a/app/Http/Controllers/TransportController.php
+++ b/app/Http/Controllers/TransportController.php
@@ -341,9 +341,11 @@ class TransportController extends Controller
                 try {
                     $mastodonDomain = MastodonServer::where('id', $user->socialProfile->mastodon_server)->first()->domain;
                     Mastodon::domain($mastodonDomain)->token($user->socialProfile->mastodon_token);
-                    Mastodon::createStatus($post_text . $post_url, ['visibility' => 'private']);
+                    Mastodon::createStatus($post_text . $post_url, ['visibility' => 'unlisted']);
                 } catch (RequestException $e) {
                     $user->notify(new MastodonNotSend($e->getResponse()->getStatusCode(), $status));
+                } catch (\Exception $e) {
+                    // Other exceptions are thrown into the void.
                 }
             }
             if (isset($tweet_check)) {
@@ -371,7 +373,8 @@ class TransportController extends Controller
                         $user->notify(new TwitterNotSend($connection->getLastHttpCode(), $status));
                     }
                 } catch (\Exception $exception) {
-                    // The Twitter adapter itself won't throw Exceptions
+                    // The Twitter adapter itself won't throw Exceptions, but rather return HTTP codes.
+                    // However, we still want to continue if it explodes, thus why not catch exceptions here.
                 }
             }
         }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -13,6 +13,7 @@ use App\Notifications\UserFollowed;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
@@ -154,6 +155,7 @@ class UserController extends Controller
 
         SocialLoginProfile::where('user_id', $user->id)->delete();
         Follow::where('user_id', $user->id)->orWhere('follow_id', $user->id)->delete();
+        DatabaseNotification::where(['notifiable_id' => $user->id, 'notifiable_type' => get_class($user)])->delete();
 
         $user->delete();
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -9,6 +9,7 @@ use App\Status;
 use App\HafasTrip;
 use App\TrainCheckin;
 use App\Like;
+use App\Notifications\UserFollowed;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -188,6 +189,10 @@ class UserController extends Controller
 
     }
 
+    /** 
+     * @param User The user who wants to see stuff in their timeline
+     * @param int The user id of the person who is followed
+     */
     public static function CreateFollow($user, $follow_id) {
         $follow = $user->follows()->where('follow_id', $follow_id)->first();
         if ($follow) {
@@ -198,9 +203,15 @@ class UserController extends Controller
         $follow->user_id = $user->id;
         $follow->follow_id = $follow_id;
         $follow->save();
+        
+        User::find($follow_id)->notify(new UserFollowed($follow));
         return true;
     }
 
+    /** 
+     * @param User The user who doesn't want to see stuff in their timeline anymore
+     * @param int The user id of the person who was followed and now isn't
+     */
     public static function DestroyFollow($user, $follow_id) {
         $follow = $user->follows()->where('follow_id', $follow_id)->where('user_id', $user->id)->first();
         if ($follow) {

--- a/app/Notifications/MastodonNotSend.php
+++ b/app/Notifications/MastodonNotSend.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Exceptions\ShouldDeleteNotificationException;
+use App\Status;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class MastodonNotSend extends Notification {
+    use Queueable;
+
+    public $error;
+    public $status;
+
+    public function __construct($error, Status $status) {
+        $this->error = $error;
+        $this->status = $status;
+    }
+
+    public function via($notifiable)
+    {
+        return ['database'];
+    }
+
+    public function toArray($notifiable)
+    {
+        return [
+            'error' => $this->error,
+            'status_id' => $this->status->id,
+        ];
+    }
+
+    public static function render($notification) {
+        $data = $notification->data;
+        
+        try {
+            $status = Status::findOrFail($data['status_id']);
+        } catch(ModelNotFoundException $e) {
+            throw new ShouldDeleteNotificationException();
+        }
+
+        $hafas = $status->trainCheckin->hafasTrip;
+        
+        return view("includes.notification", [
+            'color' => "warning",
+            'icon' => "fas fa-exclamation-triangle",
+            'lead' => __('notifications.socialNotShared.lead', ['platform' => "Mastodon"]),
+            "link" => route('statuses.get', ['id' => $status->id]),
+            'notice' => __('notifications.socialNotShared.mastodon.' . $data['error']),
+
+            'date_for_humans' => $notification->created_at->diffForHumans(),
+            'read' => $notification->read_at != null,
+            'notificationId' => $notification->id
+        ])->render();
+    }
+}

--- a/app/Notifications/StatusLiked.php
+++ b/app/Notifications/StatusLiked.php
@@ -79,7 +79,8 @@ class StatusLiked extends Notification {
                 ]
                 ),
             'date_for_humans' => $notification->created_at->diffForHumans(),
-            'read' => $notification->read_at != null
+            'read' => $notification->read_at != null,
+            'notificationId' => $notification->id
 
         ])->render();
     }

--- a/app/Notifications/StatusLiked.php
+++ b/app/Notifications/StatusLiked.php
@@ -76,6 +76,7 @@ class StatusLiked extends Notification {
             'color' => "neutral",
             'icon' => "fas fa-heart",
             'lead' => __('notifications.statusLiked.lead', ['likerUsername' => $sender->username]),
+            "link" => route('statuses.get', ['id' => $status->id]),
             'notice' => trans_choice(
                 'notifications.statusLiked.notice',
                 preg_match('/\s/', $hafas->linename),

--- a/app/Notifications/StatusLiked.php
+++ b/app/Notifications/StatusLiked.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Status;
+use App\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class StatusLiked extends Notification {
+    use Queueable;
+
+    public $sender;
+    public $status;
+
+    /**
+     * Hide certain fields from appearing in JSON
+     */
+    protected $hidden = [
+        "locale",
+        "connection",
+        "queue",
+        "chainConnection",
+        "chainQueue",
+        "delay",
+        "chained"
+    ];
+
+    /**
+     * Create a new notification instance
+     *
+     * @param User Who liked the status?
+     * @param Status Which status was liked?
+     * @return void
+     */
+    public function __construct(User $sender = null, Status $status = null) {
+        $this->sender = $sender;
+        $this->status = $status;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            'sender_id' => $this->sender->id,
+            'status_id' => $this->status->id
+        ];
+    }
+
+    public static function render($notification) {
+        $data = $notification->data;
+        $sender = User::findOrFail($data['sender_id']);
+        $status = Status::findOrFail($data['status_id']);
+        $hafas = $status->trainCheckin->hafasTrip;
+        
+        return view("includes.notification", [
+            'color' => "neutral",
+            'icon' => "fas fa-heart",
+            'lead' => __('notifications.statusLiked.lead', ['likerUsername' => $sender->username]),
+            'notice' => trans_choice(
+                'notifications.statusLiked.notice',
+                preg_match('/\s/', $hafas->linename),
+                [
+                    'line' => $hafas->linename,
+                    'createdDate' => date("Y-m-d", strtotime($hafas->departure))
+                ]
+                ),
+            'date_for_humans' => $notification->created_at->diffForHumans(),
+            'read' => $notification->read_at != null
+
+        ])->render();
+    }
+}

--- a/app/Notifications/TwitterNotSend.php
+++ b/app/Notifications/TwitterNotSend.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Exceptions\ShouldDeleteNotificationException;
+use App\Status;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class TwitterNotSend extends Notification {
+    use Queueable;
+
+    public $error;
+    public $status;
+
+    public function __construct($error, Status $status) {
+        $this->error = $error;
+        $this->status = $status;
+    }
+
+    public function via($notifiable)
+    {
+        return ['database'];
+    }
+
+    public function toArray($notifiable)
+    {
+        return [
+            'error' => $this->error,
+            'status_id' => $this->status->id,
+        ];
+    }
+
+    public static function render($notification) {
+        $data = $notification->data;
+        
+        try {
+            $status = Status::findOrFail($data['status_id']);
+        } catch(ModelNotFoundException $e) {
+            throw new ShouldDeleteNotificationException();
+        }
+
+        $hafas = $status->trainCheckin->hafasTrip;
+        
+        return view("includes.notification", [
+            'color' => "warning",
+            'icon' => "fas fa-exclamation-triangle",
+            'lead' => __('notifications.socialNotShared.lead', ['platform' => "Twitter"]),
+            "link" => route('statuses.get', ['id' => $status->id]),
+            'notice' => __('notifications.socialNotShared.twitter.' . $data['error']),
+
+            'date_for_humans' => $notification->created_at->diffForHumans(),
+            'read' => $notification->read_at != null,
+            'notificationId' => $notification->id
+        ])->render();
+    }
+}

--- a/app/Notifications/UserFollowed.php
+++ b/app/Notifications/UserFollowed.php
@@ -68,7 +68,8 @@ class UserFollowed extends Notification {
             "link" => route('account.show', ['username' => $sender->username]),
             'notice' => "",
             'date_for_humans' => $notification->created_at->diffForHumans(),
-            'read' => $notification->read_at != null
+            'read' => $notification->read_at != null,
+            'notificationId' => $notification->id
         ])->render();
     }
 }

--- a/app/Notifications/UserFollowed.php
+++ b/app/Notifications/UserFollowed.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Exceptions\ShouldDeleteNotificationException;
+use App\Follow;
+use App\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class UserFollowed extends Notification {
+    use Queueable;
+
+    public $follow;
+
+    /**
+     * Create a new notification instance
+     *
+     * @return void
+     */
+    public function __construct(Follow $follow = null) {
+        $this->follow = $follow;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            'follow_id' => $this->follow->id,
+        ];
+    }
+
+    public static function render($notification) {
+        $data = $notification->data;
+        
+        try {
+            $follow = Follow::findOrFail($data['follow_id']);
+            $sender = User::findOrFail($follow->user_id);
+        } catch(ModelNotFoundException $e) {
+            // The follow doesn't exist anymore or the user following you was deleted. Eitherway,
+            // we can delete the notification.
+            throw new ShouldDeleteNotificationException();
+        }
+        
+        return view("includes.notification", [
+            'color' => "neutral",
+            'icon' => "fas fa-user-friends",
+            'lead' => __('notifications.userFollowed.lead', ['followerUsername' => $sender->username]),
+            "link" => route('account.show', ['username' => $sender->username]),
+            'notice' => "",
+            'date_for_humans' => $notification->created_at->diffForHumans(),
+            'read' => $notification->read_at != null
+        ])->render();
+    }
+}

--- a/app/Notifications/UserJoinedConnection.php
+++ b/app/Notifications/UserJoinedConnection.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Exceptions\ShouldDeleteNotificationException;
+use App\Status;
+use App\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class UserJoinedConnection extends Notification {
+    use Queueable;
+
+    private $statusId;
+    private $linename;
+    private $origin;
+    private $destination;
+
+    /**
+     * Create a new notification instance
+     *
+     * @return void
+     */
+    public function __construct($statusId = null, $linename = null, $origin = null, $destination = null) {
+        $this->statusId = $statusId;
+        $this->linename = $linename;
+        $this->origin = $origin;
+        $this->destination = $destination;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            'status_id' => $this->statusId,
+            'linename' => $this->linename,
+            'origin' => $this->origin,
+            'destination' => $this->destination
+        ];
+    }
+
+    public static function render($notification) {
+        $data = $notification->data;
+        
+        try {
+            $status = status::findOrFail($data['status_id']);
+        } catch(ModelNotFoundException $e) {
+            throw new ShouldDeleteNotificationException();
+        }
+        
+        return view("includes.notification", [
+            'color' => "neutral",
+            'icon' => "fa fa-train",
+            'lead' => __('notifications.userJoinedConnection.lead', ['username' => $status->user->username]),
+            "link" => route('statuses.get', ['id' => $status->id]),
+            'notice' => trans_choice('notifications.userJoinedConnection.notice', preg_match('/\s/', $data['linename']), [
+                'username' => $status->user->username,
+                'linename' => $data['linename'],
+                'origin' => $data['origin'],
+                'destination' => $data['destination']
+            ]),
+            'date_for_humans' => $notification->created_at->diffForHumans(),
+            'read' => $notification->read_at != null,
+            'notificationId' => $notification->id
+        ])->render();
+    }
+}

--- a/database/migrations/2020_02_20_162218_create_notifications_table.php
+++ b/database/migrations/2020_02_20_162218_create_notifications_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateNotificationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('notifications');
+    }
+}

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -6,7 +6,7 @@ body {
 }
 
 /*!
- *   AdminLTE v3.0.1
+ *   AdminLTE v3.0.2
  *   Author: Colorlib
  *   Website: AdminLTE.io <http://adminlte.io>
  *   License: Open source - MIT <http://opensource.org/licenses/MIT>
@@ -3850,7 +3850,7 @@ input[type=button].btn-block {
   position: relative;
   display: block;
   min-height: 1.44rem;
-  padding-left: 2.5rem;
+  padding-left: 1.5rem;
 }
 
 .custom-control-inline {
@@ -3903,7 +3903,7 @@ input[type=button].btn-block {
 .custom-control-label::before {
   position: absolute;
   top: 0.22rem;
-  left: -2.5rem;
+  left: -1.5rem;
   display: block;
   width: 1rem;
   height: 1rem;
@@ -3917,7 +3917,7 @@ input[type=button].btn-block {
 .custom-control-label::after {
   position: absolute;
   top: 0.22rem;
-  left: -2.5rem;
+  left: -1.5rem;
   display: block;
   width: 1rem;
   height: 1rem;
@@ -3964,11 +3964,11 @@ input[type=button].btn-block {
 }
 
 .custom-switch {
-  padding-left: 3.25rem;
+  padding-left: 2.25rem;
 }
 
 .custom-switch .custom-control-label::before {
-  left: -3.25rem;
+  left: -2.25rem;
   width: 1.75rem;
   pointer-events: all;
   border-radius: 0.5rem;
@@ -3976,7 +3976,7 @@ input[type=button].btn-block {
 
 .custom-switch .custom-control-label::after {
   top: calc(0.22rem + 2px);
-  left: calc(-3.25rem + 2px);
+  left: calc(-2.25rem + 2px);
   width: calc(1rem - 4px);
   height: calc(1rem - 4px);
   background-color: #adb5bd;
@@ -10783,6 +10783,22 @@ body,
   height: calc(2.806rem + 1px);
 }
 
+body:not(.layout-fixed).layout-navbar-fixed .wrapper .main-sidebar {
+  margin-top: calc(calc(3.44rem + 1px) / -1);
+}
+
+body:not(.layout-fixed).layout-navbar-fixed .wrapper .main-sidebar .sidebar {
+  margin-top: calc(3.44rem + 1px);
+}
+
+body:not(.layout-fixed).layout-navbar-fixed.text-sm .wrapper .main-sidebar {
+  margin-top: calc(calc(2.806rem + 1px) / -1);
+}
+
+body:not(.layout-fixed).layout-navbar-fixed.text-sm .wrapper .main-sidebar .sidebar {
+  margin-top: calc(2.806rem + 1px);
+}
+
 .layout-navbar-fixed .wrapper .control-sidebar {
   top: 0;
 }
@@ -11054,6 +11070,22 @@ body,
   margin-top: calc(2.806rem + 1px);
 }
 
+body:not(.layout-fixed).layout-navbar-fixed .wrapper .main-sidebar {
+  margin-top: calc(calc(3.44rem + 1px) / -1);
+}
+
+body:not(.layout-fixed).layout-navbar-fixed .wrapper .main-sidebar .sidebar {
+  margin-top: calc(3.44rem + 1px);
+}
+
+body:not(.layout-fixed).layout-navbar-fixed.text-sm .wrapper .main-sidebar {
+  margin-top: calc(calc(2.806rem + 1px) / -1);
+}
+
+body:not(.layout-fixed).layout-navbar-fixed.text-sm .wrapper .main-sidebar .sidebar {
+  margin-top: calc(2.806rem + 1px);
+}
+
 .layout-navbar-not-fixed .wrapper .brand-link {
   position: static;
 }
@@ -11215,6 +11247,22 @@ body,
   }
 
   .layout-sm-navbar-fixed.text-sm .wrapper .content-wrapper {
+    margin-top: calc(2.806rem + 1px);
+  }
+
+  body:not(.layout-fixed).layout-sm-navbar-fixed .wrapper .main-sidebar {
+    margin-top: calc(calc(3.44rem + 1px) / -1);
+  }
+
+  body:not(.layout-fixed).layout-sm-navbar-fixed .wrapper .main-sidebar .sidebar {
+    margin-top: calc(3.44rem + 1px);
+  }
+
+  body:not(.layout-fixed).layout-sm-navbar-fixed.text-sm .wrapper .main-sidebar {
+    margin-top: calc(calc(2.806rem + 1px) / -1);
+  }
+
+  body:not(.layout-fixed).layout-sm-navbar-fixed.text-sm .wrapper .main-sidebar .sidebar {
     margin-top: calc(2.806rem + 1px);
   }
 
@@ -11383,6 +11431,22 @@ body,
     margin-top: calc(2.806rem + 1px);
   }
 
+  body:not(.layout-fixed).layout-md-navbar-fixed .wrapper .main-sidebar {
+    margin-top: calc(calc(3.44rem + 1px) / -1);
+  }
+
+  body:not(.layout-fixed).layout-md-navbar-fixed .wrapper .main-sidebar .sidebar {
+    margin-top: calc(3.44rem + 1px);
+  }
+
+  body:not(.layout-fixed).layout-md-navbar-fixed.text-sm .wrapper .main-sidebar {
+    margin-top: calc(calc(2.806rem + 1px) / -1);
+  }
+
+  body:not(.layout-fixed).layout-md-navbar-fixed.text-sm .wrapper .main-sidebar .sidebar {
+    margin-top: calc(2.806rem + 1px);
+  }
+
   .layout-md-navbar-not-fixed .wrapper .brand-link {
     position: static;
   }
@@ -11545,6 +11609,22 @@ body,
   }
 
   .layout-lg-navbar-fixed.text-sm .wrapper .content-wrapper {
+    margin-top: calc(2.806rem + 1px);
+  }
+
+  body:not(.layout-fixed).layout-lg-navbar-fixed .wrapper .main-sidebar {
+    margin-top: calc(calc(3.44rem + 1px) / -1);
+  }
+
+  body:not(.layout-fixed).layout-lg-navbar-fixed .wrapper .main-sidebar .sidebar {
+    margin-top: calc(3.44rem + 1px);
+  }
+
+  body:not(.layout-fixed).layout-lg-navbar-fixed.text-sm .wrapper .main-sidebar {
+    margin-top: calc(calc(2.806rem + 1px) / -1);
+  }
+
+  body:not(.layout-fixed).layout-lg-navbar-fixed.text-sm .wrapper .main-sidebar .sidebar {
     margin-top: calc(2.806rem + 1px);
   }
 
@@ -11713,6 +11793,22 @@ body,
     margin-top: calc(2.806rem + 1px);
   }
 
+  body:not(.layout-fixed).layout-xl-navbar-fixed .wrapper .main-sidebar {
+    margin-top: calc(calc(3.44rem + 1px) / -1);
+  }
+
+  body:not(.layout-fixed).layout-xl-navbar-fixed .wrapper .main-sidebar .sidebar {
+    margin-top: calc(3.44rem + 1px);
+  }
+
+  body:not(.layout-fixed).layout-xl-navbar-fixed.text-sm .wrapper .main-sidebar {
+    margin-top: calc(calc(2.806rem + 1px) / -1);
+  }
+
+  body:not(.layout-fixed).layout-xl-navbar-fixed.text-sm .wrapper .main-sidebar .sidebar {
+    margin-top: calc(2.806rem + 1px);
+  }
+
   .layout-xl-navbar-not-fixed .wrapper .brand-link {
     position: static;
   }
@@ -11863,21 +11959,15 @@ body,
   margin-left: 0;
 }
 
-.layout-top-nav .wrapper .text-sm .brand-image {
+.layout-top-nav .wrapper .main-header .brand-image {
   margin-top: -0.5rem;
+  margin-right: 0.2rem;
+  height: 33px;
 }
 
 .layout-top-nav .wrapper .main-sidebar {
   bottom: inherit;
   height: inherit;
-}
-
-.layout-top-nav .wrapper .brand-image {
-  height: 33px;
-}
-
-.layout-top-nav .wrapper .main-sidebar {
-  display: none;
 }
 
 .layout-top-nav .wrapper .content-wrapper,
@@ -11986,6 +12076,11 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   .main-sidebar::before {
     transition: none;
   }
+}
+
+.sidebar-collapse:not(.sidebar-mini):not(.sidebar-mini-md) .main-sidebar,
+.sidebar-collapse:not(.sidebar-mini):not(.sidebar-mini-md) .main-sidebar::before {
+  box-shadow: none !important;
 }
 
 .sidebar-collapse .main-sidebar,
@@ -12749,6 +12844,17 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   border-color: #343a40;
 }
 
+.sidebar-dark-lightblue .nav-sidebar > .nav-item > .nav-link.active,
+.sidebar-light-lightblue .nav-sidebar > .nav-item > .nav-link.active {
+  background-color: #3c8dbc;
+  color: #ffffff;
+}
+
+.sidebar-dark-lightblue .nav-sidebar.nav-legacy > .nav-item > .nav-link.active,
+.sidebar-light-lightblue .nav-sidebar.nav-legacy > .nav-item > .nav-link.active {
+  border-color: #3c8dbc;
+}
+
 .sidebar-dark-navy .nav-sidebar > .nav-item > .nav-link.active,
 .sidebar-light-navy .nav-sidebar > .nav-item > .nav-link.active {
   background-color: #001f3f;
@@ -12947,6 +13053,31 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   border-color: #343a40;
 }
 
+.sidebar-mini.sidebar-collapse .nav-compact .nav-icon,
+.sidebar-mini-md.sidebar-collapse .nav-compact .nav-icon {
+  transition: margin-left ease-in-out 0.3s;
+  margin-left: 0.45rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-mini.sidebar-collapse .nav-compact .nav-icon,
+  .sidebar-mini-md.sidebar-collapse .nav-compact .nav-icon {
+    transition: none;
+  }
+}
+
+.sidebar-mini.sidebar-collapse .nav-compact .nav-treeview .nav-icon,
+.sidebar-mini-md.sidebar-collapse .nav-compact .nav-treeview .nav-icon {
+  margin-left: 0.45rem;
+}
+
+.sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-compact.nav-compact .nav-icon,
+.sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-compact.nav-compact .nav-icon,
+.sidebar-mini .main-sidebar.sidebar-focused .nav-compact.nav-compact .nav-icon,
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-compact.nav-compact .nav-icon {
+  margin-left: 0;
+}
+
 .nav-flat {
   margin: -0.25rem -0.5rem 0;
 }
@@ -12996,6 +13127,16 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   border-left: 0.2rem solid;
 }
 
+.sidebar-mini.sidebar-collapse .nav-flat.nav-compact .nav-icon,
+.sidebar-mini-md.sidebar-collapse .nav-flat.nav-compact .nav-icon {
+  margin-left: 1.05rem;
+}
+
+.sidebar-mini.sidebar-collapse .nav-flat.nav-compact .nav-treeview .nav-icon,
+.sidebar-mini-md.sidebar-collapse .nav-flat.nav-compact .nav-treeview .nav-icon {
+  margin-left: 0.805rem;
+}
+
 .nav-legacy {
   margin: -0.25rem -0.5rem 0;
 }
@@ -13012,6 +13153,124 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 }
 
 .nav-legacy.nav-sidebar > .nav-item > .nav-link.active > .nav-icon {
+  margin-left: -3px;
+}
+
+.sidebar-mini .nav-legacy > .nav-item .nav-link .nav-icon,
+.sidebar-mini-md .nav-legacy > .nav-item .nav-link .nav-icon {
+  transition: margin-left ease-in-out 0.3s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-mini .nav-legacy > .nav-item .nav-link .nav-icon,
+  .sidebar-mini-md .nav-legacy > .nav-item .nav-link .nav-icon {
+    transition: none;
+  }
+}
+
+.sidebar-mini.sidebar-collapse .nav-legacy > .nav-item .nav-link .nav-icon,
+.sidebar-mini-md.sidebar-collapse .nav-legacy > .nav-item .nav-link .nav-icon {
+  margin-left: 0.55rem;
+}
+
+.sidebar-mini.sidebar-collapse .nav-legacy > .nav-item .nav-link.active > .nav-icon,
+.sidebar-mini-md.sidebar-collapse .nav-legacy > .nav-item .nav-link.active > .nav-icon {
+  margin-left: 0.36rem;
+}
+
+.sidebar-mini.sidebar-collapse .nav-legacy.nav-compact > .nav-item .nav-link .nav-icon,
+.sidebar-mini-md.sidebar-collapse .nav-legacy.nav-compact > .nav-item .nav-link .nav-icon {
+  margin-left: 1.05rem;
+}
+
+.sidebar-mini.sidebar-collapse .nav-legacy.nav-compact > .nav-item .nav-link.active > .nav-icon,
+.sidebar-mini-md.sidebar-collapse .nav-legacy.nav-compact > .nav-item .nav-link.active > .nav-icon {
+  margin-left: 1.05rem;
+}
+
+.sidebar-mini.sidebar-collapse .nav-legacy.nav-compact > .nav-item > .nav-link .nav-icon,
+.sidebar-mini-md.sidebar-collapse .nav-legacy.nav-compact > .nav-item > .nav-link .nav-icon {
+  margin-left: 1.05rem;
+}
+
+.sidebar-mini.sidebar-collapse .nav-legacy.nav-compact > .nav-item > .nav-link.active > .nav-icon,
+.sidebar-mini-md.sidebar-collapse .nav-legacy.nav-compact > .nav-item > .nav-link.active > .nav-icon {
+  margin-left: 0.85rem;
+}
+
+.sidebar-mini.sidebar-collapse .nav-legacy.nav-compact.nav-flat > .nav-item .nav-link .nav-icon,
+.sidebar-mini-md.sidebar-collapse .nav-legacy.nav-compact.nav-flat > .nav-item .nav-link .nav-icon {
+  margin-left: 0.85rem;
+}
+
+.sidebar-mini.sidebar-collapse .nav-legacy.nav-compact.nav-flat > .nav-item .nav-link.active > .nav-icon,
+.sidebar-mini-md.sidebar-collapse .nav-legacy.nav-compact.nav-flat > .nav-item .nav-link.active > .nav-icon {
+  margin-left: 0.85rem;
+}
+
+.sidebar-mini.sidebar-collapse .nav-legacy.nav-compact.nav-flat > .nav-item > .nav-link .nav-icon,
+.sidebar-mini-md.sidebar-collapse .nav-legacy.nav-compact.nav-flat > .nav-item > .nav-link .nav-icon {
+  margin-left: 1.05rem;
+}
+
+.sidebar-mini.sidebar-collapse .nav-legacy.nav-compact.nav-flat > .nav-item > .nav-link.active > .nav-icon,
+.sidebar-mini-md.sidebar-collapse .nav-legacy.nav-compact.nav-flat > .nav-item > .nav-link.active > .nav-icon {
+  margin-left: 0.85rem;
+}
+
+.sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-compact > .nav-item .nav-link .nav-icon,
+.sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-compact > .nav-item .nav-link .nav-icon,
+.sidebar-mini .main-sidebar.sidebar-focused .nav-legacy.nav-compact > .nav-item .nav-link .nav-icon,
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-legacy.nav-compact > .nav-item .nav-link .nav-icon {
+  margin-left: 0;
+}
+
+.sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-compact > .nav-item .nav-link.active > .nav-icon,
+.sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-compact > .nav-item .nav-link.active > .nav-icon,
+.sidebar-mini .main-sidebar.sidebar-focused .nav-legacy.nav-compact > .nav-item .nav-link.active > .nav-icon,
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-legacy.nav-compact > .nav-item .nav-link.active > .nav-icon {
+  margin-left: 0;
+}
+
+.sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-compact > .nav-item > .nav-link .nav-icon,
+.sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-compact > .nav-item > .nav-link .nav-icon,
+.sidebar-mini .main-sidebar.sidebar-focused .nav-legacy.nav-compact > .nav-item > .nav-link .nav-icon,
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-legacy.nav-compact > .nav-item > .nav-link .nav-icon {
+  margin-left: 0;
+}
+
+.sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-compact > .nav-item > .nav-link.active > .nav-icon,
+.sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-compact > .nav-item > .nav-link.active > .nav-icon,
+.sidebar-mini .main-sidebar.sidebar-focused .nav-legacy.nav-compact > .nav-item > .nav-link.active > .nav-icon,
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-legacy.nav-compact > .nav-item > .nav-link.active > .nav-icon {
+  margin-left: -3px;
+}
+
+.sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-flat > .nav-item .nav-link .nav-icon,
+.sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-flat > .nav-item .nav-link .nav-icon,
+.sidebar-mini .main-sidebar.sidebar-focused .nav-legacy.nav-flat > .nav-item .nav-link .nav-icon,
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-legacy.nav-flat > .nav-item .nav-link .nav-icon {
+  margin-left: -3px;
+}
+
+.sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-flat > .nav-item .nav-link.active > .nav-icon,
+.sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-flat > .nav-item .nav-link.active > .nav-icon,
+.sidebar-mini .main-sidebar.sidebar-focused .nav-legacy.nav-flat > .nav-item .nav-link.active > .nav-icon,
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-legacy.nav-flat > .nav-item .nav-link.active > .nav-icon {
+  margin-left: -3px;
+}
+
+.sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-flat > .nav-item > .nav-link .nav-icon,
+.sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-flat > .nav-item > .nav-link .nav-icon,
+.sidebar-mini .main-sidebar.sidebar-focused .nav-legacy.nav-flat > .nav-item > .nav-link .nav-icon,
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-legacy.nav-flat > .nav-item > .nav-link .nav-icon {
+  margin-left: 0;
+}
+
+.sidebar-mini .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-flat > .nav-item > .nav-link.active > .nav-icon,
+.sidebar-mini-md .main-sidebar:not(.sidebar-no-expand):hover .nav-legacy.nav-flat > .nav-item > .nav-link.active > .nav-icon,
+.sidebar-mini .main-sidebar.sidebar-focused .nav-legacy.nav-flat > .nav-item > .nav-link.active > .nav-icon,
+.sidebar-mini-md .main-sidebar.sidebar-focused .nav-legacy.nav-flat > .nav-item > .nav-link.active > .nav-icon {
   margin-left: -3px;
 }
 
@@ -13305,6 +13564,12 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   }
 }
 
+@media (max-width: 991.98px) {
+  .sidebar-mini.sidebar-collapse .main-sidebar {
+    box-shadow: none !important;
+  }
+}
+
 @media (min-width: 768px) {
   .sidebar-mini-md .nav-sidebar,
   .sidebar-mini-md .nav-sidebar > .nav-header,
@@ -13450,9 +13715,25 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
   }
 }
 
+@media (max-width: 767.98px) {
+  .sidebar-mini-md.sidebar-collapse .main-sidebar {
+    box-shadow: none !important;
+  }
+}
+
+.sidebar-collapse .main-sidebar.sidebar-focused .nav-header,
+.sidebar-collapse .main-sidebar:hover .nav-header {
+  display: inline-block;
+}
+
 .sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused,
 .sidebar-collapse .sidebar-no-expand.main-sidebar:hover {
   width: 4.6rem;
+}
+
+.sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused .nav-header,
+.sidebar-collapse .sidebar-no-expand.main-sidebar:hover .nav-header {
+  display: none;
 }
 
 .sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused .brand-link,
@@ -13507,6 +13788,16 @@ body.sidebar-collapse:not(.sidebar-mini-md):not(.sidebar-mini) .main-header::bef
 .sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused .nav-flat .nav-treeview .nav-icon,
 .sidebar-collapse .sidebar-no-expand.main-sidebar:hover .nav-flat .nav-treeview .nav-icon {
   margin-left: 0.3rem;
+}
+
+.sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused .nav-flat.nav-compact .nav-icon,
+.sidebar-collapse .sidebar-no-expand.main-sidebar:hover .nav-flat.nav-compact .nav-icon {
+  margin-left: 1.05rem;
+}
+
+.sidebar-collapse .sidebar-no-expand.main-sidebar.sidebar-focused .nav-flat.nav-compact .nav-treeview .nav-icon,
+.sidebar-collapse .sidebar-no-expand.main-sidebar:hover .nav-flat.nav-compact .nav-treeview .nav-icon {
+  margin-left: 0.85rem;
 }
 
 .nav-sidebar {
@@ -14072,6 +14363,10 @@ body.text-sm .control-sidebar {
   padding-right: 1rem;
 }
 
+.navbar-no-expand .dropdown-menu {
+  position: absolute;
+}
+
 .navbar-light {
   background-color: #f8f9fa;
 }
@@ -14102,6 +14397,10 @@ body.text-sm .control-sidebar {
 
 .navbar-danger {
   background-color: #e3342f;
+}
+
+.navbar-lightblue {
+  background-color: #3c8dbc;
 }
 
 .navbar-navy {
@@ -14257,7 +14556,7 @@ body.text-sm .control-sidebar {
   line-height: calc(1.68125rem + 2px);
 }
 
-label:not(.form-check-label, .custom-file-label) {
+label:not(.form-check-label):not(.custom-file-label) {
   font-weight: 700;
 }
 
@@ -14577,6 +14876,32 @@ textarea.form-control.is-warning {
 
 .custom-switch.custom-switch-on-dark .custom-control-input:checked ~ .custom-control-label::after {
   background: #7a8793;
+}
+
+.custom-switch.custom-switch-off-lightblue .custom-control-input ~ .custom-control-label::before {
+  background: #3c8dbc;
+  border-color: #23536f;
+}
+
+.custom-switch.custom-switch-off-lightblue .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #f8fafc, 0 0 0 2px rgba(60, 141, 188, 0.25);
+}
+
+.custom-switch.custom-switch-off-lightblue .custom-control-input ~ .custom-control-label::after {
+  background: #1d455b;
+}
+
+.custom-switch.custom-switch-on-lightblue .custom-control-input:checked ~ .custom-control-label::before {
+  background: #3c8dbc;
+  border-color: #23536f;
+}
+
+.custom-switch.custom-switch-on-lightblue .custom-control-input:checked:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 1px #f8fafc, 0 0 0 2px rgba(60, 141, 188, 0.25);
+}
+
+.custom-switch.custom-switch-on-lightblue .custom-control-input:checked ~ .custom-control-label::after {
+  background: #acd0e5;
 }
 
 .custom-switch.custom-switch-off-navy .custom-control-input ~ .custom-control-label::before {
@@ -15367,6 +15692,46 @@ textarea.form-control.is-warning {
   background-color: #88939e;
 }
 
+.custom-range.custom-range-lightblue:focus {
+  outline: none;
+}
+
+.custom-range.custom-range-lightblue:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #f8fafc, 0 0 0 2px rgba(60, 141, 188, 0.25);
+}
+
+.custom-range.custom-range-lightblue:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #f8fafc, 0 0 0 2px rgba(60, 141, 188, 0.25);
+}
+
+.custom-range.custom-range-lightblue:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #f8fafc, 0 0 0 2px rgba(60, 141, 188, 0.25);
+}
+
+.custom-range.custom-range-lightblue::-webkit-slider-thumb {
+  background-color: #3c8dbc;
+}
+
+.custom-range.custom-range-lightblue::-webkit-slider-thumb:active {
+  background-color: #c0dbeb;
+}
+
+.custom-range.custom-range-lightblue::-moz-range-thumb {
+  background-color: #3c8dbc;
+}
+
+.custom-range.custom-range-lightblue::-moz-range-thumb:active {
+  background-color: #c0dbeb;
+}
+
+.custom-range.custom-range-lightblue::-ms-thumb {
+  background-color: #3c8dbc;
+}
+
+.custom-range.custom-range-lightblue::-ms-thumb:active {
+  background-color: #c0dbeb;
+}
+
 .custom-range.custom-range-navy:focus {
   outline: none;
 }
@@ -16141,6 +16506,1923 @@ textarea.form-control.is-warning {
   margin: 0;
 }
 
+.card-primary:not(.card-outline) > .card-header {
+  background-color: #3490dc;
+}
+
+.card-primary:not(.card-outline) > .card-header,
+.card-primary:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-primary:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-primary.card-outline {
+  border-top: 3px solid #3490dc;
+}
+
+.card-primary.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-primary.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #3490dc;
+}
+
+.bg-primary .btn-tool,
+.bg-gradient-primary .btn-tool,
+.card-primary:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-primary .btn-tool:hover,
+.bg-gradient-primary .btn-tool:hover,
+.card-primary:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-primary .bootstrap-datetimepicker-widget .table td,
+.card.bg-primary .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-primary .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-primary .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-primary .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-primary .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-primary .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-primary .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-primary .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-primary .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #227bc5;
+  color: #ffffff;
+}
+
+.card.bg-primary .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-primary .bootstrap-datetimepicker-widget table td.active,
+.card.bg-primary .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #60a8e4;
+  color: #ffffff;
+}
+
+.card-secondary:not(.card-outline) > .card-header {
+  background-color: #6c757d;
+}
+
+.card-secondary:not(.card-outline) > .card-header,
+.card-secondary:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-secondary:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-secondary.card-outline {
+  border-top: 3px solid #6c757d;
+}
+
+.card-secondary.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-secondary.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #6c757d;
+}
+
+.bg-secondary .btn-tool,
+.bg-gradient-secondary .btn-tool,
+.card-secondary:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-secondary .btn-tool:hover,
+.bg-gradient-secondary .btn-tool:hover,
+.card-secondary:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-secondary .bootstrap-datetimepicker-widget .table td,
+.card.bg-secondary .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-secondary .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-secondary .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-secondary .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-secondary .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-secondary .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-secondary .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-secondary .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #596167;
+  color: #ffffff;
+}
+
+.card.bg-secondary .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-secondary .bootstrap-datetimepicker-widget table td.active,
+.card.bg-secondary .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #868e96;
+  color: #ffffff;
+}
+
+.card-success:not(.card-outline) > .card-header {
+  background-color: #38c172;
+}
+
+.card-success:not(.card-outline) > .card-header,
+.card-success:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-success:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-success.card-outline {
+  border-top: 3px solid #38c172;
+}
+
+.card-success.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-success.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #38c172;
+}
+
+.bg-success .btn-tool,
+.bg-gradient-success .btn-tool,
+.card-success:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-success .btn-tool:hover,
+.bg-gradient-success .btn-tool:hover,
+.card-success:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-success .bootstrap-datetimepicker-widget .table td,
+.card.bg-success .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-success .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-success .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-success .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-success .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-success .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-success .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-success .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-success .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-success .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-success .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-success .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-success .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #2fa15f;
+  color: #ffffff;
+}
+
+.card.bg-success .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-success .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-success .bootstrap-datetimepicker-widget table td.active,
+.card.bg-success .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-success .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-success .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #5cd08d;
+  color: #ffffff;
+}
+
+.card-info:not(.card-outline) > .card-header {
+  background-color: #6cb2eb;
+}
+
+.card-info:not(.card-outline) > .card-header,
+.card-info:not(.card-outline) > .card-header a {
+  color: #1F2D3D;
+}
+
+.card-info:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-info.card-outline {
+  border-top: 3px solid #6cb2eb;
+}
+
+.card-info.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-info.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #6cb2eb;
+}
+
+.bg-info .btn-tool,
+.bg-gradient-info .btn-tool,
+.card-info:not(.card-outline) .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.bg-info .btn-tool:hover,
+.bg-gradient-info .btn-tool:hover,
+.card-info:not(.card-outline) .btn-tool:hover {
+  color: #1F2D3D;
+}
+
+.card.bg-info .bootstrap-datetimepicker-widget .table td,
+.card.bg-info .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-info .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-info .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-info .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-info .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-info .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-info .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-info .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-info .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-info .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-info .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-info .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-info .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #489fe6;
+  color: #1F2D3D;
+}
+
+.card.bg-info .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-info .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1F2D3D;
+}
+
+.card.bg-info .bootstrap-datetimepicker-widget table td.active,
+.card.bg-info .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-info .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-info .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #99caf1;
+  color: #1F2D3D;
+}
+
+.card-warning:not(.card-outline) > .card-header {
+  background-color: #ffed4a;
+}
+
+.card-warning:not(.card-outline) > .card-header,
+.card-warning:not(.card-outline) > .card-header a {
+  color: #1F2D3D;
+}
+
+.card-warning:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-warning.card-outline {
+  border-top: 3px solid #ffed4a;
+}
+
+.card-warning.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-warning.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #ffed4a;
+}
+
+.bg-warning .btn-tool,
+.bg-gradient-warning .btn-tool,
+.card-warning:not(.card-outline) .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.bg-warning .btn-tool:hover,
+.bg-gradient-warning .btn-tool:hover,
+.card-warning:not(.card-outline) .btn-tool:hover {
+  color: #1F2D3D;
+}
+
+.card.bg-warning .bootstrap-datetimepicker-widget .table td,
+.card.bg-warning .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-warning .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-warning .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-warning .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-warning .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-warning .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-warning .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-warning .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-warning .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #ffe921;
+  color: #1F2D3D;
+}
+
+.card.bg-warning .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1F2D3D;
+}
+
+.card.bg-warning .bootstrap-datetimepicker-widget table td.active,
+.card.bg-warning .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #fff27d;
+  color: #1F2D3D;
+}
+
+.card-danger:not(.card-outline) > .card-header {
+  background-color: #e3342f;
+}
+
+.card-danger:not(.card-outline) > .card-header,
+.card-danger:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-danger:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-danger.card-outline {
+  border-top: 3px solid #e3342f;
+}
+
+.card-danger.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-danger.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #e3342f;
+}
+
+.bg-danger .btn-tool,
+.bg-gradient-danger .btn-tool,
+.card-danger:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-danger .btn-tool:hover,
+.bg-gradient-danger .btn-tool:hover,
+.card-danger:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-danger .bootstrap-datetimepicker-widget .table td,
+.card.bg-danger .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-danger .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-danger .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-danger .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-danger .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-danger .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-danger .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-danger .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-danger .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #ce211c;
+  color: #ffffff;
+}
+
+.card.bg-danger .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-danger .bootstrap-datetimepicker-widget table td.active,
+.card.bg-danger .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #e9605c;
+  color: #ffffff;
+}
+
+.card-light:not(.card-outline) > .card-header {
+  background-color: #f8f9fa;
+}
+
+.card-light:not(.card-outline) > .card-header,
+.card-light:not(.card-outline) > .card-header a {
+  color: #1F2D3D;
+}
+
+.card-light:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-light.card-outline {
+  border-top: 3px solid #f8f9fa;
+}
+
+.card-light.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-light.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #f8f9fa;
+}
+
+.bg-light .btn-tool,
+.bg-gradient-light .btn-tool,
+.card-light:not(.card-outline) .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.bg-light .btn-tool:hover,
+.bg-gradient-light .btn-tool:hover,
+.card-light:not(.card-outline) .btn-tool:hover {
+  color: #1F2D3D;
+}
+
+.card.bg-light .bootstrap-datetimepicker-widget .table td,
+.card.bg-light .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-light .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-light .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-light .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-light .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-light .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-light .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-light .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-light .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-light .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-light .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-light .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-light .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #e0e5e9;
+  color: #1F2D3D;
+}
+
+.card.bg-light .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-light .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1F2D3D;
+}
+
+.card.bg-light .bootstrap-datetimepicker-widget table td.active,
+.card.bg-light .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-light .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-light .bootstrap-datetimepicker-widget table td.active:hover {
+  background: white;
+  color: #1F2D3D;
+}
+
+.card-dark:not(.card-outline) > .card-header {
+  background-color: #343a40;
+}
+
+.card-dark:not(.card-outline) > .card-header,
+.card-dark:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-dark:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-dark.card-outline {
+  border-top: 3px solid #343a40;
+}
+
+.card-dark.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-dark.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #343a40;
+}
+
+.bg-dark .btn-tool,
+.bg-gradient-dark .btn-tool,
+.card-dark:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-dark .btn-tool:hover,
+.bg-gradient-dark .btn-tool:hover,
+.card-dark:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-dark .bootstrap-datetimepicker-widget .table td,
+.card.bg-dark .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-dark .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-dark .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-dark .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-dark .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-dark .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-dark .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-dark .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-dark .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #222629;
+  color: #ffffff;
+}
+
+.card.bg-dark .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-dark .bootstrap-datetimepicker-widget table td.active,
+.card.bg-dark .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #4b545c;
+  color: #ffffff;
+}
+
+.card-lightblue:not(.card-outline) > .card-header {
+  background-color: #3c8dbc;
+}
+
+.card-lightblue:not(.card-outline) > .card-header,
+.card-lightblue:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-lightblue:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-lightblue.card-outline {
+  border-top: 3px solid #3c8dbc;
+}
+
+.card-lightblue.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-lightblue.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #3c8dbc;
+}
+
+.bg-lightblue .btn-tool,
+.bg-gradient-lightblue .btn-tool,
+.card-lightblue:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-lightblue .btn-tool:hover,
+.bg-gradient-lightblue .btn-tool:hover,
+.card-lightblue:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-lightblue .bootstrap-datetimepicker-widget .table td,
+.card.bg-lightblue .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-lightblue .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-lightblue .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-lightblue .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-lightblue .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-lightblue .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-lightblue .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-lightblue .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #32769d;
+  color: #ffffff;
+}
+
+.card.bg-lightblue .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-lightblue .bootstrap-datetimepicker-widget table td.active,
+.card.bg-lightblue .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-lightblue .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #5fa4cc;
+  color: #ffffff;
+}
+
+.card-navy:not(.card-outline) > .card-header {
+  background-color: #001f3f;
+}
+
+.card-navy:not(.card-outline) > .card-header,
+.card-navy:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-navy:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-navy.card-outline {
+  border-top: 3px solid #001f3f;
+}
+
+.card-navy.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-navy.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #001f3f;
+}
+
+.bg-navy .btn-tool,
+.bg-gradient-navy .btn-tool,
+.card-navy:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-navy .btn-tool:hover,
+.bg-gradient-navy .btn-tool:hover,
+.card-navy:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-navy .bootstrap-datetimepicker-widget .table td,
+.card.bg-navy .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-navy .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-navy .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-navy .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-navy .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-navy .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-navy .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-navy .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-navy .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #000b16;
+  color: #ffffff;
+}
+
+.card.bg-navy .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-navy .bootstrap-datetimepicker-widget table td.active,
+.card.bg-navy .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #003872;
+  color: #ffffff;
+}
+
+.card-olive:not(.card-outline) > .card-header {
+  background-color: #3d9970;
+}
+
+.card-olive:not(.card-outline) > .card-header,
+.card-olive:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-olive:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-olive.card-outline {
+  border-top: 3px solid #3d9970;
+}
+
+.card-olive.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-olive.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #3d9970;
+}
+
+.bg-olive .btn-tool,
+.bg-gradient-olive .btn-tool,
+.card-olive:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-olive .btn-tool:hover,
+.bg-gradient-olive .btn-tool:hover,
+.card-olive:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-olive .bootstrap-datetimepicker-widget .table td,
+.card.bg-olive .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-olive .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-olive .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-olive .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-olive .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-olive .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-olive .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-olive .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-olive .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #317c5b;
+  color: #ffffff;
+}
+
+.card.bg-olive .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-olive .bootstrap-datetimepicker-widget table td.active,
+.card.bg-olive .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #50b98a;
+  color: #ffffff;
+}
+
+.card-lime:not(.card-outline) > .card-header {
+  background-color: #01ff70;
+}
+
+.card-lime:not(.card-outline) > .card-header,
+.card-lime:not(.card-outline) > .card-header a {
+  color: #1F2D3D;
+}
+
+.card-lime:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-lime.card-outline {
+  border-top: 3px solid #01ff70;
+}
+
+.card-lime.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-lime.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #01ff70;
+}
+
+.bg-lime .btn-tool,
+.bg-gradient-lime .btn-tool,
+.card-lime:not(.card-outline) .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.bg-lime .btn-tool:hover,
+.bg-gradient-lime .btn-tool:hover,
+.card-lime:not(.card-outline) .btn-tool:hover {
+  color: #1F2D3D;
+}
+
+.card.bg-lime .bootstrap-datetimepicker-widget .table td,
+.card.bg-lime .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-lime .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-lime .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-lime .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-lime .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-lime .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-lime .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-lime .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-lime .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #00d75e;
+  color: #1F2D3D;
+}
+
+.card.bg-lime .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1F2D3D;
+}
+
+.card.bg-lime .bootstrap-datetimepicker-widget table td.active,
+.card.bg-lime .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #34ff8d;
+  color: #1F2D3D;
+}
+
+.card-fuchsia:not(.card-outline) > .card-header {
+  background-color: #f012be;
+}
+
+.card-fuchsia:not(.card-outline) > .card-header,
+.card-fuchsia:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-fuchsia:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-fuchsia.card-outline {
+  border-top: 3px solid #f012be;
+}
+
+.card-fuchsia.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-fuchsia.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #f012be;
+}
+
+.bg-fuchsia .btn-tool,
+.bg-gradient-fuchsia .btn-tool,
+.card-fuchsia:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-fuchsia .btn-tool:hover,
+.bg-gradient-fuchsia .btn-tool:hover,
+.card-fuchsia:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-fuchsia .bootstrap-datetimepicker-widget .table td,
+.card.bg-fuchsia .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-fuchsia .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-fuchsia .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-fuchsia .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-fuchsia .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-fuchsia .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #cc0da1;
+  color: #ffffff;
+}
+
+.card.bg-fuchsia .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-fuchsia .bootstrap-datetimepicker-widget table td.active,
+.card.bg-fuchsia .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #f342cb;
+  color: #ffffff;
+}
+
+.card-maroon:not(.card-outline) > .card-header {
+  background-color: #d81b60;
+}
+
+.card-maroon:not(.card-outline) > .card-header,
+.card-maroon:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-maroon:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-maroon.card-outline {
+  border-top: 3px solid #d81b60;
+}
+
+.card-maroon.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-maroon.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #d81b60;
+}
+
+.bg-maroon .btn-tool,
+.bg-gradient-maroon .btn-tool,
+.card-maroon:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-maroon .btn-tool:hover,
+.bg-gradient-maroon .btn-tool:hover,
+.card-maroon:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-maroon .bootstrap-datetimepicker-widget .table td,
+.card.bg-maroon .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-maroon .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-maroon .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-maroon .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-maroon .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-maroon .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-maroon .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-maroon .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #b41650;
+  color: #ffffff;
+}
+
+.card.bg-maroon .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-maroon .bootstrap-datetimepicker-widget table td.active,
+.card.bg-maroon .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #e73f7c;
+  color: #ffffff;
+}
+
+.card-blue:not(.card-outline) > .card-header {
+  background-color: #3490dc;
+}
+
+.card-blue:not(.card-outline) > .card-header,
+.card-blue:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-blue:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-blue.card-outline {
+  border-top: 3px solid #3490dc;
+}
+
+.card-blue.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-blue.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #3490dc;
+}
+
+.bg-blue .btn-tool,
+.bg-gradient-blue .btn-tool,
+.card-blue:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-blue .btn-tool:hover,
+.bg-gradient-blue .btn-tool:hover,
+.card-blue:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-blue .bootstrap-datetimepicker-widget .table td,
+.card.bg-blue .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-blue .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-blue .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-blue .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-blue .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-blue .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-blue .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-blue .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-blue .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #227bc5;
+  color: #ffffff;
+}
+
+.card.bg-blue .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-blue .bootstrap-datetimepicker-widget table td.active,
+.card.bg-blue .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #60a8e4;
+  color: #ffffff;
+}
+
+.card-indigo:not(.card-outline) > .card-header {
+  background-color: #6574cd;
+}
+
+.card-indigo:not(.card-outline) > .card-header,
+.card-indigo:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-indigo:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-indigo.card-outline {
+  border-top: 3px solid #6574cd;
+}
+
+.card-indigo.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-indigo.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #6574cd;
+}
+
+.bg-indigo .btn-tool,
+.bg-gradient-indigo .btn-tool,
+.card-indigo:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-indigo .btn-tool:hover,
+.bg-gradient-indigo .btn-tool:hover,
+.card-indigo:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-indigo .bootstrap-datetimepicker-widget .table td,
+.card.bg-indigo .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-indigo .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-indigo .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-indigo .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-indigo .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-indigo .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-indigo .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-indigo .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #4658c3;
+  color: #ffffff;
+}
+
+.card.bg-indigo .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-indigo .bootstrap-datetimepicker-widget table td.active,
+.card.bg-indigo .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #8c97da;
+  color: #ffffff;
+}
+
+.card-purple:not(.card-outline) > .card-header {
+  background-color: #9561e2;
+}
+
+.card-purple:not(.card-outline) > .card-header,
+.card-purple:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-purple:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-purple.card-outline {
+  border-top: 3px solid #9561e2;
+}
+
+.card-purple.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-purple.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #9561e2;
+}
+
+.bg-purple .btn-tool,
+.bg-gradient-purple .btn-tool,
+.card-purple:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-purple .btn-tool:hover,
+.bg-gradient-purple .btn-tool:hover,
+.card-purple:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-purple .bootstrap-datetimepicker-widget .table td,
+.card.bg-purple .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-purple .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-purple .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-purple .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-purple .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-purple .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-purple .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-purple .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-purple .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #7e3fdc;
+  color: #ffffff;
+}
+
+.card.bg-purple .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-purple .bootstrap-datetimepicker-widget table td.active,
+.card.bg-purple .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #b28cea;
+  color: #ffffff;
+}
+
+.card-pink:not(.card-outline) > .card-header {
+  background-color: #f66d9b;
+}
+
+.card-pink:not(.card-outline) > .card-header,
+.card-pink:not(.card-outline) > .card-header a {
+  color: #1F2D3D;
+}
+
+.card-pink:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-pink.card-outline {
+  border-top: 3px solid #f66d9b;
+}
+
+.card-pink.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-pink.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #f66d9b;
+}
+
+.bg-pink .btn-tool,
+.bg-gradient-pink .btn-tool,
+.card-pink:not(.card-outline) .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.bg-pink .btn-tool:hover,
+.bg-gradient-pink .btn-tool:hover,
+.card-pink:not(.card-outline) .btn-tool:hover {
+  color: #1F2D3D;
+}
+
+.card.bg-pink .bootstrap-datetimepicker-widget .table td,
+.card.bg-pink .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-pink .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-pink .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-pink .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-pink .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-pink .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-pink .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-pink .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-pink .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #f44781;
+  color: #1F2D3D;
+}
+
+.card.bg-pink .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1F2D3D;
+}
+
+.card.bg-pink .bootstrap-datetimepicker-widget table td.active,
+.card.bg-pink .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #f99dbc;
+  color: #1F2D3D;
+}
+
+.card-red:not(.card-outline) > .card-header {
+  background-color: #e3342f;
+}
+
+.card-red:not(.card-outline) > .card-header,
+.card-red:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-red:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-red.card-outline {
+  border-top: 3px solid #e3342f;
+}
+
+.card-red.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-red.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #e3342f;
+}
+
+.bg-red .btn-tool,
+.bg-gradient-red .btn-tool,
+.card-red:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-red .btn-tool:hover,
+.bg-gradient-red .btn-tool:hover,
+.card-red:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-red .bootstrap-datetimepicker-widget .table td,
+.card.bg-red .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-red .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-red .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-red .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-red .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-red .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-red .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-red .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-red .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-red .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-red .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-red .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-red .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #ce211c;
+  color: #ffffff;
+}
+
+.card.bg-red .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-red .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-red .bootstrap-datetimepicker-widget table td.active,
+.card.bg-red .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-red .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-red .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #e9605c;
+  color: #ffffff;
+}
+
+.card-orange:not(.card-outline) > .card-header {
+  background-color: #f6993f;
+}
+
+.card-orange:not(.card-outline) > .card-header,
+.card-orange:not(.card-outline) > .card-header a {
+  color: #1F2D3D;
+}
+
+.card-orange:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-orange.card-outline {
+  border-top: 3px solid #f6993f;
+}
+
+.card-orange.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-orange.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #f6993f;
+}
+
+.bg-orange .btn-tool,
+.bg-gradient-orange .btn-tool,
+.card-orange:not(.card-outline) .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.bg-orange .btn-tool:hover,
+.bg-gradient-orange .btn-tool:hover,
+.card-orange:not(.card-outline) .btn-tool:hover {
+  color: #1F2D3D;
+}
+
+.card.bg-orange .bootstrap-datetimepicker-widget .table td,
+.card.bg-orange .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-orange .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-orange .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-orange .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-orange .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-orange .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-orange .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-orange .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-orange .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #f48418;
+  color: #1F2D3D;
+}
+
+.card.bg-orange .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1F2D3D;
+}
+
+.card.bg-orange .bootstrap-datetimepicker-widget table td.active,
+.card.bg-orange .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #f8b370;
+  color: #1F2D3D;
+}
+
+.card-yellow:not(.card-outline) > .card-header {
+  background-color: #ffed4a;
+}
+
+.card-yellow:not(.card-outline) > .card-header,
+.card-yellow:not(.card-outline) > .card-header a {
+  color: #1F2D3D;
+}
+
+.card-yellow:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-yellow.card-outline {
+  border-top: 3px solid #ffed4a;
+}
+
+.card-yellow.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-yellow.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #ffed4a;
+}
+
+.bg-yellow .btn-tool,
+.bg-gradient-yellow .btn-tool,
+.card-yellow:not(.card-outline) .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.bg-yellow .btn-tool:hover,
+.bg-gradient-yellow .btn-tool:hover,
+.card-yellow:not(.card-outline) .btn-tool:hover {
+  color: #1F2D3D;
+}
+
+.card.bg-yellow .bootstrap-datetimepicker-widget .table td,
+.card.bg-yellow .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-yellow .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-yellow .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-yellow .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-yellow .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-yellow .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-yellow .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-yellow .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #ffe921;
+  color: #1F2D3D;
+}
+
+.card.bg-yellow .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1F2D3D;
+}
+
+.card.bg-yellow .bootstrap-datetimepicker-widget table td.active,
+.card.bg-yellow .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #fff27d;
+  color: #1F2D3D;
+}
+
+.card-green:not(.card-outline) > .card-header {
+  background-color: #38c172;
+}
+
+.card-green:not(.card-outline) > .card-header,
+.card-green:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-green:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-green.card-outline {
+  border-top: 3px solid #38c172;
+}
+
+.card-green.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-green.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #38c172;
+}
+
+.bg-green .btn-tool,
+.bg-gradient-green .btn-tool,
+.card-green:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-green .btn-tool:hover,
+.bg-gradient-green .btn-tool:hover,
+.card-green:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-green .bootstrap-datetimepicker-widget .table td,
+.card.bg-green .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-green .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-green .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-green .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-green .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-green .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-green .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-green .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-green .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-green .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-green .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-green .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-green .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #2fa15f;
+  color: #ffffff;
+}
+
+.card.bg-green .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-green .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-green .bootstrap-datetimepicker-widget table td.active,
+.card.bg-green .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-green .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-green .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #5cd08d;
+  color: #ffffff;
+}
+
+.card-teal:not(.card-outline) > .card-header {
+  background-color: #4dc0b5;
+}
+
+.card-teal:not(.card-outline) > .card-header,
+.card-teal:not(.card-outline) > .card-header a {
+  color: #1F2D3D;
+}
+
+.card-teal:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-teal.card-outline {
+  border-top: 3px solid #4dc0b5;
+}
+
+.card-teal.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-teal.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #4dc0b5;
+}
+
+.bg-teal .btn-tool,
+.bg-gradient-teal .btn-tool,
+.card-teal:not(.card-outline) .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.bg-teal .btn-tool:hover,
+.bg-gradient-teal .btn-tool:hover,
+.card-teal:not(.card-outline) .btn-tool:hover {
+  color: #1F2D3D;
+}
+
+.card.bg-teal .bootstrap-datetimepicker-widget .table td,
+.card.bg-teal .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-teal .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-teal .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-teal .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-teal .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-teal .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-teal .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-teal .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-teal .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #3ca99e;
+  color: #1F2D3D;
+}
+
+.card.bg-teal .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1F2D3D;
+}
+
+.card.bg-teal .bootstrap-datetimepicker-widget table td.active,
+.card.bg-teal .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #73cdc5;
+  color: #1F2D3D;
+}
+
+.card-cyan:not(.card-outline) > .card-header {
+  background-color: #6cb2eb;
+}
+
+.card-cyan:not(.card-outline) > .card-header,
+.card-cyan:not(.card-outline) > .card-header a {
+  color: #1F2D3D;
+}
+
+.card-cyan:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-cyan.card-outline {
+  border-top: 3px solid #6cb2eb;
+}
+
+.card-cyan.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-cyan.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #6cb2eb;
+}
+
+.bg-cyan .btn-tool,
+.bg-gradient-cyan .btn-tool,
+.card-cyan:not(.card-outline) .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.bg-cyan .btn-tool:hover,
+.bg-gradient-cyan .btn-tool:hover,
+.card-cyan:not(.card-outline) .btn-tool:hover {
+  color: #1F2D3D;
+}
+
+.card.bg-cyan .bootstrap-datetimepicker-widget .table td,
+.card.bg-cyan .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-cyan .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-cyan .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-cyan .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-cyan .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-cyan .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-cyan .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-cyan .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #489fe6;
+  color: #1F2D3D;
+}
+
+.card.bg-cyan .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1F2D3D;
+}
+
+.card.bg-cyan .bootstrap-datetimepicker-widget table td.active,
+.card.bg-cyan .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #99caf1;
+  color: #1F2D3D;
+}
+
+.card-white:not(.card-outline) > .card-header {
+  background-color: #ffffff;
+}
+
+.card-white:not(.card-outline) > .card-header,
+.card-white:not(.card-outline) > .card-header a {
+  color: #1F2D3D;
+}
+
+.card-white:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-white.card-outline {
+  border-top: 3px solid #ffffff;
+}
+
+.card-white.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-white.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #ffffff;
+}
+
+.bg-white .btn-tool,
+.bg-gradient-white .btn-tool,
+.card-white:not(.card-outline) .btn-tool {
+  color: rgba(31, 45, 61, 0.8);
+}
+
+.bg-white .btn-tool:hover,
+.bg-gradient-white .btn-tool:hover,
+.card-white:not(.card-outline) .btn-tool:hover {
+  color: #1F2D3D;
+}
+
+.card.bg-white .bootstrap-datetimepicker-widget .table td,
+.card.bg-white .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-white .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-white .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-white .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-white .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-white .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-white .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-white .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-white .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-white .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-white .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-white .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-white .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #ebebeb;
+  color: #1F2D3D;
+}
+
+.card.bg-white .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-white .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #1F2D3D;
+}
+
+.card.bg-white .bootstrap-datetimepicker-widget table td.active,
+.card.bg-white .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-white .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-white .bootstrap-datetimepicker-widget table td.active:hover {
+  background: white;
+  color: #1F2D3D;
+}
+
+.card-gray:not(.card-outline) > .card-header {
+  background-color: #6c757d;
+}
+
+.card-gray:not(.card-outline) > .card-header,
+.card-gray:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-gray:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-gray.card-outline {
+  border-top: 3px solid #6c757d;
+}
+
+.card-gray.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-gray.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #6c757d;
+}
+
+.bg-gray .btn-tool,
+.bg-gradient-gray .btn-tool,
+.card-gray:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-gray .btn-tool:hover,
+.bg-gradient-gray .btn-tool:hover,
+.card-gray:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-gray .bootstrap-datetimepicker-widget .table td,
+.card.bg-gray .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-gray .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-gray .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-gray .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gray .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gray .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gray .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gray .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-gray .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #596167;
+  color: #ffffff;
+}
+
+.card.bg-gray .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-gray .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gray .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #868e96;
+  color: #ffffff;
+}
+
+.card-gray-dark:not(.card-outline) > .card-header {
+  background-color: #343a40;
+}
+
+.card-gray-dark:not(.card-outline) > .card-header,
+.card-gray-dark:not(.card-outline) > .card-header a {
+  color: #ffffff;
+}
+
+.card-gray-dark:not(.card-outline) > .card-header a.active {
+  color: #1F2D3D;
+}
+
+.card-gray-dark.card-outline {
+  border-top: 3px solid #343a40;
+}
+
+.card-gray-dark.card-outline-tabs > .card-header a:hover {
+  border-top: 3px solid #dee2e6;
+}
+
+.card-gray-dark.card-outline-tabs > .card-header a.active {
+  border-top: 3px solid #343a40;
+}
+
+.bg-gray-dark .btn-tool,
+.bg-gradient-gray-dark .btn-tool,
+.card-gray-dark:not(.card-outline) .btn-tool {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.bg-gray-dark .btn-tool:hover,
+.bg-gradient-gray-dark .btn-tool:hover,
+.card-gray-dark:not(.card-outline) .btn-tool:hover {
+  color: #ffffff;
+}
+
+.card.bg-gray-dark .bootstrap-datetimepicker-widget .table td,
+.card.bg-gray-dark .bootstrap-datetimepicker-widget .table th,
+.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget .table td,
+.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget .table th {
+  border: none;
+}
+
+.card.bg-gray-dark .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gray-dark .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gray-dark .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gray-dark .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gray-dark .bootstrap-datetimepicker-widget table td.second:hover,
+.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
+.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.day:hover,
+.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.hour:hover,
+.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.minute:hover,
+.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.second:hover {
+  background: #222629;
+  color: #ffffff;
+}
+
+.card.bg-gray-dark .bootstrap-datetimepicker-widget table td.today::before,
+.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.today::before {
+  border-bottom-color: #ffffff;
+}
+
+.card.bg-gray-dark .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gray-dark .bootstrap-datetimepicker-widget table td.active:hover,
+.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.active,
+.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.active:hover {
+  background: #4b545c;
+  color: #ffffff;
+}
+
 .card {
   box-shadow: 0 0 1px rgba(0, 0, 0, 0.125), 0 1px 3px rgba(0, 0, 0, 0.2);
   margin-bottom: 1rem;
@@ -16206,11 +18488,11 @@ textarea.form-control.is-warning {
   border-left: 1px solid rgba(0, 0, 0, 0.125);
 }
 
-.card.card-tabs:not(.card-outline) .card-header {
+.card.card-tabs:not(.card-outline) > .card-header {
   border-bottom: 0;
 }
 
-.card.card-tabs:not(.card-outline) .card-header .nav-item:first-child .nav-link {
+.card.card-tabs:not(.card-outline) > .card-header .nav-item:first-child .nav-link {
   margin-left: -1px;
 }
 
@@ -16501,6 +18783,10 @@ html.maximized-card {
   border-left-color: #343a40;
 }
 
+.todo-list .lightblue {
+  border-left-color: #3c8dbc;
+}
+
 .todo-list .navy {
   border-left-color: #001f3f;
 }
@@ -16581,1852 +18867,6 @@ html.maximized-card {
 
 .card-input {
   max-width: 200px;
-}
-
-.card-primary:not(.card-outline) .card-header {
-  background-color: #3490dc;
-}
-
-.card-primary:not(.card-outline) .card-header,
-.card-primary:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-primary:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-primary.card-outline {
-  border-top: 3px solid #3490dc;
-}
-
-.card-primary.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-primary.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #3490dc;
-}
-
-.bg-primary .btn-tool,
-.bg-gradient-primary .btn-tool,
-.card-primary:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-primary .btn-tool:hover,
-.bg-gradient-primary .btn-tool:hover,
-.card-primary:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-primary .bootstrap-datetimepicker-widget .table td,
-.card.bg-primary .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-primary .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-primary .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-primary .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-primary .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-primary .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-primary .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-primary .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-primary .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #227bc5;
-  color: #ffffff;
-}
-
-.card.bg-primary .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-primary .bootstrap-datetimepicker-widget table td.active,
-.card.bg-primary .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-primary .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #60a8e4;
-  color: #ffffff;
-}
-
-.card-secondary:not(.card-outline) .card-header {
-  background-color: #6c757d;
-}
-
-.card-secondary:not(.card-outline) .card-header,
-.card-secondary:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-secondary:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-secondary.card-outline {
-  border-top: 3px solid #6c757d;
-}
-
-.card-secondary.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-secondary.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #6c757d;
-}
-
-.bg-secondary .btn-tool,
-.bg-gradient-secondary .btn-tool,
-.card-secondary:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-secondary .btn-tool:hover,
-.bg-gradient-secondary .btn-tool:hover,
-.card-secondary:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-secondary .bootstrap-datetimepicker-widget .table td,
-.card.bg-secondary .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-secondary .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-secondary .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-secondary .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-secondary .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-secondary .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-secondary .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-secondary .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #596167;
-  color: #ffffff;
-}
-
-.card.bg-secondary .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-secondary .bootstrap-datetimepicker-widget table td.active,
-.card.bg-secondary .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-secondary .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #868e96;
-  color: #ffffff;
-}
-
-.card-success:not(.card-outline) .card-header {
-  background-color: #38c172;
-}
-
-.card-success:not(.card-outline) .card-header,
-.card-success:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-success:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-success.card-outline {
-  border-top: 3px solid #38c172;
-}
-
-.card-success.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-success.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #38c172;
-}
-
-.bg-success .btn-tool,
-.bg-gradient-success .btn-tool,
-.card-success:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-success .btn-tool:hover,
-.bg-gradient-success .btn-tool:hover,
-.card-success:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-success .bootstrap-datetimepicker-widget .table td,
-.card.bg-success .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-success .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-success .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-success .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-success .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-success .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-success .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-success .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-success .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-success .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-success .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-success .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-success .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #2fa15f;
-  color: #ffffff;
-}
-
-.card.bg-success .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-success .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-success .bootstrap-datetimepicker-widget table td.active,
-.card.bg-success .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-success .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-success .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #5cd08d;
-  color: #ffffff;
-}
-
-.card-info:not(.card-outline) .card-header {
-  background-color: #6cb2eb;
-}
-
-.card-info:not(.card-outline) .card-header,
-.card-info:not(.card-outline) .card-header a {
-  color: #1F2D3D;
-}
-
-.card-info:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-info.card-outline {
-  border-top: 3px solid #6cb2eb;
-}
-
-.card-info.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-info.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #6cb2eb;
-}
-
-.bg-info .btn-tool,
-.bg-gradient-info .btn-tool,
-.card-info:not(.card-outline) .btn-tool {
-  color: rgba(31, 45, 61, 0.8);
-}
-
-.bg-info .btn-tool:hover,
-.bg-gradient-info .btn-tool:hover,
-.card-info:not(.card-outline) .btn-tool:hover {
-  color: #1F2D3D;
-}
-
-.card.bg-info .bootstrap-datetimepicker-widget .table td,
-.card.bg-info .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-info .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-info .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-info .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-info .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-info .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-info .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-info .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-info .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-info .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-info .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-info .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-info .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #489fe6;
-  color: #1F2D3D;
-}
-
-.card.bg-info .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-info .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #1F2D3D;
-}
-
-.card.bg-info .bootstrap-datetimepicker-widget table td.active,
-.card.bg-info .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-info .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-info .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #99caf1;
-  color: #1F2D3D;
-}
-
-.card-warning:not(.card-outline) .card-header {
-  background-color: #ffed4a;
-}
-
-.card-warning:not(.card-outline) .card-header,
-.card-warning:not(.card-outline) .card-header a {
-  color: #1F2D3D;
-}
-
-.card-warning:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-warning.card-outline {
-  border-top: 3px solid #ffed4a;
-}
-
-.card-warning.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-warning.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #ffed4a;
-}
-
-.bg-warning .btn-tool,
-.bg-gradient-warning .btn-tool,
-.card-warning:not(.card-outline) .btn-tool {
-  color: rgba(31, 45, 61, 0.8);
-}
-
-.bg-warning .btn-tool:hover,
-.bg-gradient-warning .btn-tool:hover,
-.card-warning:not(.card-outline) .btn-tool:hover {
-  color: #1F2D3D;
-}
-
-.card.bg-warning .bootstrap-datetimepicker-widget .table td,
-.card.bg-warning .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-warning .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-warning .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-warning .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-warning .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-warning .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-warning .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-warning .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-warning .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #ffe921;
-  color: #1F2D3D;
-}
-
-.card.bg-warning .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #1F2D3D;
-}
-
-.card.bg-warning .bootstrap-datetimepicker-widget table td.active,
-.card.bg-warning .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-warning .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #fff27d;
-  color: #1F2D3D;
-}
-
-.card-danger:not(.card-outline) .card-header {
-  background-color: #e3342f;
-}
-
-.card-danger:not(.card-outline) .card-header,
-.card-danger:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-danger:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-danger.card-outline {
-  border-top: 3px solid #e3342f;
-}
-
-.card-danger.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-danger.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #e3342f;
-}
-
-.bg-danger .btn-tool,
-.bg-gradient-danger .btn-tool,
-.card-danger:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-danger .btn-tool:hover,
-.bg-gradient-danger .btn-tool:hover,
-.card-danger:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-danger .bootstrap-datetimepicker-widget .table td,
-.card.bg-danger .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-danger .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-danger .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-danger .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-danger .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-danger .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-danger .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-danger .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-danger .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #ce211c;
-  color: #ffffff;
-}
-
-.card.bg-danger .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-danger .bootstrap-datetimepicker-widget table td.active,
-.card.bg-danger .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-danger .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #e9605c;
-  color: #ffffff;
-}
-
-.card-light:not(.card-outline) .card-header {
-  background-color: #f8f9fa;
-}
-
-.card-light:not(.card-outline) .card-header,
-.card-light:not(.card-outline) .card-header a {
-  color: #1F2D3D;
-}
-
-.card-light:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-light.card-outline {
-  border-top: 3px solid #f8f9fa;
-}
-
-.card-light.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-light.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #f8f9fa;
-}
-
-.bg-light .btn-tool,
-.bg-gradient-light .btn-tool,
-.card-light:not(.card-outline) .btn-tool {
-  color: rgba(31, 45, 61, 0.8);
-}
-
-.bg-light .btn-tool:hover,
-.bg-gradient-light .btn-tool:hover,
-.card-light:not(.card-outline) .btn-tool:hover {
-  color: #1F2D3D;
-}
-
-.card.bg-light .bootstrap-datetimepicker-widget .table td,
-.card.bg-light .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-light .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-light .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-light .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-light .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-light .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-light .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-light .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-light .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-light .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-light .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-light .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-light .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #e0e5e9;
-  color: #1F2D3D;
-}
-
-.card.bg-light .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-light .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #1F2D3D;
-}
-
-.card.bg-light .bootstrap-datetimepicker-widget table td.active,
-.card.bg-light .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-light .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-light .bootstrap-datetimepicker-widget table td.active:hover {
-  background: white;
-  color: #1F2D3D;
-}
-
-.card-dark:not(.card-outline) .card-header {
-  background-color: #343a40;
-}
-
-.card-dark:not(.card-outline) .card-header,
-.card-dark:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-dark:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-dark.card-outline {
-  border-top: 3px solid #343a40;
-}
-
-.card-dark.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-dark.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #343a40;
-}
-
-.bg-dark .btn-tool,
-.bg-gradient-dark .btn-tool,
-.card-dark:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-dark .btn-tool:hover,
-.bg-gradient-dark .btn-tool:hover,
-.card-dark:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-dark .bootstrap-datetimepicker-widget .table td,
-.card.bg-dark .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-dark .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-dark .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-dark .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-dark .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-dark .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-dark .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-dark .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-dark .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #222629;
-  color: #ffffff;
-}
-
-.card.bg-dark .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-dark .bootstrap-datetimepicker-widget table td.active,
-.card.bg-dark .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-dark .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #4b545c;
-  color: #ffffff;
-}
-
-.card-navy:not(.card-outline) .card-header {
-  background-color: #001f3f;
-}
-
-.card-navy:not(.card-outline) .card-header,
-.card-navy:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-navy:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-navy.card-outline {
-  border-top: 3px solid #001f3f;
-}
-
-.card-navy.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-navy.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #001f3f;
-}
-
-.bg-navy .btn-tool,
-.bg-gradient-navy .btn-tool,
-.card-navy:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-navy .btn-tool:hover,
-.bg-gradient-navy .btn-tool:hover,
-.card-navy:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-navy .bootstrap-datetimepicker-widget .table td,
-.card.bg-navy .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-navy .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-navy .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-navy .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-navy .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-navy .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-navy .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-navy .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-navy .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #000b16;
-  color: #ffffff;
-}
-
-.card.bg-navy .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-navy .bootstrap-datetimepicker-widget table td.active,
-.card.bg-navy .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-navy .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #003872;
-  color: #ffffff;
-}
-
-.card-olive:not(.card-outline) .card-header {
-  background-color: #3d9970;
-}
-
-.card-olive:not(.card-outline) .card-header,
-.card-olive:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-olive:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-olive.card-outline {
-  border-top: 3px solid #3d9970;
-}
-
-.card-olive.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-olive.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #3d9970;
-}
-
-.bg-olive .btn-tool,
-.bg-gradient-olive .btn-tool,
-.card-olive:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-olive .btn-tool:hover,
-.bg-gradient-olive .btn-tool:hover,
-.card-olive:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-olive .bootstrap-datetimepicker-widget .table td,
-.card.bg-olive .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-olive .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-olive .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-olive .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-olive .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-olive .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-olive .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-olive .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-olive .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #317c5b;
-  color: #ffffff;
-}
-
-.card.bg-olive .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-olive .bootstrap-datetimepicker-widget table td.active,
-.card.bg-olive .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-olive .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #50b98a;
-  color: #ffffff;
-}
-
-.card-lime:not(.card-outline) .card-header {
-  background-color: #01ff70;
-}
-
-.card-lime:not(.card-outline) .card-header,
-.card-lime:not(.card-outline) .card-header a {
-  color: #1F2D3D;
-}
-
-.card-lime:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-lime.card-outline {
-  border-top: 3px solid #01ff70;
-}
-
-.card-lime.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-lime.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #01ff70;
-}
-
-.bg-lime .btn-tool,
-.bg-gradient-lime .btn-tool,
-.card-lime:not(.card-outline) .btn-tool {
-  color: rgba(31, 45, 61, 0.8);
-}
-
-.bg-lime .btn-tool:hover,
-.bg-gradient-lime .btn-tool:hover,
-.card-lime:not(.card-outline) .btn-tool:hover {
-  color: #1F2D3D;
-}
-
-.card.bg-lime .bootstrap-datetimepicker-widget .table td,
-.card.bg-lime .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-lime .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-lime .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-lime .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-lime .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-lime .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-lime .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-lime .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-lime .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #00d75e;
-  color: #1F2D3D;
-}
-
-.card.bg-lime .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #1F2D3D;
-}
-
-.card.bg-lime .bootstrap-datetimepicker-widget table td.active,
-.card.bg-lime .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-lime .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #34ff8d;
-  color: #1F2D3D;
-}
-
-.card-fuchsia:not(.card-outline) .card-header {
-  background-color: #f012be;
-}
-
-.card-fuchsia:not(.card-outline) .card-header,
-.card-fuchsia:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-fuchsia:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-fuchsia.card-outline {
-  border-top: 3px solid #f012be;
-}
-
-.card-fuchsia.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-fuchsia.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #f012be;
-}
-
-.bg-fuchsia .btn-tool,
-.bg-gradient-fuchsia .btn-tool,
-.card-fuchsia:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-fuchsia .btn-tool:hover,
-.bg-gradient-fuchsia .btn-tool:hover,
-.card-fuchsia:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-fuchsia .bootstrap-datetimepicker-widget .table td,
-.card.bg-fuchsia .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-fuchsia .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-fuchsia .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-fuchsia .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-fuchsia .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-fuchsia .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #cc0da1;
-  color: #ffffff;
-}
-
-.card.bg-fuchsia .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-fuchsia .bootstrap-datetimepicker-widget table td.active,
-.card.bg-fuchsia .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-fuchsia .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #f342cb;
-  color: #ffffff;
-}
-
-.card-maroon:not(.card-outline) .card-header {
-  background-color: #d81b60;
-}
-
-.card-maroon:not(.card-outline) .card-header,
-.card-maroon:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-maroon:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-maroon.card-outline {
-  border-top: 3px solid #d81b60;
-}
-
-.card-maroon.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-maroon.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #d81b60;
-}
-
-.bg-maroon .btn-tool,
-.bg-gradient-maroon .btn-tool,
-.card-maroon:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-maroon .btn-tool:hover,
-.bg-gradient-maroon .btn-tool:hover,
-.card-maroon:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-maroon .bootstrap-datetimepicker-widget .table td,
-.card.bg-maroon .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-maroon .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-maroon .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-maroon .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-maroon .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-maroon .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-maroon .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-maroon .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #b41650;
-  color: #ffffff;
-}
-
-.card.bg-maroon .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-maroon .bootstrap-datetimepicker-widget table td.active,
-.card.bg-maroon .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-maroon .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #e73f7c;
-  color: #ffffff;
-}
-
-.card-blue:not(.card-outline) .card-header {
-  background-color: #3490dc;
-}
-
-.card-blue:not(.card-outline) .card-header,
-.card-blue:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-blue:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-blue.card-outline {
-  border-top: 3px solid #3490dc;
-}
-
-.card-blue.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-blue.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #3490dc;
-}
-
-.bg-blue .btn-tool,
-.bg-gradient-blue .btn-tool,
-.card-blue:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-blue .btn-tool:hover,
-.bg-gradient-blue .btn-tool:hover,
-.card-blue:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-blue .bootstrap-datetimepicker-widget .table td,
-.card.bg-blue .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-blue .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-blue .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-blue .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-blue .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-blue .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-blue .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-blue .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-blue .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #227bc5;
-  color: #ffffff;
-}
-
-.card.bg-blue .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-blue .bootstrap-datetimepicker-widget table td.active,
-.card.bg-blue .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-blue .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #60a8e4;
-  color: #ffffff;
-}
-
-.card-indigo:not(.card-outline) .card-header {
-  background-color: #6574cd;
-}
-
-.card-indigo:not(.card-outline) .card-header,
-.card-indigo:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-indigo:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-indigo.card-outline {
-  border-top: 3px solid #6574cd;
-}
-
-.card-indigo.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-indigo.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #6574cd;
-}
-
-.bg-indigo .btn-tool,
-.bg-gradient-indigo .btn-tool,
-.card-indigo:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-indigo .btn-tool:hover,
-.bg-gradient-indigo .btn-tool:hover,
-.card-indigo:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-indigo .bootstrap-datetimepicker-widget .table td,
-.card.bg-indigo .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-indigo .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-indigo .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-indigo .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-indigo .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-indigo .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-indigo .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-indigo .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #4658c3;
-  color: #ffffff;
-}
-
-.card.bg-indigo .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-indigo .bootstrap-datetimepicker-widget table td.active,
-.card.bg-indigo .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-indigo .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #8c97da;
-  color: #ffffff;
-}
-
-.card-purple:not(.card-outline) .card-header {
-  background-color: #9561e2;
-}
-
-.card-purple:not(.card-outline) .card-header,
-.card-purple:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-purple:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-purple.card-outline {
-  border-top: 3px solid #9561e2;
-}
-
-.card-purple.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-purple.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #9561e2;
-}
-
-.bg-purple .btn-tool,
-.bg-gradient-purple .btn-tool,
-.card-purple:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-purple .btn-tool:hover,
-.bg-gradient-purple .btn-tool:hover,
-.card-purple:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-purple .bootstrap-datetimepicker-widget .table td,
-.card.bg-purple .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-purple .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-purple .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-purple .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-purple .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-purple .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-purple .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-purple .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-purple .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #7e3fdc;
-  color: #ffffff;
-}
-
-.card.bg-purple .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-purple .bootstrap-datetimepicker-widget table td.active,
-.card.bg-purple .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-purple .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #b28cea;
-  color: #ffffff;
-}
-
-.card-pink:not(.card-outline) .card-header {
-  background-color: #f66d9b;
-}
-
-.card-pink:not(.card-outline) .card-header,
-.card-pink:not(.card-outline) .card-header a {
-  color: #1F2D3D;
-}
-
-.card-pink:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-pink.card-outline {
-  border-top: 3px solid #f66d9b;
-}
-
-.card-pink.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-pink.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #f66d9b;
-}
-
-.bg-pink .btn-tool,
-.bg-gradient-pink .btn-tool,
-.card-pink:not(.card-outline) .btn-tool {
-  color: rgba(31, 45, 61, 0.8);
-}
-
-.bg-pink .btn-tool:hover,
-.bg-gradient-pink .btn-tool:hover,
-.card-pink:not(.card-outline) .btn-tool:hover {
-  color: #1F2D3D;
-}
-
-.card.bg-pink .bootstrap-datetimepicker-widget .table td,
-.card.bg-pink .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-pink .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-pink .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-pink .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-pink .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-pink .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-pink .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-pink .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-pink .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #f44781;
-  color: #1F2D3D;
-}
-
-.card.bg-pink .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #1F2D3D;
-}
-
-.card.bg-pink .bootstrap-datetimepicker-widget table td.active,
-.card.bg-pink .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-pink .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #f99dbc;
-  color: #1F2D3D;
-}
-
-.card-red:not(.card-outline) .card-header {
-  background-color: #e3342f;
-}
-
-.card-red:not(.card-outline) .card-header,
-.card-red:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-red:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-red.card-outline {
-  border-top: 3px solid #e3342f;
-}
-
-.card-red.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-red.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #e3342f;
-}
-
-.bg-red .btn-tool,
-.bg-gradient-red .btn-tool,
-.card-red:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-red .btn-tool:hover,
-.bg-gradient-red .btn-tool:hover,
-.card-red:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-red .bootstrap-datetimepicker-widget .table td,
-.card.bg-red .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-red .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-red .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-red .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-red .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-red .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-red .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-red .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-red .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-red .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-red .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-red .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-red .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #ce211c;
-  color: #ffffff;
-}
-
-.card.bg-red .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-red .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-red .bootstrap-datetimepicker-widget table td.active,
-.card.bg-red .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-red .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-red .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #e9605c;
-  color: #ffffff;
-}
-
-.card-orange:not(.card-outline) .card-header {
-  background-color: #f6993f;
-}
-
-.card-orange:not(.card-outline) .card-header,
-.card-orange:not(.card-outline) .card-header a {
-  color: #1F2D3D;
-}
-
-.card-orange:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-orange.card-outline {
-  border-top: 3px solid #f6993f;
-}
-
-.card-orange.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-orange.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #f6993f;
-}
-
-.bg-orange .btn-tool,
-.bg-gradient-orange .btn-tool,
-.card-orange:not(.card-outline) .btn-tool {
-  color: rgba(31, 45, 61, 0.8);
-}
-
-.bg-orange .btn-tool:hover,
-.bg-gradient-orange .btn-tool:hover,
-.card-orange:not(.card-outline) .btn-tool:hover {
-  color: #1F2D3D;
-}
-
-.card.bg-orange .bootstrap-datetimepicker-widget .table td,
-.card.bg-orange .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-orange .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-orange .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-orange .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-orange .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-orange .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-orange .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-orange .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-orange .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #f48418;
-  color: #1F2D3D;
-}
-
-.card.bg-orange .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #1F2D3D;
-}
-
-.card.bg-orange .bootstrap-datetimepicker-widget table td.active,
-.card.bg-orange .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-orange .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #f8b370;
-  color: #1F2D3D;
-}
-
-.card-yellow:not(.card-outline) .card-header {
-  background-color: #ffed4a;
-}
-
-.card-yellow:not(.card-outline) .card-header,
-.card-yellow:not(.card-outline) .card-header a {
-  color: #1F2D3D;
-}
-
-.card-yellow:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-yellow.card-outline {
-  border-top: 3px solid #ffed4a;
-}
-
-.card-yellow.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-yellow.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #ffed4a;
-}
-
-.bg-yellow .btn-tool,
-.bg-gradient-yellow .btn-tool,
-.card-yellow:not(.card-outline) .btn-tool {
-  color: rgba(31, 45, 61, 0.8);
-}
-
-.bg-yellow .btn-tool:hover,
-.bg-gradient-yellow .btn-tool:hover,
-.card-yellow:not(.card-outline) .btn-tool:hover {
-  color: #1F2D3D;
-}
-
-.card.bg-yellow .bootstrap-datetimepicker-widget .table td,
-.card.bg-yellow .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-yellow .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-yellow .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-yellow .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-yellow .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-yellow .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-yellow .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-yellow .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #ffe921;
-  color: #1F2D3D;
-}
-
-.card.bg-yellow .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #1F2D3D;
-}
-
-.card.bg-yellow .bootstrap-datetimepicker-widget table td.active,
-.card.bg-yellow .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-yellow .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #fff27d;
-  color: #1F2D3D;
-}
-
-.card-green:not(.card-outline) .card-header {
-  background-color: #38c172;
-}
-
-.card-green:not(.card-outline) .card-header,
-.card-green:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-green:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-green.card-outline {
-  border-top: 3px solid #38c172;
-}
-
-.card-green.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-green.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #38c172;
-}
-
-.bg-green .btn-tool,
-.bg-gradient-green .btn-tool,
-.card-green:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-green .btn-tool:hover,
-.bg-gradient-green .btn-tool:hover,
-.card-green:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-green .bootstrap-datetimepicker-widget .table td,
-.card.bg-green .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-green .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-green .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-green .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-green .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-green .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-green .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-green .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-green .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-green .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-green .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-green .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-green .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #2fa15f;
-  color: #ffffff;
-}
-
-.card.bg-green .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-green .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-green .bootstrap-datetimepicker-widget table td.active,
-.card.bg-green .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-green .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-green .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #5cd08d;
-  color: #ffffff;
-}
-
-.card-teal:not(.card-outline) .card-header {
-  background-color: #4dc0b5;
-}
-
-.card-teal:not(.card-outline) .card-header,
-.card-teal:not(.card-outline) .card-header a {
-  color: #1F2D3D;
-}
-
-.card-teal:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-teal.card-outline {
-  border-top: 3px solid #4dc0b5;
-}
-
-.card-teal.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-teal.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #4dc0b5;
-}
-
-.bg-teal .btn-tool,
-.bg-gradient-teal .btn-tool,
-.card-teal:not(.card-outline) .btn-tool {
-  color: rgba(31, 45, 61, 0.8);
-}
-
-.bg-teal .btn-tool:hover,
-.bg-gradient-teal .btn-tool:hover,
-.card-teal:not(.card-outline) .btn-tool:hover {
-  color: #1F2D3D;
-}
-
-.card.bg-teal .bootstrap-datetimepicker-widget .table td,
-.card.bg-teal .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-teal .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-teal .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-teal .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-teal .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-teal .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-teal .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-teal .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-teal .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #3ca99e;
-  color: #1F2D3D;
-}
-
-.card.bg-teal .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #1F2D3D;
-}
-
-.card.bg-teal .bootstrap-datetimepicker-widget table td.active,
-.card.bg-teal .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-teal .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #73cdc5;
-  color: #1F2D3D;
-}
-
-.card-cyan:not(.card-outline) .card-header {
-  background-color: #6cb2eb;
-}
-
-.card-cyan:not(.card-outline) .card-header,
-.card-cyan:not(.card-outline) .card-header a {
-  color: #1F2D3D;
-}
-
-.card-cyan:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-cyan.card-outline {
-  border-top: 3px solid #6cb2eb;
-}
-
-.card-cyan.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-cyan.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #6cb2eb;
-}
-
-.bg-cyan .btn-tool,
-.bg-gradient-cyan .btn-tool,
-.card-cyan:not(.card-outline) .btn-tool {
-  color: rgba(31, 45, 61, 0.8);
-}
-
-.bg-cyan .btn-tool:hover,
-.bg-gradient-cyan .btn-tool:hover,
-.card-cyan:not(.card-outline) .btn-tool:hover {
-  color: #1F2D3D;
-}
-
-.card.bg-cyan .bootstrap-datetimepicker-widget .table td,
-.card.bg-cyan .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-cyan .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-cyan .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-cyan .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-cyan .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-cyan .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-cyan .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-cyan .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #489fe6;
-  color: #1F2D3D;
-}
-
-.card.bg-cyan .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #1F2D3D;
-}
-
-.card.bg-cyan .bootstrap-datetimepicker-widget table td.active,
-.card.bg-cyan .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-cyan .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #99caf1;
-  color: #1F2D3D;
-}
-
-.card-white:not(.card-outline) .card-header {
-  background-color: #ffffff;
-}
-
-.card-white:not(.card-outline) .card-header,
-.card-white:not(.card-outline) .card-header a {
-  color: #1F2D3D;
-}
-
-.card-white:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-white.card-outline {
-  border-top: 3px solid #ffffff;
-}
-
-.card-white.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-white.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #ffffff;
-}
-
-.bg-white .btn-tool,
-.bg-gradient-white .btn-tool,
-.card-white:not(.card-outline) .btn-tool {
-  color: rgba(31, 45, 61, 0.8);
-}
-
-.bg-white .btn-tool:hover,
-.bg-gradient-white .btn-tool:hover,
-.card-white:not(.card-outline) .btn-tool:hover {
-  color: #1F2D3D;
-}
-
-.card.bg-white .bootstrap-datetimepicker-widget .table td,
-.card.bg-white .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-white .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-white .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-white .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-white .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-white .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-white .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-white .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-white .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-white .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-white .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-white .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-white .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #ebebeb;
-  color: #1F2D3D;
-}
-
-.card.bg-white .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-white .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #1F2D3D;
-}
-
-.card.bg-white .bootstrap-datetimepicker-widget table td.active,
-.card.bg-white .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-white .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-white .bootstrap-datetimepicker-widget table td.active:hover {
-  background: white;
-  color: #1F2D3D;
-}
-
-.card-gray:not(.card-outline) .card-header {
-  background-color: #6c757d;
-}
-
-.card-gray:not(.card-outline) .card-header,
-.card-gray:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-gray:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-gray.card-outline {
-  border-top: 3px solid #6c757d;
-}
-
-.card-gray.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-gray.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #6c757d;
-}
-
-.bg-gray .btn-tool,
-.bg-gradient-gray .btn-tool,
-.card-gray:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-gray .btn-tool:hover,
-.bg-gradient-gray .btn-tool:hover,
-.card-gray:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-gray .bootstrap-datetimepicker-widget .table td,
-.card.bg-gray .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-gray .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-gray .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-gray .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gray .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gray .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gray .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gray .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-gray .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #596167;
-  color: #ffffff;
-}
-
-.card.bg-gray .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-gray .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gray .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-gray .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #868e96;
-  color: #ffffff;
-}
-
-.card-gray-dark:not(.card-outline) .card-header {
-  background-color: #343a40;
-}
-
-.card-gray-dark:not(.card-outline) .card-header,
-.card-gray-dark:not(.card-outline) .card-header a {
-  color: #ffffff;
-}
-
-.card-gray-dark:not(.card-outline) .card-header a.active {
-  color: #1F2D3D;
-}
-
-.card-gray-dark.card-outline {
-  border-top: 3px solid #343a40;
-}
-
-.card-gray-dark.card-outline-tabs .card-header a:hover {
-  border-top: 3px solid #dee2e6;
-}
-
-.card-gray-dark.card-outline-tabs .card-header a.active {
-  border-top: 3px solid #343a40;
-}
-
-.bg-gray-dark .btn-tool,
-.bg-gradient-gray-dark .btn-tool,
-.card-gray-dark:not(.card-outline) .btn-tool {
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.bg-gray-dark .btn-tool:hover,
-.bg-gradient-gray-dark .btn-tool:hover,
-.card-gray-dark:not(.card-outline) .btn-tool:hover {
-  color: #ffffff;
-}
-
-.card.bg-gray-dark .bootstrap-datetimepicker-widget .table td,
-.card.bg-gray-dark .bootstrap-datetimepicker-widget .table th,
-.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget .table td,
-.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget .table th {
-  border: none;
-}
-
-.card.bg-gray-dark .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gray-dark .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gray-dark .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gray-dark .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gray-dark .bootstrap-datetimepicker-widget table td.second:hover,
-.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table thead tr:first-child th:hover,
-.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.day:hover,
-.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.hour:hover,
-.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.minute:hover,
-.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #222629;
-  color: #ffffff;
-}
-
-.card.bg-gray-dark .bootstrap-datetimepicker-widget table td.today::before,
-.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.today::before {
-  border-bottom-color: #ffffff;
-}
-
-.card.bg-gray-dark .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gray-dark .bootstrap-datetimepicker-widget table td.active:hover,
-.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.active,
-.card.bg-gradient-gray-dark .bootstrap-datetimepicker-widget table td.active:hover {
-  background: #4b545c;
-  color: #ffffff;
 }
 
 .card-default .nav-item:first-child .nav-link {
@@ -18607,6 +19047,21 @@ html.maximized-card {
 
 .toast.bg-dark .toast-header {
   background: rgba(52, 58, 64, 0.85);
+  color: #ffffff;
+}
+
+.toast.bg-lightblue {
+  background: rgba(60, 141, 188, 0.9) !important;
+}
+
+.toast.bg-lightblue .close,
+.toast.bg-lightblue .mailbox-attachment-close {
+  color: #ffffff;
+  text-shadow: 0 1px 0 #000;
+}
+
+.toast.bg-lightblue .toast-header {
+  background: rgba(60, 141, 188, 0.85);
   color: #ffffff;
 }
 
@@ -20005,6 +20460,17 @@ html.maximized-card {
   border-left-color: #343a40;
 }
 
+.direct-chat-lightblue .right > .direct-chat-text {
+  background: #3c8dbc;
+  border-color: #3c8dbc;
+  color: #ffffff;
+}
+
+.direct-chat-lightblue .right > .direct-chat-text::after,
+.direct-chat-lightblue .right > .direct-chat-text::before {
+  border-left-color: #3c8dbc;
+}
+
 .direct-chat-navy .right > .direct-chat-text {
   background: #001f3f;
   border-color: #001f3f;
@@ -20493,6 +20959,7 @@ html.maximized-card {
   align-items: center;
   background: #e9ecef;
   display: flex;
+  flex-direction: column;
   height: 100vh;
   justify-content: center;
 }
@@ -21394,6 +21861,56 @@ html.maximized-card {
 .select2-container--default .select2-dark.select2-container--focus .select2-selection--multiple,
 .select2-dark .select2-container--default.select2-container--focus .select2-selection--multiple {
   border-color: #6d7a86;
+}
+
+.select2-container--default .select2-lightblue.select2-dropdown .select2-search__field:focus,
+.select2-container--default .select2-lightblue .select2-dropdown .select2-search__field:focus,
+.select2-container--default .select2-lightblue .select2-search--inline .select2-search__field:focus,
+.select2-lightblue .select2-container--default.select2-dropdown .select2-search__field:focus,
+.select2-lightblue .select2-container--default .select2-dropdown .select2-search__field:focus,
+.select2-lightblue .select2-container--default .select2-search--inline .select2-search__field:focus {
+  border: 1px solid #99c5de;
+}
+
+.select2-container--default .select2-lightblue .select2-results__option--highlighted,
+.select2-lightblue .select2-container--default .select2-results__option--highlighted {
+  background-color: #3c8dbc;
+  color: #ffffff;
+}
+
+.select2-container--default .select2-lightblue .select2-results__option--highlighted[aria-selected],
+.select2-container--default .select2-lightblue .select2-results__option--highlighted[aria-selected]:hover,
+.select2-lightblue .select2-container--default .select2-results__option--highlighted[aria-selected],
+.select2-lightblue .select2-container--default .select2-results__option--highlighted[aria-selected]:hover {
+  background-color: #3884b0;
+  color: #ffffff;
+}
+
+.select2-container--default .select2-lightblue .select2-selection--multiple:focus,
+.select2-lightblue .select2-container--default .select2-selection--multiple:focus {
+  border-color: #99c5de;
+}
+
+.select2-container--default .select2-lightblue .select2-selection--multiple .select2-selection__choice,
+.select2-lightblue .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: #3c8dbc;
+  border-color: #367fa9;
+  color: #ffffff;
+}
+
+.select2-container--default .select2-lightblue .select2-selection--multiple .select2-selection__choice__remove,
+.select2-lightblue .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.select2-container--default .select2-lightblue .select2-selection--multiple .select2-selection__choice__remove:hover,
+.select2-lightblue .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: #ffffff;
+}
+
+.select2-container--default .select2-lightblue.select2-container--focus .select2-selection--multiple,
+.select2-lightblue .select2-container--default.select2-container--focus .select2-selection--multiple {
+  border-color: #99c5de;
 }
 
 .select2-container--default .select2-navy.select2-dropdown .select2-search__field:focus,
@@ -22340,6 +22857,10 @@ html.maximized-card {
   background: #343a40;
 }
 
+.slider-lightblue .slider .slider-selection {
+  background: #3c8dbc;
+}
+
 .slider-navy .slider .slider-selection {
   background: #001f3f;
 }
@@ -22538,6 +23059,22 @@ html.maximized-card {
 .icheck-dark > input:first-child:checked + input[type=hidden] + label::before {
   background-color: #343a40;
   border-color: #343a40;
+}
+
+.icheck-lightblue > input:first-child:not(:checked):not(:disabled):hover + label::before,
+.icheck-lightblue > input:first-child:not(:checked):not(:disabled):hover + input[type=hidden] + label::before {
+  border-color: #3c8dbc;
+}
+
+.icheck-lightblue > input:first-child:not(:checked):not(:disabled):focus + label::before,
+.icheck-lightblue > input:first-child:not(:checked):not(:disabled):focus + input[type=hidden] + label::before {
+  border-color: #3c8dbc;
+}
+
+.icheck-lightblue > input:first-child:checked + label::before,
+.icheck-lightblue > input:first-child:checked + input[type=hidden] + label::before {
+  background-color: #3c8dbc;
+  border-color: #3c8dbc;
 }
 
 .icheck-navy > input:first-child:not(:checked):not(:disabled):hover + label::before,
@@ -24047,6 +24584,138 @@ html.maximized-card {
 
 .pace-progress-color-dark .pace-progress {
   color: #343a40;
+}
+
+.pace-lightblue .pace .pace-progress {
+  background: #3c8dbc;
+}
+
+.pace-barber-shop-lightblue .pace {
+  background: #ffffff;
+}
+
+.pace-barber-shop-lightblue .pace .pace-progress {
+  background: #3c8dbc;
+}
+
+.pace-barber-shop-lightblue .pace .pace-activity {
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.2) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0.2) 75%, transparent 75%, transparent);
+}
+
+.pace-big-counter-lightblue .pace .pace-progress::after {
+  color: rgba(60, 141, 188, 0.2);
+}
+
+.pace-bounce-lightblue .pace .pace-activity {
+  background: #3c8dbc;
+}
+
+.pace-center-atom-lightblue .pace-progress {
+  height: 100px;
+  width: 80px;
+}
+
+.pace-center-atom-lightblue .pace-progress::before {
+  background: #3c8dbc;
+  color: #ffffff;
+  font-size: 0.8rem;
+  line-height: 0.7rem;
+  padding-top: 17%;
+}
+
+.pace-center-atom-lightblue .pace-activity {
+  border-color: #3c8dbc;
+}
+
+.pace-center-atom-lightblue .pace-activity::after,
+.pace-center-atom-lightblue .pace-activity::before {
+  border-color: #3c8dbc;
+}
+
+.pace-center-circle-lightblue .pace .pace-progress {
+  background: rgba(60, 141, 188, 0.8);
+  color: #ffffff;
+}
+
+.pace-center-radar-lightblue .pace .pace-activity {
+  border-color: #3c8dbc transparent transparent;
+}
+
+.pace-center-radar-lightblue .pace .pace-activity::before {
+  border-color: #3c8dbc transparent transparent;
+}
+
+.pace-center-simple-lightblue .pace {
+  background: #ffffff;
+  border-color: #3c8dbc;
+}
+
+.pace-center-simple-lightblue .pace .pace-progress {
+  background: #3c8dbc;
+}
+
+.pace-material-lightblue .pace {
+  color: #3c8dbc;
+}
+
+.pace-corner-indicator-lightblue .pace .pace-activity {
+  background: #3c8dbc;
+}
+
+.pace-corner-indicator-lightblue .pace .pace-activity::after,
+.pace-corner-indicator-lightblue .pace .pace-activity::before {
+  border: 5px solid #ffffff;
+}
+
+.pace-corner-indicator-lightblue .pace .pace-activity::before {
+  border-right-color: rgba(60, 141, 188, 0.2);
+  border-left-color: rgba(60, 141, 188, 0.2);
+}
+
+.pace-corner-indicator-lightblue .pace .pace-activity::after {
+  border-top-color: rgba(60, 141, 188, 0.2);
+  border-bottom-color: rgba(60, 141, 188, 0.2);
+}
+
+.pace-fill-left-lightblue .pace .pace-progress {
+  background-color: rgba(60, 141, 188, 0.2);
+}
+
+.pace-flash-lightblue .pace .pace-progress {
+  background: #3c8dbc;
+}
+
+.pace-flash-lightblue .pace .pace-progress-inner {
+  box-shadow: 0 0 10px #3c8dbc, 0 0 5px #3c8dbc;
+}
+
+.pace-flash-lightblue .pace .pace-activity {
+  border-top-color: #3c8dbc;
+  border-left-color: #3c8dbc;
+}
+
+.pace-loading-bar-lightblue .pace .pace-progress {
+  background: #3c8dbc;
+  color: #3c8dbc;
+  box-shadow: 120px 0 #ffffff, 240px 0 #ffffff;
+}
+
+.pace-loading-bar-lightblue .pace .pace-activity {
+  box-shadow: inset 0 0 0 2px #3c8dbc, inset 0 0 0 7px #ffffff;
+}
+
+.pace-mac-osx-lightblue .pace .pace-progress {
+  background-color: #3c8dbc;
+  box-shadow: inset -1px 0 #3c8dbc, inset 0 -1px #3c8dbc, inset 0 2px rgba(255, 255, 255, 0.5), inset 0 6px rgba(255, 255, 255, 0.3);
+}
+
+.pace-mac-osx-lightblue .pace .pace-activity {
+  background-image: radial-gradient(rgba(255, 255, 255, 0.65) 0%, rgba(255, 255, 255, 0.15) 100%);
+  height: 12px;
+}
+
+.pace-progress-color-lightblue .pace-progress {
+  color: #3c8dbc;
 }
 
 .pace-navy .pace .pace-progress {
@@ -26537,6 +27206,12 @@ html.maximized-card {
   color: #ffffff;
 }
 
+.bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-lightblue,
+.bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-lightblue {
+  background: #3c8dbc;
+  color: #ffffff;
+}
+
 .bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-navy,
 .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-navy {
   background: #001f3f;
@@ -27288,6 +27963,19 @@ blockquote.quote-dark h6 {
   color: #343a40;
 }
 
+blockquote.quote-lightblue {
+  border-color: #3c8dbc;
+}
+
+blockquote.quote-lightblue h1,
+blockquote.quote-lightblue h2,
+blockquote.quote-lightblue h3,
+blockquote.quote-lightblue h4,
+blockquote.quote-lightblue h5,
+blockquote.quote-lightblue h6 {
+  color: #3c8dbc;
+}
+
 blockquote.quote-navy {
   border-color: #001f3f;
 }
@@ -27536,6 +28224,17 @@ blockquote.quote-gray-dark h6 {
   padding-bottom: 0.5rem;
 }
 
+.badge-btn {
+  border-radius: 0.15rem;
+  font-size: 0.675rem;
+  font-weight: 400;
+  padding: 0.25rem 0.5rem;
+}
+
+.badge-btn.badge-pill {
+  padding: 0.375rem 0.6rem;
+}
+
 @media print {
   .no-print,
   .main-sidebar,
@@ -27601,6 +28300,10 @@ blockquote.quote-gray-dark h6 {
 
 .text-xl {
   font-size: 1.8rem !important;
+}
+
+.text-lightblue {
+  color: #3c8dbc;
 }
 
 .text-navy {
@@ -27880,6 +28583,29 @@ blockquote.quote-gray-dark h6 {
 .bg-dark.btn.active {
   background-color: #1d2124 !important;
   border-color: #171a1d;
+  color: #ffffff;
+}
+
+.bg-lightblue {
+  background-color: #3c8dbc !important;
+}
+
+.bg-lightblue,
+.bg-lightblue > a {
+  color: #ffffff !important;
+}
+
+.bg-lightblue.btn:hover {
+  border-color: #307095;
+  color: #ececec;
+}
+
+.bg-lightblue.btn:not(:disabled):not(.disabled):active,
+.bg-lightblue.btn:not(:disabled):not(.disabled).active,
+.bg-lightblue.btn:active,
+.bg-lightblue.btn.active {
+  background-color: #307095 !important;
+  border-color: #2d698c;
   color: #ffffff;
 }
 
@@ -28637,6 +29363,46 @@ blockquote.quote-gray-dark h6 {
   background: #1d2124 linear-gradient(180deg, #3e4244, #1d2124) repeat-x !important;
 }
 
+.bg-gradient-lightblue {
+  color: #ffffff;
+}
+
+.bg-gradient-lightblue {
+  background: #3c8dbc linear-gradient(180deg, #589dc6, #3c8dbc) repeat-x !important;
+}
+
+.bg-gradient-lightblue.btn.disabled,
+.bg-gradient-lightblue.btn:disabled,
+.bg-gradient-lightblue.btn:not(:disabled):not(.disabled):active,
+.bg-gradient-lightblue.btn:not(:disabled):not(.disabled).active,
+.show > .bg-gradient-lightblue.btn.dropdown-toggle {
+  background-image: none !important;
+}
+
+.bg-gradient-lightblue.btn:hover {
+  border-color: #307095;
+  color: #ececec;
+}
+
+.bg-gradient-lightblue.btn:hover {
+  background: #33779f linear-gradient(180deg, #518bad, #33779f) repeat-x !important;
+}
+
+.bg-gradient-lightblue.btn:not(:disabled):not(.disabled):active,
+.bg-gradient-lightblue.btn:not(:disabled):not(.disabled).active,
+.bg-gradient-lightblue.btn:active,
+.bg-gradient-lightblue.btn.active {
+  border-color: #2d698c;
+  color: #ffffff;
+}
+
+.bg-gradient-lightblue.btn:not(:disabled):not(.disabled):active,
+.bg-gradient-lightblue.btn:not(:disabled):not(.disabled).active,
+.bg-gradient-lightblue.btn:active,
+.bg-gradient-lightblue.btn.active {
+  background: #307095 linear-gradient(180deg, #4e85a4, #307095) repeat-x !important;
+}
+
 .bg-gradient-navy {
   color: #ffffff;
 }
@@ -29383,12 +30149,40 @@ a.text-muted:hover {
   color: #e6e8ea;
 }
 
-.accent-primary a {
+.accent-primary .btn-link,
+.accent-primary a:not(.dropdown-item) {
   color: #3490dc;
 }
 
-.accent-primary a:hover {
+.accent-primary .btn-link:hover,
+.accent-primary a:not(.dropdown-item):hover {
   color: #1d68a7;
+}
+
+.accent-primary .dropdown-item.active {
+  background: #3490dc;
+  color: #ffffff;
+}
+
+.accent-primary .custom-control-input:checked ~ .custom-control-label::before {
+  background: #3490dc;
+  border-color: #195b91;
+}
+
+.accent-primary .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-primary .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-primary .custom-select:focus,
+.accent-primary .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-primary .custom-file-input:focus ~ .custom-file-label {
+  border-color: #a1cbef;
+}
+
+.accent-primary [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-primary[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #3490dc;
 }
 
 .accent-primary .page-item.active .page-link {
@@ -29401,12 +30195,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-secondary a {
+.accent-secondary .btn-link,
+.accent-secondary a:not(.dropdown-item) {
   color: #6c757d;
 }
 
-.accent-secondary a:hover {
+.accent-secondary .btn-link:hover,
+.accent-secondary a:not(.dropdown-item):hover {
   color: #494f54;
+}
+
+.accent-secondary .dropdown-item.active {
+  background: #6c757d;
+  color: #ffffff;
+}
+
+.accent-secondary .custom-control-input:checked ~ .custom-control-label::before {
+  background: #6c757d;
+  border-color: #3d4246;
+}
+
+.accent-secondary .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-secondary .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-secondary .custom-select:focus,
+.accent-secondary .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-secondary .custom-file-input:focus ~ .custom-file-label {
+  border-color: #afb5ba;
+}
+
+.accent-secondary [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-secondary[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #6c757d;
 }
 
 .accent-secondary .page-item.active .page-link {
@@ -29419,12 +30241,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-success a {
+.accent-success .btn-link,
+.accent-success a:not(.dropdown-item) {
   color: #38c172;
 }
 
-.accent-success a:hover {
+.accent-success .btn-link:hover,
+.accent-success a:not(.dropdown-item):hover {
   color: #27864f;
+}
+
+.accent-success .dropdown-item.active {
+  background: #38c172;
+  color: #ffffff;
+}
+
+.accent-success .custom-control-input:checked ~ .custom-control-label::before {
+  background: #38c172;
+  border-color: #217243;
+}
+
+.accent-success .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-success .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-success .custom-select:focus,
+.accent-success .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-success .custom-file-input:focus ~ .custom-file-label {
+  border-color: #98e1b7;
+}
+
+.accent-success [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-success[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #38c172;
 }
 
 .accent-success .page-item.active .page-link {
@@ -29437,12 +30287,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-info a {
+.accent-info .btn-link,
+.accent-info a:not(.dropdown-item) {
   color: #6cb2eb;
 }
 
-.accent-info a:hover {
+.accent-info .btn-link:hover,
+.accent-info a:not(.dropdown-item):hover {
   color: #298fe2;
+}
+
+.accent-info .dropdown-item.active {
+  background: #6cb2eb;
+  color: #1F2D3D;
+}
+
+.accent-info .custom-control-input:checked ~ .custom-control-label::before {
+  background: #6cb2eb;
+  border-color: #1d82d4;
+}
+
+.accent-info .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231F2D3D' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-info .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-info .custom-select:focus,
+.accent-info .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-info .custom-file-input:focus ~ .custom-file-label {
+  border-color: #dcedfa;
+}
+
+.accent-info [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-info[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #6cb2eb;
 }
 
 .accent-info .page-item.active .page-link {
@@ -29455,12 +30333,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-warning a {
+.accent-warning .btn-link,
+.accent-warning a:not(.dropdown-item) {
   color: #ffed4a;
 }
 
-.accent-warning a:hover {
+.accent-warning .btn-link:hover,
+.accent-warning a:not(.dropdown-item):hover {
   color: #fde300;
+}
+
+.accent-warning .dropdown-item.active {
+  background: #ffed4a;
+  color: #1F2D3D;
+}
+
+.accent-warning .custom-control-input:checked ~ .custom-control-label::before {
+  background: #ffed4a;
+  border-color: #e3cc00;
+}
+
+.accent-warning .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231F2D3D' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-warning .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-warning .custom-select:focus,
+.accent-warning .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-warning .custom-file-input:focus ~ .custom-file-label {
+  border-color: #fffaca;
+}
+
+.accent-warning [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-warning[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #ffed4a;
 }
 
 .accent-warning .page-item.active .page-link {
@@ -29473,12 +30379,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-danger a {
+.accent-danger .btn-link,
+.accent-danger a:not(.dropdown-item) {
   color: #e3342f;
 }
 
-.accent-danger a:hover {
+.accent-danger .btn-link:hover,
+.accent-danger a:not(.dropdown-item):hover {
   color: #ae1c17;
+}
+
+.accent-danger .dropdown-item.active {
+  background: #e3342f;
+  color: #ffffff;
+}
+
+.accent-danger .custom-control-input:checked ~ .custom-control-label::before {
+  background: #e3342f;
+  border-color: #981814;
+}
+
+.accent-danger .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-danger .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-danger .custom-select:focus,
+.accent-danger .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-danger .custom-file-input:focus ~ .custom-file-label {
+  border-color: #f2a29f;
+}
+
+.accent-danger [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-danger[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #e3342f;
 }
 
 .accent-danger .page-item.active .page-link {
@@ -29491,12 +30425,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-light a {
+.accent-light .btn-link,
+.accent-light a:not(.dropdown-item) {
   color: #f8f9fa;
 }
 
-.accent-light a:hover {
+.accent-light .btn-link:hover,
+.accent-light a:not(.dropdown-item):hover {
   color: #cbd3da;
+}
+
+.accent-light .dropdown-item.active {
+  background: #f8f9fa;
+  color: #1F2D3D;
+}
+
+.accent-light .custom-control-input:checked ~ .custom-control-label::before {
+  background: #f8f9fa;
+  border-color: #bdc6d0;
+}
+
+.accent-light .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231F2D3D' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-light .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-light .custom-select:focus,
+.accent-light .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-light .custom-file-input:focus ~ .custom-file-label {
+  border-color: white;
+}
+
+.accent-light [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-light[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #f8f9fa;
 }
 
 .accent-light .page-item.active .page-link {
@@ -29509,12 +30471,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-dark a {
+.accent-dark .btn-link,
+.accent-dark a:not(.dropdown-item) {
   color: #343a40;
 }
 
-.accent-dark a:hover {
+.accent-dark .btn-link:hover,
+.accent-dark a:not(.dropdown-item):hover {
   color: #121416;
+}
+
+.accent-dark .dropdown-item.active {
+  background: #343a40;
+  color: #ffffff;
+}
+
+.accent-dark .custom-control-input:checked ~ .custom-control-label::before {
+  background: #343a40;
+  border-color: #060708;
+}
+
+.accent-dark .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-dark .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-dark .custom-select:focus,
+.accent-dark .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-dark .custom-file-input:focus ~ .custom-file-label {
+  border-color: #6d7a86;
+}
+
+.accent-dark [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-dark[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #343a40;
 }
 
 .accent-dark .page-item.active .page-link {
@@ -29527,12 +30517,86 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-navy a {
+.accent-lightblue .btn-link,
+.accent-lightblue a:not(.dropdown-item) {
+  color: #3c8dbc;
+}
+
+.accent-lightblue .btn-link:hover,
+.accent-lightblue a:not(.dropdown-item):hover {
+  color: #296282;
+}
+
+.accent-lightblue .dropdown-item.active {
+  background: #3c8dbc;
+  color: #ffffff;
+}
+
+.accent-lightblue .custom-control-input:checked ~ .custom-control-label::before {
+  background: #3c8dbc;
+  border-color: #23536f;
+}
+
+.accent-lightblue .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-lightblue .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-lightblue .custom-select:focus,
+.accent-lightblue .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-lightblue .custom-file-input:focus ~ .custom-file-label {
+  border-color: #99c5de;
+}
+
+.accent-lightblue [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-lightblue[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #3c8dbc;
+}
+
+.accent-lightblue .page-item.active .page-link {
+  background-color: #3c8dbc;
+  border-color: #3c8dbc;
+}
+
+.accent-lightblue .page-item.disabled .page-link {
+  background-color: #ffffff;
+  border-color: #dee2e6;
+}
+
+.accent-navy .btn-link,
+.accent-navy a:not(.dropdown-item) {
   color: #001f3f;
 }
 
-.accent-navy a:hover {
+.accent-navy .btn-link:hover,
+.accent-navy a:not(.dropdown-item):hover {
   color: black;
+}
+
+.accent-navy .dropdown-item.active {
+  background: #001f3f;
+  color: #ffffff;
+}
+
+.accent-navy .custom-control-input:checked ~ .custom-control-label::before {
+  background: #001f3f;
+  border-color: black;
+}
+
+.accent-navy .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-navy .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-navy .custom-select:focus,
+.accent-navy .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-navy .custom-file-input:focus ~ .custom-file-label {
+  border-color: #005ebf;
+}
+
+.accent-navy [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-navy[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #001f3f;
 }
 
 .accent-navy .page-item.active .page-link {
@@ -29545,12 +30609,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-olive a {
+.accent-olive .btn-link,
+.accent-olive a:not(.dropdown-item) {
   color: #3d9970;
 }
 
-.accent-olive a:hover {
+.accent-olive .btn-link:hover,
+.accent-olive a:not(.dropdown-item):hover {
   color: #276248;
+}
+
+.accent-olive .dropdown-item.active {
+  background: #3d9970;
+  color: #ffffff;
+}
+
+.accent-olive .custom-control-input:checked ~ .custom-control-label::before {
+  background: #3d9970;
+  border-color: #20503b;
+}
+
+.accent-olive .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-olive .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-olive .custom-select:focus,
+.accent-olive .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-olive .custom-file-input:focus ~ .custom-file-label {
+  border-color: #87cfaf;
+}
+
+.accent-olive [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-olive[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #3d9970;
 }
 
 .accent-olive .page-item.active .page-link {
@@ -29563,12 +30655,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-lime a {
+.accent-lime .btn-link,
+.accent-lime a:not(.dropdown-item) {
   color: #01ff70;
 }
 
-.accent-lime a:hover {
+.accent-lime .btn-link:hover,
+.accent-lime a:not(.dropdown-item):hover {
   color: #00b44e;
+}
+
+.accent-lime .dropdown-item.active {
+  background: #01ff70;
+  color: #1F2D3D;
+}
+
+.accent-lime .custom-control-input:checked ~ .custom-control-label::before {
+  background: #01ff70;
+  border-color: #009a43;
+}
+
+.accent-lime .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231F2D3D' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-lime .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-lime .custom-select:focus,
+.accent-lime .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-lime .custom-file-input:focus ~ .custom-file-label {
+  border-color: #81ffb8;
+}
+
+.accent-lime [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-lime[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #01ff70;
 }
 
 .accent-lime .page-item.active .page-link {
@@ -29581,12 +30701,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-fuchsia a {
+.accent-fuchsia .btn-link,
+.accent-fuchsia a:not(.dropdown-item) {
   color: #f012be;
 }
 
-.accent-fuchsia a:hover {
+.accent-fuchsia .btn-link:hover,
+.accent-fuchsia a:not(.dropdown-item):hover {
   color: #ab0b87;
+}
+
+.accent-fuchsia .dropdown-item.active {
+  background: #f012be;
+  color: #ffffff;
+}
+
+.accent-fuchsia .custom-control-input:checked ~ .custom-control-label::before {
+  background: #f012be;
+  border-color: #930974;
+}
+
+.accent-fuchsia .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-fuchsia .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-fuchsia .custom-select:focus,
+.accent-fuchsia .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-fuchsia .custom-file-input:focus ~ .custom-file-label {
+  border-color: #f88adf;
+}
+
+.accent-fuchsia [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-fuchsia[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #f012be;
 }
 
 .accent-fuchsia .page-item.active .page-link {
@@ -29599,12 +30747,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-maroon a {
+.accent-maroon .btn-link,
+.accent-maroon a:not(.dropdown-item) {
   color: #d81b60;
 }
 
-.accent-maroon a:hover {
+.accent-maroon .btn-link:hover,
+.accent-maroon a:not(.dropdown-item):hover {
   color: #941342;
+}
+
+.accent-maroon .dropdown-item.active {
+  background: #d81b60;
+  color: #ffffff;
+}
+
+.accent-maroon .custom-control-input:checked ~ .custom-control-label::before {
+  background: #d81b60;
+  border-color: #7d1038;
+}
+
+.accent-maroon .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-maroon .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-maroon .custom-select:focus,
+.accent-maroon .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-maroon .custom-file-input:focus ~ .custom-file-label {
+  border-color: #f083ab;
+}
+
+.accent-maroon [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-maroon[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #d81b60;
 }
 
 .accent-maroon .page-item.active .page-link {
@@ -29617,12 +30793,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-blue a {
+.accent-blue .btn-link,
+.accent-blue a:not(.dropdown-item) {
   color: #3490dc;
 }
 
-.accent-blue a:hover {
+.accent-blue .btn-link:hover,
+.accent-blue a:not(.dropdown-item):hover {
   color: #1d68a7;
+}
+
+.accent-blue .dropdown-item.active {
+  background: #3490dc;
+  color: #ffffff;
+}
+
+.accent-blue .custom-control-input:checked ~ .custom-control-label::before {
+  background: #3490dc;
+  border-color: #195b91;
+}
+
+.accent-blue .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-blue .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-blue .custom-select:focus,
+.accent-blue .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-blue .custom-file-input:focus ~ .custom-file-label {
+  border-color: #a1cbef;
+}
+
+.accent-blue [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-blue[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #3490dc;
 }
 
 .accent-blue .page-item.active .page-link {
@@ -29635,12 +30839,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-indigo a {
+.accent-indigo .btn-link,
+.accent-indigo a:not(.dropdown-item) {
   color: #6574cd;
 }
 
-.accent-indigo a:hover {
+.accent-indigo .btn-link:hover,
+.accent-indigo a:not(.dropdown-item):hover {
   color: #3849ad;
+}
+
+.accent-indigo .dropdown-item.active {
+  background: #6574cd;
+  color: #ffffff;
+}
+
+.accent-indigo .custom-control-input:checked ~ .custom-control-label::before {
+  background: #6574cd;
+  border-color: #32419a;
+}
+
+.accent-indigo .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-indigo .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-indigo .custom-select:focus,
+.accent-indigo .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-indigo .custom-file-input:focus ~ .custom-file-label {
+  border-color: #c5cbec;
+}
+
+.accent-indigo [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-indigo[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #6574cd;
 }
 
 .accent-indigo .page-item.active .page-link {
@@ -29653,12 +30885,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-purple a {
+.accent-purple .btn-link,
+.accent-purple a:not(.dropdown-item) {
   color: #9561e2;
 }
 
-.accent-purple a:hover {
+.accent-purple .btn-link:hover,
+.accent-purple a:not(.dropdown-item):hover {
   color: #6b26d0;
+}
+
+.accent-purple .dropdown-item.active {
+  background: #9561e2;
+  color: #ffffff;
+}
+
+.accent-purple .custom-control-input:checked ~ .custom-control-label::before {
+  background: #9561e2;
+  border-color: #6022bb;
+}
+
+.accent-purple .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-purple .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-purple .custom-select:focus,
+.accent-purple .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-purple .custom-file-input:focus ~ .custom-file-label {
+  border-color: #ddcdf6;
+}
+
+.accent-purple [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-purple[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #9561e2;
 }
 
 .accent-purple .page-item.active .page-link {
@@ -29671,12 +30931,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-pink a {
+.accent-pink .btn-link,
+.accent-pink a:not(.dropdown-item) {
   color: #f66d9b;
 }
 
-.accent-pink a:hover {
+.accent-pink .btn-link:hover,
+.accent-pink a:not(.dropdown-item):hover {
   color: #f2256a;
+}
+
+.accent-pink .dropdown-item.active {
+  background: #f66d9b;
+  color: #1F2D3D;
+}
+
+.accent-pink .custom-control-input:checked ~ .custom-control-label::before {
+  background: #f66d9b;
+  border-color: #ee0f5a;
+}
+
+.accent-pink .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231F2D3D' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-pink .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-pink .custom-select:focus,
+.accent-pink .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-pink .custom-file-input:focus ~ .custom-file-label {
+  border-color: #fde5ed;
+}
+
+.accent-pink [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-pink[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #f66d9b;
 }
 
 .accent-pink .page-item.active .page-link {
@@ -29689,12 +30977,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-red a {
+.accent-red .btn-link,
+.accent-red a:not(.dropdown-item) {
   color: #e3342f;
 }
 
-.accent-red a:hover {
+.accent-red .btn-link:hover,
+.accent-red a:not(.dropdown-item):hover {
   color: #ae1c17;
+}
+
+.accent-red .dropdown-item.active {
+  background: #e3342f;
+  color: #ffffff;
+}
+
+.accent-red .custom-control-input:checked ~ .custom-control-label::before {
+  background: #e3342f;
+  border-color: #981814;
+}
+
+.accent-red .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-red .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-red .custom-select:focus,
+.accent-red .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-red .custom-file-input:focus ~ .custom-file-label {
+  border-color: #f2a29f;
+}
+
+.accent-red [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-red[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #e3342f;
 }
 
 .accent-red .page-item.active .page-link {
@@ -29707,12 +31023,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-orange a {
+.accent-orange .btn-link,
+.accent-orange a:not(.dropdown-item) {
   color: #f6993f;
 }
 
-.accent-orange a:hover {
+.accent-orange .btn-link:hover,
+.accent-orange a:not(.dropdown-item):hover {
   color: #de730a;
+}
+
+.accent-orange .dropdown-item.active {
+  background: #f6993f;
+  color: #1F2D3D;
+}
+
+.accent-orange .custom-control-input:checked ~ .custom-control-label::before {
+  background: #f6993f;
+  border-color: #c66609;
+}
+
+.accent-orange .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231F2D3D' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-orange .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-orange .custom-select:focus,
+.accent-orange .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-orange .custom-file-input:focus ~ .custom-file-label {
+  border-color: #fcdab9;
+}
+
+.accent-orange [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-orange[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #f6993f;
 }
 
 .accent-orange .page-item.active .page-link {
@@ -29725,12 +31069,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-yellow a {
+.accent-yellow .btn-link,
+.accent-yellow a:not(.dropdown-item) {
   color: #ffed4a;
 }
 
-.accent-yellow a:hover {
+.accent-yellow .btn-link:hover,
+.accent-yellow a:not(.dropdown-item):hover {
   color: #fde300;
+}
+
+.accent-yellow .dropdown-item.active {
+  background: #ffed4a;
+  color: #1F2D3D;
+}
+
+.accent-yellow .custom-control-input:checked ~ .custom-control-label::before {
+  background: #ffed4a;
+  border-color: #e3cc00;
+}
+
+.accent-yellow .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231F2D3D' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-yellow .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-yellow .custom-select:focus,
+.accent-yellow .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-yellow .custom-file-input:focus ~ .custom-file-label {
+  border-color: #fffaca;
+}
+
+.accent-yellow [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-yellow[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #ffed4a;
 }
 
 .accent-yellow .page-item.active .page-link {
@@ -29743,12 +31115,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-green a {
+.accent-green .btn-link,
+.accent-green a:not(.dropdown-item) {
   color: #38c172;
 }
 
-.accent-green a:hover {
+.accent-green .btn-link:hover,
+.accent-green a:not(.dropdown-item):hover {
   color: #27864f;
+}
+
+.accent-green .dropdown-item.active {
+  background: #38c172;
+  color: #ffffff;
+}
+
+.accent-green .custom-control-input:checked ~ .custom-control-label::before {
+  background: #38c172;
+  border-color: #217243;
+}
+
+.accent-green .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-green .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-green .custom-select:focus,
+.accent-green .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-green .custom-file-input:focus ~ .custom-file-label {
+  border-color: #98e1b7;
+}
+
+.accent-green [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-green[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #38c172;
 }
 
 .accent-green .page-item.active .page-link {
@@ -29761,12 +31161,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-teal a {
+.accent-teal .btn-link,
+.accent-teal a:not(.dropdown-item) {
   color: #4dc0b5;
 }
 
-.accent-teal a:hover {
+.accent-teal .btn-link:hover,
+.accent-teal a:not(.dropdown-item):hover {
   color: #328e85;
+}
+
+.accent-teal .dropdown-item.active {
+  background: #4dc0b5;
+  color: #1F2D3D;
+}
+
+.accent-teal .custom-control-input:checked ~ .custom-control-label::before {
+  background: #4dc0b5;
+  border-color: #2c7b74;
+}
+
+.accent-teal .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231F2D3D' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-teal .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-teal .custom-select:focus,
+.accent-teal .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-teal .custom-file-input:focus ~ .custom-file-label {
+  border-color: #abe1dc;
+}
+
+.accent-teal [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-teal[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #4dc0b5;
 }
 
 .accent-teal .page-item.active .page-link {
@@ -29779,12 +31207,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-cyan a {
+.accent-cyan .btn-link,
+.accent-cyan a:not(.dropdown-item) {
   color: #6cb2eb;
 }
 
-.accent-cyan a:hover {
+.accent-cyan .btn-link:hover,
+.accent-cyan a:not(.dropdown-item):hover {
   color: #298fe2;
+}
+
+.accent-cyan .dropdown-item.active {
+  background: #6cb2eb;
+  color: #1F2D3D;
+}
+
+.accent-cyan .custom-control-input:checked ~ .custom-control-label::before {
+  background: #6cb2eb;
+  border-color: #1d82d4;
+}
+
+.accent-cyan .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231F2D3D' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-cyan .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-cyan .custom-select:focus,
+.accent-cyan .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-cyan .custom-file-input:focus ~ .custom-file-label {
+  border-color: #dcedfa;
+}
+
+.accent-cyan [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-cyan[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #6cb2eb;
 }
 
 .accent-cyan .page-item.active .page-link {
@@ -29797,12 +31253,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-white a {
+.accent-white .btn-link,
+.accent-white a:not(.dropdown-item) {
   color: #ffffff;
 }
 
-.accent-white a:hover {
+.accent-white .btn-link:hover,
+.accent-white a:not(.dropdown-item):hover {
   color: #d9d9d9;
+}
+
+.accent-white .dropdown-item.active {
+  background: #ffffff;
+  color: #1F2D3D;
+}
+
+.accent-white .custom-control-input:checked ~ .custom-control-label::before {
+  background: #ffffff;
+  border-color: #cccccc;
+}
+
+.accent-white .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%231F2D3D' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-white .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-white .custom-select:focus,
+.accent-white .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-white .custom-file-input:focus ~ .custom-file-label {
+  border-color: white;
+}
+
+.accent-white [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-white[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #ffffff;
 }
 
 .accent-white .page-item.active .page-link {
@@ -29815,12 +31299,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-gray a {
+.accent-gray .btn-link,
+.accent-gray a:not(.dropdown-item) {
   color: #6c757d;
 }
 
-.accent-gray a:hover {
+.accent-gray .btn-link:hover,
+.accent-gray a:not(.dropdown-item):hover {
   color: #494f54;
+}
+
+.accent-gray .dropdown-item.active {
+  background: #6c757d;
+  color: #ffffff;
+}
+
+.accent-gray .custom-control-input:checked ~ .custom-control-label::before {
+  background: #6c757d;
+  border-color: #3d4246;
+}
+
+.accent-gray .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-gray .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-gray .custom-select:focus,
+.accent-gray .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-gray .custom-file-input:focus ~ .custom-file-label {
+  border-color: #afb5ba;
+}
+
+.accent-gray [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-gray[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #6c757d;
 }
 
 .accent-gray .page-item.active .page-link {
@@ -29833,12 +31345,40 @@ a.text-muted:hover {
   border-color: #dee2e6;
 }
 
-.accent-gray-dark a {
+.accent-gray-dark .btn-link,
+.accent-gray-dark a:not(.dropdown-item) {
   color: #343a40;
 }
 
-.accent-gray-dark a:hover {
+.accent-gray-dark .btn-link:hover,
+.accent-gray-dark a:not(.dropdown-item):hover {
   color: #121416;
+}
+
+.accent-gray-dark .dropdown-item.active {
+  background: #343a40;
+  color: #ffffff;
+}
+
+.accent-gray-dark .custom-control-input:checked ~ .custom-control-label::before {
+  background: #343a40;
+  border-color: #060708;
+}
+
+.accent-gray-dark .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23ffffff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.accent-gray-dark .form-control:focus:not(.is-invalid):not(.is-warning):not(.is-valid),
+.accent-gray-dark .custom-select:focus,
+.accent-gray-dark .custom-control-input:focus:not(:checked) ~ .custom-control-label::before,
+.accent-gray-dark .custom-file-input:focus ~ .custom-file-label {
+  border-color: #6d7a86;
+}
+
+.accent-gray-dark [class*=sidebar-light-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover,
+.accent-gray-dark[class*=sidebar-dark-] .nav-sidebar .nav-treeview > .nav-item > .nav-link:not(.active):hover {
+  color: #343a40;
 }
 
 .accent-gray-dark .page-item.active .page-link {
@@ -29849,5 +31389,37 @@ a.text-muted:hover {
 .accent-gray-dark .page-item.disabled .page-link {
   background-color: #ffffff;
   border-color: #dee2e6;
+}
+
+[class*=accent-] a.btn-primary {
+  color: #ffffff;
+}
+
+[class*=accent-] a.btn-secondary {
+  color: #ffffff;
+}
+
+[class*=accent-] a.btn-success {
+  color: #ffffff;
+}
+
+[class*=accent-] a.btn-info {
+  color: #1F2D3D;
+}
+
+[class*=accent-] a.btn-warning {
+  color: #1F2D3D;
+}
+
+[class*=accent-] a.btn-danger {
+  color: #ffffff;
+}
+
+[class*=accent-] a.btn-light {
+  color: #1F2D3D;
+}
+
+[class*=accent-] a.btn-dark {
+  color: #ffffff;
 }
 

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -36376,3 +36376,9 @@ p.train-status:before {
   padding-right: 0;
 }
 
+.navbar .nav-item span.notifications-bell.fa,
+.navbar .nav-item span.notifications-bell.far {
+  padding-left: 3px;
+  padding-right: 3px;
+}
+

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -36312,35 +36312,35 @@ p.train-status:before {
   font-size: 0.6em;
 }
 
-#notifications-board .modal-body {
+#notifications-board .modal-body#notifications-list {
   padding: 0;
 }
 
-#notifications-board #notifications-list .row {
+#notifications-board .modal-body#notifications-list .row {
   background-color: white;
   padding: 1rem 0;
   border-bottom: 0.5rem solid #f8fafc;
   margin: 0;
 }
 
-#notifications-board #notifications-list .row.unread.warning {
+#notifications-board .modal-body#notifications-list .row.unread.warning {
   background-color: #f2c9c5;
 }
 
-#notifications-board #notifications-list .row.unread.info {
+#notifications-board .modal-body#notifications-list .row.unread.neutral {
   background-color: #e2effa;
 }
 
-#notifications-board #notifications-list .row p.lead {
+#notifications-board .modal-body#notifications-list .row p.lead {
   margin-bottom: 0.5rem;
 }
 
-#notifications-board #notifications-list .row p.lead i {
+#notifications-board .modal-body#notifications-list .row p.lead i {
   padding-right: 0.5rem;
 }
 
-#notifications-board #notifications-list .row .col-1 i,
-#notifications-board #notifications-list .row .interact {
+#notifications-board .modal-body#notifications-list .row .col-1 i,
+#notifications-board .modal-body#notifications-list .row .interact {
   font-weight: 700;
   line-height: 1;
   color: #343a40;
@@ -36353,8 +36353,12 @@ p.train-status:before {
   font-size: 1.25rem;
 }
 
-#notifications-board #notifications-list strong {
+#notifications-board .modal-body#notifications-list .row strong {
   font-weight: bold;
+}
+
+#notifications-board #notifications-empty {
+  padding: 2rem 0;
 }
 
 .navbar div.navbar-toggler {

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -36323,6 +36323,10 @@ p.train-status:before {
   margin: 0;
 }
 
+#notifications-board .modal-body#notifications-list .row a {
+  color: #212529;
+}
+
 #notifications-board .modal-body#notifications-list .row.unread.warning {
   background-color: #f2c9c5;
 }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -36357,7 +36357,8 @@ p.train-status:before {
   font-size: 1.25rem;
 }
 
-#notifications-board .modal-body#notifications-list .row strong {
+#notifications-board .modal-body#notifications-list .row strong,
+#notifications-board .modal-body#notifications-list .row b {
   font-weight: bold;
 }
 

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -36294,3 +36294,81 @@ p.train-status:before {
   line-height: 1.5;
 }
 
+#notifications-board .modal-header {
+  justify-content: initial;
+}
+
+#notifications-board .modal-header .close {
+  font-size: 2rem;
+  float: none;
+}
+
+#notifications-board .modal-header .close#mark-read {
+  flex-grow: 1;
+  text-align: left;
+}
+
+#notifications-board .modal-header .close#mark-read i.fas {
+  font-size: 0.6em;
+}
+
+#notifications-board .modal-body {
+  padding: 0;
+}
+
+#notifications-board #notifications-list .row {
+  background-color: white;
+  padding: 1rem 0;
+  border-bottom: 0.5rem solid #f8fafc;
+  margin: 0;
+}
+
+#notifications-board #notifications-list .row.unread.warning {
+  background-color: #f2c9c5;
+}
+
+#notifications-board #notifications-list .row.unread.info {
+  background-color: #e2effa;
+}
+
+#notifications-board #notifications-list .row p.lead {
+  margin-bottom: 0.5rem;
+}
+
+#notifications-board #notifications-list .row p.lead i {
+  padding-right: 0.5rem;
+}
+
+#notifications-board #notifications-list .row .col-1 i,
+#notifications-board #notifications-list .row .interact {
+  font-weight: 700;
+  line-height: 1;
+  color: #343a40;
+  text-shadow: 0 1px 0 #fff;
+  padding: 0;
+  background-color: transparent;
+  border: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  font-size: 1.25rem;
+}
+
+#notifications-board #notifications-list strong {
+  font-weight: bold;
+}
+
+.navbar div.navbar-toggler {
+  display: table-cell;
+  padding-right: 0;
+}
+
+.navbar div.navbar-toggler button.navbar-toggler {
+  vertical-align: middle;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.navbar div.navbar-toggler button.navbar-toggler:last-child {
+  padding-right: 0;
+}
+

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -36303,12 +36303,12 @@ p.train-status:before {
   float: none;
 }
 
-#notifications-board .modal-header .close#mark-read {
+#notifications-board .modal-header .close#mark-all-read {
   flex-grow: 1;
   text-align: left;
 }
 
-#notifications-board .modal-header .close#mark-read i.fas {
+#notifications-board .modal-header .close#mark-all-read i.fas {
   font-size: 0.6em;
 }
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -12,13 +12,14 @@ require("leaflet/dist/leaflet.js");
  * Once the page is loaded, we can load our frontend components.
  */
 window.addEventListener("load", () => {
-    require("bootstrap-cookie-alert/cookiealert");
+    require("./components/alert");
+    require("./components/notifications-board");
     require("./components/progressbar");
+    require("./components/pwa_fix");
+    require("./components/settings");
+    require("./components/station-autocomplete");
     require("./components/stationboard");
     require("./components/statusMap");
     require("./components/timepicker");
-    require("./components/settings");
-    require("./components/alert");
-    require("./components/pwa_fix");
-    require("./components/station-autocomplete");
+    require("bootstrap-cookie-alert/cookiealert");
 });

--- a/resources/js/components/notifications-board.js
+++ b/resources/js/components/notifications-board.js
@@ -1,8 +1,17 @@
-fetch('/notifications/latest')
+fetch('/notifications/latest', {
+    credentials: 'same-origin'
+})
     .then(res => res.json())
     .then(notifications => {
+        // If there are no notifications, we can just quit here. Else, show the items.
         if (notifications.length == 0) return;
         document.getElementById('notifications-empty').classList.add('d-none');
+
+        // if there are unread notifications, make the bell ring.
+        if (notifications.some(n => n.read_at == null)) {
+            Array.from(document.getElementsByClassName('notifications-bell'))
+                .forEach(bell => bell.classList.replace("far", "fa"));
+        }
 
         var html = notifications.reduce((sum, add) => {
             return sum + add.html;

--- a/resources/js/components/notifications-board.js
+++ b/resources/js/components/notifications-board.js
@@ -18,4 +18,31 @@ fetch('/notifications/latest', {
         }, "");
 
         document.getElementById('notifications-list').insertAdjacentHTML('afterbegin', html);
+    })
+    .then(() => { // After the notification rows have been created, we can add eventlisteners for them
+        Array.from(document.getElementsByClassName('toggleReadState')).forEach(btn =>
+            btn.addEventListener('click', () => {
+
+                fetch('/notifications/toggleReadState/' + btn.dataset.id, {
+                    credentials: 'same-origin',
+                    method: 'POST',
+                    body: JSON.stringify({}),
+                    headers: {
+                        'X-CSRF-TOKEN': token
+                    }
+                })
+                    .then(res => {
+                        const icon = btn.getElementsByTagName('i')[0];
+                        const row = document.getElementById('notification-' + btn.dataset.id);
+
+                        if (res.status == 201) { // new state = read
+                            icon.classList.replace('fa-envelope', 'fa-envelope-open');
+                            row.classList.remove('unread');
+                        } else if (res.status == 202) { // new state = unread
+                            icon.classList.replace('fa-envelope-open', 'fa-envelope');
+                            row.classList.add('unread');
+                        }
+                    });
+            })
+        );
     });

--- a/resources/js/components/notifications-board.js
+++ b/resources/js/components/notifications-board.js
@@ -1,0 +1,12 @@
+fetch('/notifications/latest')
+    .then(res => res.json())
+    .then(notifications => {
+        if (notifications.length == 0) return;
+        document.getElementById('notifications-empty').classList.add('d-none');
+
+        var html = notifications.reduce((sum, add) => {
+            return sum + add.html;
+        }, "");
+
+        document.getElementById('notifications-list').insertAdjacentHTML('afterbegin', html);
+    });

--- a/resources/js/components/notifications-board.js
+++ b/resources/js/components/notifications-board.js
@@ -32,17 +32,40 @@ fetch('/notifications/latest', {
                     }
                 })
                     .then(res => {
-                        const icon = btn.getElementsByTagName('i')[0];
-                        const row = document.getElementById('notification-' + btn.dataset.id);
-
-                        if (res.status == 201) { // new state = read
-                            icon.classList.replace('fa-envelope', 'fa-envelope-open');
-                            row.classList.remove('unread');
-                        } else if (res.status == 202) { // new state = unread
-                            icon.classList.replace('fa-envelope-open', 'fa-envelope');
-                            row.classList.add('unread');
-                        }
+                        toggleRead(btn.dataset.id, res.status == 201);
                     });
             })
         );
     });
+
+document.getElementById('mark-all-read').addEventListener('click', () => {
+    fetch('/notifications/readAll', {
+        credentials: 'same-origin',
+        method: 'POST',
+        body: JSON.stringify({}),
+        headers: {
+            'X-CSRF-TOKEN': token
+        }
+    }).then(() => {
+        Array.from(document.getElementsByClassName('toggleReadState')).forEach(btn => {
+            toggleRead(btn.dataset.id, true);
+        });
+    })
+});
+
+const toggleRead = (notificationId, isNewStateRead) => {
+    console.log(notificationId, isNewStateRead);
+    console.log("#notification-" + notificationId + " .toggleReadState i");
+
+
+    const icon = document.querySelector("#notification-" + notificationId + " .toggleReadState i");
+    const row = document.getElementById('notification-' + notificationId);
+
+    if (isNewStateRead) { // new state = read
+        icon.classList.replace('fa-envelope', 'fa-envelope-open');
+        row.classList.remove('unread');
+    } else { // new state = unread
+        icon.classList.replace('fa-envelope-open', 'fa-envelope');
+        row.classList.add('unread');
+    }
+};

--- a/resources/lang/de/notifications.php
+++ b/resources/lang/de/notifications.php
@@ -12,5 +12,18 @@ return [
     ],
     "userFollowed" => [
         "lead" => "<b>@:followerUsername</b> folgt Dir jetzt."
+    ],
+    "socialNotShared" => [
+        "lead" => "Dein Check-in wurde nicht auf :Platform geteilt.",
+        "mastodon" => [
+            "401" => "Deine Instanz hat uns einen <code>401 Unauthorized</code>-Fehler gemeldet, als wir versucht haben, Deinen Check-In zu tooten. Vielleicht hilft es, Mastodon erneut mit Träwelling zu verbinden?",
+            "429" => "Es scheint, dass Träwelling temporär von Deiner Instanz gesperrt wurde. (<code>429 Too Many Requests</code>)",
+            "504" => "Deine Instanz war nicht verfügbar, als wir versucht haben, Deinen Check-In zu tooten. (<code>504 Bad Gateway</code>)",
+        ],
+        "twitter" => [
+            "401" => "Twitter hat uns einen <code>401 Unauthorized</code>-Fehler gemeldet, als wir versucht haben, Deinen Check-In zu twittern. Vielleicht hilft es, Twitter erneut mit Träwelling zu verbinden?",
+            "429" => "Es scheint, dass Träwelling temporär von Twitter gesperrt wurde. (<code>429 Too Many Requests</code>)",
+            "504" => "Twitter war down, als wir versucht haben, Deinen Check-In zu twittern. (<code>504 Bad Gateway</code>)",
+        ]
     ]
 ];

--- a/resources/lang/de/notifications.php
+++ b/resources/lang/de/notifications.php
@@ -28,6 +28,6 @@ return [
     ],
     "userJoinedConnection" => [
         "lead" => "<b>@:username</b> ist auch in Deiner Verbindung!",
-        "notice" => "@:username reist mit <b>:linename</b> von <b>:origin</b> nach <b>:destination</b>.|:username reist mit Linie <b>:linename</b> von <b>:origin</b> nach <b>:destination</b>."
+        "notice" => "@:username reist mit <b>:linename</b> von <b>:origin</b> nach <b>:destination</b>.|@:username reist mit Linie <b>:linename</b> von <b>:origin</b> nach <b>:destination</b>."
     ]
 ];

--- a/resources/lang/de/notifications.php
+++ b/resources/lang/de/notifications.php
@@ -25,5 +25,9 @@ return [
             "429" => "Es scheint, dass Träwelling temporär von Twitter gesperrt wurde. (<code>429 Too Many Requests</code>)",
             "504" => "Twitter war down, als wir versucht haben, Deinen Check-In zu twittern. (<code>504 Bad Gateway</code>)",
         ]
+    ],
+    "userJoinedConnection" => [
+        "lead" => "<b>@:username</b> ist auch in Deiner Verbindung!",
+        "notice" => "@:username reist mit <b>:linename</b> von <b>:origin</b> nach <b>:destination</b>.|:username reist mit Linie <b>:linename</b> von <b>:origin</b> nach <b>:destination</b>."
     ]
 ];

--- a/resources/lang/de/notifications.php
+++ b/resources/lang/de/notifications.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    "empty" => "Du hast bisher noch keine Benachrichtigungen bekommen.",
     "title" => "Benachrichtigungen",
     "mark-all-read" => "Alle als gelesen markieren",
     "mark-as-unread" => "Als ungelesen markieren",
@@ -9,5 +10,7 @@ return [
         "lead" => "<b>@:likerUsername</b> gefällt Dein Check-in.",
         "notice" => "Reise mit :line am :createdDate|Reise mit Linie :line am :createdDate"
     ],
-    "empty" => "Du hast bisher noch keine Benachrichtigungen bekommen."
+    "userFollowed" => [
+        "lead" => "<b>@:followerUsername</b> folgt Dir jetzt."
+    ]
 ];

--- a/resources/lang/de/notifications.php
+++ b/resources/lang/de/notifications.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    "title" => "Benachrichtigungen",
+    "mark-all-read" => "Alle als gelesen markieren",
+    "mark-as-unread" => "Als ungelesen markieren",
+    "mark-as-read" => "Als gelesen markieren",
+    "statusLiked" => [
+        "lead" => "<b>@:likerUsername</b> gefällt Dein Check-in.",
+        "notice" => "Reise mit :line am :createdDate|Reise mit Linie :line am :createdDate"
+    ],
+    "empty" => "Du hast bisher noch keine Benachrichtigungen bekommen."
+];

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    "title" => "Notifications",
+    "mark-all-read" => "Mark all as read",
+    "mark-as-unread" => "Mark as unread",
+    "mark-as-read" => "Mark as read",
+    "statusLiked" => [
+        "lead" => "<b>@:likerUsername</b> liked your check-in.",
+        "notice" => "Journey in :line on :createdDate|Journey in line :line on :createdDate"
+    ],
+    "empty" => "You have not received any notifications yet."
+];

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -25,5 +25,9 @@ return [
             "429" => "It looks like we've been rate-limited by Twitter. (<code>429 Too Many Requests</code>)",
             "504" => "It looks like Twitter was having fun with whales when we tried to tweet your check-in. (<code>504 Bad Gateway</code>)",
         ]
+    ],
+    "userJoinedConnection" => [
+        "lead" => "<b>@:username</b> is in your connection!",
+        "notice" => "They are on <b>:linename</b> from <b>:origin</b> to <b>:destination</b>.|They are on line <b>:linename</b> from <b>:origin</b> to <b>:destination</b>."
     ]
 ];

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    "empty" => "You have not received any notifications yet.",
     "title" => "Notifications",
     "mark-all-read" => "Mark all as read",
     "mark-as-unread" => "Mark as unread",
@@ -9,5 +10,7 @@ return [
         "lead" => "<b>@:likerUsername</b> liked your check-in.",
         "notice" => "Journey in :line on :createdDate|Journey in line :line on :createdDate"
     ],
-    "empty" => "You have not received any notifications yet."
+    "userFollowed" => [
+        "lead" => "<b>@:followerUsername</b> is following you."
+    ]
 ];

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -12,5 +12,18 @@ return [
     ],
     "userFollowed" => [
         "lead" => "<b>@:followerUsername</b> is following you."
+    ],
+    "socialNotShared" => [
+        "lead" => "Your Check-in has not been shared to :Platform.",
+        "mastodon" => [
+            "401" => "Your instance has sent us an <code>401 Unauthorized</code> error when we tried to toot - please consider reconnecting Träwelling to Mastodon.",
+            "429" => "It looks like we've been rate-limited by your instance. (<code>429 Too Many Requests</code>)",
+            "504" => "It looks like your Mastodon instance was not available when we tried to toot. (<code>504 Bad Gateway</code>)",
+        ],
+        "twitter" => [
+            "401" => "Twitter has sent us an <code>401 Unauthorized</code> error when we tried to toot - please consider reconnecting Träwelling to Mastodon.",
+            "429" => "It looks like we've been rate-limited by Twitter. (<code>429 Too Many Requests</code>)",
+            "504" => "It looks like Twitter was having fun with whales when we tried to tweet your check-in. (<code>504 Bad Gateway</code>)",
+        ]
     ]
 ];

--- a/resources/sass/_variables.scss
+++ b/resources/sass/_variables.scss
@@ -19,3 +19,4 @@ $teal: #4dc0b5;
 $cyan: #6cb2eb;
 $grey: rgba(0, 0, 0, 0.125);
 $bahnrot: rgb(192, 57, 43);
+$text-color: #212529;

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -40,3 +40,4 @@ body {
 @import "./components/image-box";
 @import "./components/settings";
 @import "./components/eventspage";
+@import "./components/notifications-board";

--- a/resources/sass/components/notifications-board.scss
+++ b/resources/sass/components/notifications-board.scss
@@ -17,11 +17,9 @@
         }
     }
 
-    .modal-body {
+    .modal-body#notifications-list {
         padding: 0;
-    }
 
-    #notifications-list {
         .row {
             background-color: white;
             padding: 1rem 0;
@@ -32,7 +30,7 @@
                 &.warning {
                     background-color: lighten($bahnrot, 40%);
                 }
-                &.info {
+                &.neutral {
                     background-color: lighten($blue, 40%);
                 }
             }
@@ -59,10 +57,14 @@
                 -moz-appearance: none;
                 font-size: 1.25rem;
             }
+            strong {
+                font-weight: bold;
+            }
         }
-        strong {
-            font-weight: bold;
-        }
+    }
+
+    #notifications-empty {
+        padding: 2rem 0;
     }
 }
 

--- a/resources/sass/components/notifications-board.scss
+++ b/resources/sass/components/notifications-board.scss
@@ -26,6 +26,10 @@
             border-bottom: 0.5rem solid $body-bg;
             margin: 0;
 
+            a {
+                color: $text-color;
+            }
+
             &.unread {
                 &.warning {
                     background-color: lighten($bahnrot, 40%);

--- a/resources/sass/components/notifications-board.scss
+++ b/resources/sass/components/notifications-board.scss
@@ -84,4 +84,11 @@
             }
         }
     }
+    .nav-item span.notifications-bell {
+        &.fa,
+        &.far {
+            padding-left: 3px;
+            padding-right: 3px;
+        }
+    }
 }

--- a/resources/sass/components/notifications-board.scss
+++ b/resources/sass/components/notifications-board.scss
@@ -61,7 +61,8 @@
                 -moz-appearance: none;
                 font-size: 1.25rem;
             }
-            strong {
+            strong,
+            b {
                 font-weight: bold;
             }
         }

--- a/resources/sass/components/notifications-board.scss
+++ b/resources/sass/components/notifications-board.scss
@@ -1,0 +1,85 @@
+#notifications-board {
+    .modal-header {
+        justify-content: initial;
+
+        .close {
+            font-size: 2rem;
+            float: none;
+
+            &#mark-read {
+                flex-grow: 1;
+                text-align: left;
+
+                i.fas {
+                    font-size: 0.6em;
+                }
+            }
+        }
+    }
+
+    .modal-body {
+        padding: 0;
+    }
+
+    #notifications-list {
+        .row {
+            background-color: white;
+            padding: 1rem 0;
+            border-bottom: 0.5rem solid $body-bg;
+            margin: 0;
+
+            &.unread {
+                &.warning {
+                    background-color: lighten($bahnrot, 40%);
+                }
+                &.info {
+                    background-color: lighten($blue, 40%);
+                }
+            }
+
+            p.lead {
+                margin-bottom: 0.5rem;
+
+                i {
+                    padding-right: 0.5rem;
+                }
+            }
+
+            .col-1 i,
+            .interact {
+                font-weight: 700;
+                line-height: 1;
+                color: $dark;
+                text-shadow: 0 1px 0 #fff;
+
+                padding: 0;
+                background-color: transparent;
+                border: 0;
+                -webkit-appearance: none;
+                -moz-appearance: none;
+                font-size: 1.25rem;
+            }
+        }
+        strong {
+            font-weight: bold;
+        }
+    }
+}
+
+.navbar {
+    div.navbar-toggler {
+        display: table-cell;
+        padding-right: 0;
+
+        button.navbar-toggler {
+            // The toggle buttons inside the div
+            vertical-align: middle;
+            padding-top: 0;
+            padding-bottom: 0;
+
+            &:last-child {
+                padding-right: 0;
+            }
+        }
+    }
+}

--- a/resources/sass/components/notifications-board.scss
+++ b/resources/sass/components/notifications-board.scss
@@ -6,7 +6,7 @@
             font-size: 2rem;
             float: none;
 
-            &#mark-read {
+            &#mark-all-read {
                 flex-grow: 1;
                 text-align: left;
 

--- a/resources/views/includes/notification.blade.php
+++ b/resources/views/includes/notification.blade.php
@@ -1,4 +1,4 @@
-<div class="row {{ $color }} {{ $read ? '' : 'unread' }}">
+<div class="row {{ $color }} {{ $read ? '' : 'unread' }}" id="notification-{{ $notificationId }}">
     <a class="col-1 align-left lead" href="{{ $link }}">
         <i class="{{ $icon }}"></i>
     </a>
@@ -9,8 +9,8 @@
         {!! $notice !!}&nbsp;
     </a>
     <div class="col-3 text-right">
-        <button type="button" class="interact" aria-label="{{ $read ? __('notifications.mark-as-unread') : __('notifications.mark-as-read') }}">
-            <span aria-hidden="true"><i class="far {{ $read ? 'fas fa-envelope-open' : 'far fa-envelope' }}"></i></span>
+        <button type="button" class="interact toggleReadState" data-id="{{ $notificationId }}" aria-label="{{ $read ? __('notifications.mark-as-unread') : __('notifications.mark-as-read') }}">
+            <span aria-hidden="true"><i class="far {{ $read ? 'fa-envelope-open' : 'fa-envelope' }}"></i></span>
         </button>
         <div class="text-muted">{{ $date_for_humans }}</div>
     </div>

--- a/resources/views/includes/notification.blade.php
+++ b/resources/views/includes/notification.blade.php
@@ -1,0 +1,17 @@
+<div class="row {{ $color }} {{ $read ? '' : 'unread' }}">
+    <div class="col-1 align-left">
+        <i class="{{ $icon }}"></i>
+    </div>
+    <div class="col-8 align-middle">
+        <p class="lead">
+            {!! $lead !!}
+        </p>
+        {!! $notice !!}
+    </div>
+    <div class="col-3 text-right">
+        <button type="button" class="interact" aria-label="{{ $read ? __('notifications.mark-as-unread') : __('notifications.mark-as-read') }}">
+            <span aria-hidden="true"><i class="far {{ $read ? 'fas fa-envelope-open' : 'far fa-envelope' }}"></i></span>
+        </button>
+        <div class="text-muted">{{ $date_for_humans }}</div>
+    </div>
+</div>

--- a/resources/views/includes/notification.blade.php
+++ b/resources/views/includes/notification.blade.php
@@ -6,7 +6,7 @@
         <p class="lead">
             {!! $lead !!}
         </p>
-        {!! $notice !!}
+        {!! $notice !!}&nbsp;
     </a>
     <div class="col-3 text-right">
         <button type="button" class="interact" aria-label="{{ $read ? __('notifications.mark-as-unread') : __('notifications.mark-as-read') }}">

--- a/resources/views/includes/notification.blade.php
+++ b/resources/views/includes/notification.blade.php
@@ -1,13 +1,13 @@
 <div class="row {{ $color }} {{ $read ? '' : 'unread' }}">
-    <div class="col-1 align-left">
+    <a class="col-1 align-left lead" href="{{ $link }}">
         <i class="{{ $icon }}"></i>
-    </div>
-    <div class="col-8 align-middle">
+    </a>
+    <a class="col-8 align-middle" href="{{ $link }}">
         <p class="lead">
             {!! $lead !!}
         </p>
         {!! $notice !!}
-    </div>
+    </a>
     <div class="col-3 text-right">
         <button type="button" class="interact" aria-label="{{ $read ? __('notifications.mark-as-unread') : __('notifications.mark-as-read') }}">
             <span aria-hidden="true"><i class="far {{ $read ? 'fas fa-envelope-open' : 'far fa-envelope' }}"></i></span>

--- a/resources/views/includes/notification.blade.php
+++ b/resources/views/includes/notification.blade.php
@@ -1,14 +1,14 @@
 <div class="row {{ $color }} {{ $read ? '' : 'unread' }}" id="notification-{{ $notificationId }}">
-    <a class="col-1 align-left lead" href="{{ $link }}">
+    <a class="col-1 col-sm-1 align-left lead" href="{{ $link }}">
         <i class="{{ $icon }}"></i>
     </a>
-    <a class="col-8 align-middle" href="{{ $link }}">
+    <a class="col-7 col-sm-8 align-middle" href="{{ $link }}">
         <p class="lead">
             {!! $lead !!}
         </p>
         {!! $notice !!}&nbsp;
     </a>
-    <div class="col-3 text-right">
+    <div class="col col-sm-3 text-right">
         <button type="button" class="interact toggleReadState" data-id="{{ $notificationId }}" aria-label="{{ $read ? __('notifications.mark-as-unread') : __('notifications.mark-as-read') }}">
             <span aria-hidden="true"><i class="far {{ $read ? 'fa-envelope-open' : 'fa-envelope' }}"></i></span>
         </button>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -49,7 +49,9 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h4 class="modal-title">{{ __('notifications.title') }}</h4>
-                    <button type="button" class="close" id="mark-read" aria-label="{{ __('notifications.mark-all-read') }}"><span aria-hidden="true"><i class="fas fa-check-double"></i></button>
+                    <div>
+                        <button type="button" class="close" id="mark-all-read" aria-label="{{ __('notifications.mark-all-read') }}"><span aria-hidden="true"><i class="fas fa-check-double"></i></button>
+                    </div>
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                 </div>
                 <div class="modal-body" id="notifications-list">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -48,81 +48,12 @@
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h4 class="modal-title">Notifications</h4>
-                    <button type="button" class="close" id="mark-read" aria-label="Mark all read"><span aria-hidden="true"><i class="fas fa-check-double"></i></button>
+                    <h4 class="modal-title">{{ __('notifications.title') }}</h4>
+                    <button type="button" class="close" id="mark-read" aria-label="{{ __('notifications.mark-all-read') }}"><span aria-hidden="true"><i class="fas fa-check-double"></i></button>
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                 </div>
-                <div class="modal-body">
-                    <div id="notifications-list">
-                        <div class="row unread warning">
-                            <div class="col-1 align-left">
-                                <i class="fas fa-exclamation-triangle"></i>
-                            </div>
-                            <div class="col-8 align-middle">
-                                <p class="lead">
-                                    Your check-in has not been shared to Mastodon.
-                                </p>
-                                It looks like your Mastodon instance was not available when we tried to toot.
-                            </div>
-                            <div class="col-3 text-right">
-                                <button type="button" class="interact" aria-label="Mark as read">
-                                    <span aria-hidden="true"><i class="far fa-envelope"></i></span>
-                                </button>
-                                <div class="text-muted"> 1m ago</div>
-                            </div>
-                        </div>
-                        <div class="row unread info">
-                            <div class="col-1 align-left">
-                                <i class="fas fa-train"></i>
-                            </div>
-                            <div class="col-8 align-middle">
-                                <p class="lead">
-                                    @HerrLevin_ is in your connection.
-                                </p>
-                                They are on <strong>ICE 619</strong> from <strong>Frankfurt(Flughafen) Fernbf.</strong> to <strong>Karlsruhe Hbf</strong>.
-                            </div>
-                            <div class="col-3 text-right">
-                                <button type="button" class="interact" aria-label="Mark as read">
-                                    <span aria-hidden="true"><i class="far fa-envelope"></i></span>
-                                </button>
-                                <div class="text-muted">14h ago</div>
-                            </div>
-                        </div>
-                        <div class="row info">
-                            <div class="col-1 align-left">
-                                <i class="fas fa-train"></i>
-                            </div>
-                            <div class="col-8 align-middle">
-                                <p class="lead">
-                                    @aledjones is in your connection.
-                                </p>
-                                They are on <strong>NWB RE 10</strong> from <strong>Weeze</strong> to <strong>Krefeld-Oppum</strong>.
-                            </div>
-                            <div class="col-3 text-right">
-                                <button type="button" class="interact" aria-label="Mark as read">
-                                    <span aria-hidden="true"><i class="far fa-envelope-open"></i></span>
-                                </button>
-                                <div class="text-muted">2d ago</div>
-                            </div>
-                        </div>
-                        <div class="row info">
-                            <div class="col-1 align-left">
-                                <i class="fas fa-exclamation-triangle"></i>
-                            </div>
-                            <div class="col-8 align-middle">
-                                <p class="lead">
-                                    Your check-in has not been shared to Twitter.
-                                </p>
-                                Twitter has sent an <code>401 Unauthorized</code> when we tried to tweet - please consider reconnecting Träwelling to Twitter.
-                            </div>
-                            <div class="col-3 text-right">
-                                <button type="button" class="interact" aria-label="Mark as read">
-                                    <span aria-hidden="true"><i class="far fa-envelope-open"></i></span>
-                                </button>
-                                <div class="text-muted">5d ago</div>
-                            </div>
-                        </div>
-                    </div>
+                <div class="modal-body" id="notifications-list">
+                    <div id="notifications-empty" class="text-center text-muted">{{ __('notifications.empty') }}<br />¯\_(ツ)_/¯</div>
                 </div>
             </div>
         </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -44,16 +44,104 @@
 @yield('metadata')
 </head>
 <body>
+    <div class="modal fade bd-example-modal-lg" id="notifications-board" tabindex="-1" role="dialog" aria-labelledby="notifications-modal" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4 class="modal-title">Notifications</h4>
+                    <button type="button" class="close" id="mark-read" aria-label="Mark all read"><span aria-hidden="true"><i class="fas fa-check-double"></i></button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                </div>
+                <div class="modal-body">
+                    <div id="notifications-list">
+                        <div class="row unread warning">
+                            <div class="col-1 align-left">
+                                <i class="fas fa-exclamation-triangle"></i>
+                            </div>
+                            <div class="col-8 align-middle">
+                                <p class="lead">
+                                    Your check-in has not been shared to Mastodon.
+                                </p>
+                                It looks like your Mastodon instance was not available when we tried to toot.
+                            </div>
+                            <div class="col-3 text-right">
+                                <button type="button" class="interact" aria-label="Mark as read">
+                                    <span aria-hidden="true"><i class="far fa-envelope"></i></span>
+                                </button>
+                                <div class="text-muted"> 1m ago</div>
+                            </div>
+                        </div>
+                        <div class="row unread info">
+                            <div class="col-1 align-left">
+                                <i class="fas fa-train"></i>
+                            </div>
+                            <div class="col-8 align-middle">
+                                <p class="lead">
+                                    @HerrLevin_ is in your connection.
+                                </p>
+                                They are on <strong>ICE 619</strong> from <strong>Frankfurt(Flughafen) Fernbf.</strong> to <strong>Karlsruhe Hbf</strong>.
+                            </div>
+                            <div class="col-3 text-right">
+                                <button type="button" class="interact" aria-label="Mark as read">
+                                    <span aria-hidden="true"><i class="far fa-envelope"></i></span>
+                                </button>
+                                <div class="text-muted">14h ago</div>
+                            </div>
+                        </div>
+                        <div class="row info">
+                            <div class="col-1 align-left">
+                                <i class="fas fa-train"></i>
+                            </div>
+                            <div class="col-8 align-middle">
+                                <p class="lead">
+                                    @aledjones is in your connection.
+                                </p>
+                                They are on <strong>NWB RE 10</strong> from <strong>Weeze</strong> to <strong>Krefeld-Oppum</strong>.
+                            </div>
+                            <div class="col-3 text-right">
+                                <button type="button" class="interact" aria-label="Mark as read">
+                                    <span aria-hidden="true"><i class="far fa-envelope-open"></i></span>
+                                </button>
+                                <div class="text-muted">2d ago</div>
+                            </div>
+                        </div>
+                        <div class="row info">
+                            <div class="col-1 align-left">
+                                <i class="fas fa-exclamation-triangle"></i>
+                            </div>
+                            <div class="col-8 align-middle">
+                                <p class="lead">
+                                    Your check-in has not been shared to Twitter.
+                                </p>
+                                Twitter has sent an <code>401 Unauthorized</code> when we tried to tweet - please consider reconnecting Träwelling to Twitter.
+                            </div>
+                            <div class="col-3 text-right">
+                                <button type="button" class="interact" aria-label="Mark as read">
+                                    <span aria-hidden="true"><i class="far fa-envelope-open"></i></span>
+                                </button>
+                                <div class="text-muted">5d ago</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
     <div id="app">
         <nav class="navbar navbar-expand-md navbar-dark bg-trwl">
             <div class="container">
                 <a class="navbar-brand" href="{{ url('/') }}">
                     {{ config('app.name', 'Laravel') }}
                 </a>
-                <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
+                <div class="navbar-toggler">
+                    <button class="navbar-toggler" type="button" data-toggle="modal" data-target="#notifications-board" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Show notifications') }}">
+                        <span class="fa fa-bell"></span>
+                    </button>
 
+                    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                </div>
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <!-- Left Side Of Navbar -->
                     <ul class="navbar-nav mr-auto">
@@ -83,6 +171,11 @@
                                 </li>
                             @endif
                         @else
+                            <li class="nav-item d-none d-md-inline-block">
+                                <a href="#" class="nav-link" data-toggle="modal" data-target="#notifications-board">
+                                    <span class="fa fa-bell"></span>
+                                </a>
+                            </li>
                             <li class="nav-item dropdown">
                                 <a id="navbarDropdown" class="nav-link dropdown-toggle mdb-select" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
                                     {{ Auth::user()->name }} <span class="caret"></span>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -66,7 +66,7 @@
                 </a>
                 <div class="navbar-toggler">
                     <button class="navbar-toggler" type="button" data-toggle="modal" data-target="#notifications-board" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Show notifications') }}">
-                        <span class="fa fa-bell"></span>
+                        <span class="notifications-bell far fa-bell"></span>
                     </button>
 
                     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
@@ -104,7 +104,7 @@
                         @else
                             <li class="nav-item d-none d-md-inline-block">
                                 <a href="#" class="nav-link" data-toggle="modal" data-target="#notifications-board">
-                                    <span class="fa fa-bell"></span>
+                                    <span class="notifications-bell far fa-bell"></span>
                                 </a>
                             </li>
                             <li class="nav-item dropdown">
@@ -117,11 +117,11 @@
                                     <a class="dropdown-item" href="{{ route('export.landing') }}"><i class="fas fa-save"></i> {{ __('menu.export') }}</a>
                                     <a class="dropdown-item" href="{{ route('settings') }}"><i class="fas fa-cog"></i> {{ __('menu.settings') }}</a>
                                     <div class="dropdown-divider"></div>
-                                    <button class="dropdown-item" href="{{ route('logout') }}"
+                                    <a class="dropdown-item" href="{{ route('logout') }}"
                                        onclick="event.preventDefault();
                                                      document.getElementById('logout-form').submit();">
                                         <i class="fas fa-sign-out-alt"></i> {{ __('menu.logout') }}
-                                    </button>
+                                    </a>
 
                                     <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
                                         @csrf

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -119,11 +119,11 @@
                                     <a class="dropdown-item" href="{{ route('export.landing') }}"><i class="fas fa-save"></i> {{ __('menu.export') }}</a>
                                     <a class="dropdown-item" href="{{ route('settings') }}"><i class="fas fa-cog"></i> {{ __('menu.settings') }}</a>
                                     <div class="dropdown-divider"></div>
-                                    <a class="dropdown-item" href="{{ route('logout') }}"
+                                    <button class="dropdown-item" href="{{ route('logout') }}"
                                        onclick="event.preventDefault();
                                                      document.getElementById('logout-form').submit();">
                                         <i class="fas fa-sign-out-alt"></i> {{ __('menu.logout') }}
-                                    </a>
+                                    </button>
 
                                     <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
                                         @csrf

--- a/routes/web.php
+++ b/routes/web.php
@@ -67,7 +67,10 @@ Auth::routes(['verify' => true]);
 
 Route::get('/auth/redirect/{provider}', 'SocialController@redirect');
 Route::get('/callback/{provider}', 'SocialController@callback');
-Route::get('/status/{id}', 'FrontendStatusController@getStatus');
+Route::get('/status/{id}', [
+    'uses' => 'FrontendStatusController@getStatus',
+    'as' => 'statuses.get'
+]);
 
 Route::get('/blog', [
     'uses'  => 'BlogController@all',

--- a/routes/web.php
+++ b/routes/web.php
@@ -276,7 +276,8 @@ Route::middleware(['auth', 'privacy'])->group(function() {
     ]);
 
     Route::get('/notifications/latest', [
-        'uses'  => 'NotificationController@latest'
+        'uses'  => 'NotificationController@latest',
+        'as'    => 'notifications.latest'
     ]);
 });
 //Route::get('/trip', 'HafasTripController@getTrip')->defaults('tripID', '1|178890|0|80|13082019')->defaults('lineName', 'ICE 376');

--- a/routes/web.php
+++ b/routes/web.php
@@ -271,5 +271,9 @@ Route::middleware(['auth', 'privacy'])->group(function() {
     Route::get('/mastodon/test', [
         'uses'  => 'SocialController@testMastodon',
     ]);
+
+    Route::get('/notifications/latest', [
+        'uses'  => 'NotificationController@latest'
+    ]);
 });
 //Route::get('/trip', 'HafasTripController@getTrip')->defaults('tripID', '1|178890|0|80|13082019')->defaults('lineName', 'ICE 376');

--- a/routes/web.php
+++ b/routes/web.php
@@ -279,5 +279,10 @@ Route::middleware(['auth', 'privacy'])->group(function() {
         'uses'  => 'NotificationController@latest',
         'as'    => 'notifications.latest'
     ]);
+
+    Route::post('/notifications/toggleReadState/{id}', [
+        'uses'  => 'NotificationController@toggleReadState',
+        'as'    => 'notifications.toggleReadState'
+    ]);
 });
 //Route::get('/trip', 'HafasTripController@getTrip')->defaults('tripID', '1|178890|0|80|13082019')->defaults('lineName', 'ICE 376');

--- a/routes/web.php
+++ b/routes/web.php
@@ -284,5 +284,9 @@ Route::middleware(['auth', 'privacy'])->group(function() {
         'uses'  => 'NotificationController@toggleReadState',
         'as'    => 'notifications.toggleReadState'
     ]);
+    Route::post('/notifications/readAll', [
+        'uses'  => 'NotificationController@readAll',
+        'as'    => 'notifications.readAll'
+    ]);
 });
 //Route::get('/trip', 'HafasTripController@getTrip')->defaults('tripID', '1|178890|0|80|13082019')->defaults('lineName', 'ICE 376');

--- a/tests/Feature/NotificationsTest.php
+++ b/tests/Feature/NotificationsTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\TransportController;
+use App\Http\Controllers\StatusController as StatusBackend;
+use App\Like;
+use App\Status;
+use App\User;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class NotificationsTest extends TestCase {
+    use RefreshDatabase;
+
+    protected $user;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
+        $response = $this->actingAs($this->user)
+                        ->post('/gdpr-ack');
+    }
+
+    /**
+     * This is mostly copied from Checkin Test and exactly copied from ExportTripsTest.
+     */
+    protected function checkin($stationname, $ibnr, \DateTime $now) {
+        $trainStationboard = TransportController::TrainStationboard($stationname, $now->format('U'), 'express');
+
+        $countDepartures = count($trainStationboard['departures']);
+        if($countDepartures == 0) {
+            $this->markTestSkipped("Unable to find matching trains. Is it night in $stationname?");
+            return;
+        }
+        
+        // Second: We don't like broken or cancelled trains.
+        $i = 0;
+        while (
+              (isset($trainStationboard['departures'][$i]->cancelled)
+                && $trainStationboard['departures'][$i]->cancelled
+              )
+              || count($trainStationboard['departures'][$i]->remarks) != 0
+            ) {
+            $i++;
+            if ($i == $countDepartures) {
+                $this->markSkippedForMissingDependecy("Unable to find unbroken train. Is it stormy in $stationname?");
+                return;
+            }
+        }
+        $departure = $trainStationboard['departures'][$i];
+        CheckinTest::isCorrectHafasTrip($departure, $now);
+        
+        // Third: Get the trip information
+        $trip = TransportController::TrainTrip(
+            $departure->tripId,
+            $departure->line->name,
+            $departure->stop->location->id
+        );
+        
+        // WHEN: User tries to check-in
+        $response = $this->actingAs($this->user)
+            ->post(route('trains.checkin'), [
+                'body' => 'Example Body',
+                'tripID' => $departure->tripId,
+                'start' => $ibnr,
+                'destination' => $trip['stopovers'][0]['stop']['location']['id'],
+            ]);
+    }
+    
+    /** @test */
+    public function likes_appear_in_notifications() {
+        // Given: There is a likable status
+        $now = new \DateTime("+2 day 8:00");
+        $this->checkin("Essen Hbf", "8000098", $now);
+        
+        $status = $this->user->statuses->first();
+
+        // When: Someone (e.g. the user itself) likes the status
+        $like = $this->actingAs($this->user)
+                     ->post(route('like.create'), ['statusId' => $status->id]);
+        $like->assertStatus(201); // Created
+        
+        // Then: The like appears in the notifications
+        $notifications = $this->actingAs($this->user)
+                              ->get(route('notifications.latest'));
+        $notifications->assertOk();
+        $notifications->assertJsonCount(1); // one like
+        $notifications->assertJsonFragment([
+            'type' => "App\\Notifications\\StatusLiked",
+            'notifiable_type' => "App\\User",
+            'notifiable_id' => (string) $this->user->id
+        ]);
+    }
+
+    /** @test */
+    public function removed_likes_dont_appear_in_notifications() {
+        // Given: There is a likable status
+        $now = new \DateTime("+2 day 8:00");
+        $this->checkin("Essen Hbf", "8000098", $now);
+        
+        $status = $this->user->statuses->first();
+        $like = $this->actingAs($this->user)
+                     ->post(route('like.create'), ['statusId' => $status->id]);
+        $like->assertStatus(201); // Created
+        
+        // When: The like is removed
+        Like::first()->delete();
+
+        // Then: It does not show up in the notifications anymore
+        $notifications = $this->actingAs($this->user)
+                              ->get(route('notifications.latest'));
+        $notifications->assertOk();
+        $notifications->assertJsonCount(0); // no likes left
+    }
+    
+}


### PR DESCRIPTION
This PR introduces a notification system for users of the Träwelling website.

Currently supported (and tested) notifications:

_(B receives a notification.)_
* A liked B's check-in.
* A followed B.
* B has checked into a train. A checks into the same train with overlapping stations.
* B has checked into a connection and checked the Tweet or Toot boxes. Something went wrong while posting (e.g. Instance down or `401 Unauthenticed`). - not feature-tested!

Closes #3.

![grafik](https://user-images.githubusercontent.com/2796271/75092517-9c017880-5578-11ea-9ed3-dede9b6e679f.png)


To Do:
- [x] Notification Center on small phones (< iPhone 6 Plus) is kind of broken.

Stuff for later:
- [ ] Pull/push every n seconds or minutes for new notifications. Currently only watching at pageload.
- [ ] Some kind of idle-animation when marking one or all notifications as read would be great.