### PR TITLE
Fix bug in "Fast check-in" that produces 500 errors when the last station is cancelled.

### DIFF
--- a/app/Http/Controllers/FrontendTransportController.php
+++ b/app/Http/Controllers/FrontendTransportController.php
@@ -52,13 +52,21 @@ class FrontendTransportController extends Controller
             return redirect()->back()->with('error', __('controller.transport.not-in-stopovers'));
         }
 
+        // Find out where this train terminates and offer this as a "fast check-in" option.
+        $terminalStopIndex = count($TrainTripResponse['stopovers']) - 1;
+        while($terminalStopIndex >= 1 && @$TrainTripResponse['stopovers'][$terminalStopIndex]['cancelled'] == true) {
+            $terminalStopIndex--;
+        }
+        $terminalStop = $TrainTripResponse['stopovers'][$terminalStopIndex];
+
         return view('trip', [
-            'train' => $TrainTripResponse['train'],
-            'stopovers' => $TrainTripResponse['stopovers'],
             'destination' => $TrainTripResponse['destination'],
+            'events' => EventBackend::activeEvents(),
             'start' => $TrainTripResponse['start'],
+            'stopovers' => $TrainTripResponse['stopovers'],
+            'terminalStop' => $terminalStop,
+            'train' => $TrainTripResponse['train'],
             'user' => Auth::user(),
-            'events' => EventBackend::activeEvents()
         ]);
     }
 

--- a/resources/views/trip.blade.php
+++ b/resources/views/trip.blade.php
@@ -10,7 +10,7 @@
             <div class="card">
                 <div class="card-header" data-linename="{{ $train['linename'] }}" data-startname="{{ $start }}" data-start="{{ request()->start }}" data-tripid="{{ request()->tripID }}">
                     <div class="float-right">
-                        <a href="#" class="train-destinationrow" data-ibnr="{{end($stopovers)['stop']['id']}}" data-stopname="{{end($stopovers)['stop']['name']}}"><i class="fa fa-fast-forward"></i></a>
+                        <a href="#" class="train-destinationrow" data-ibnr="{{$terminalStop['stop']['id']}}" data-stopname="{{$terminalStop['stop']['name']}}"><i class="fa fa-fast-forward"></i></a>
                     </div>
                     @if (file_exists(public_path('img/'.$train['category'].'.svg')))
                         <img class="product-icon" src="{{ asset('img/'.$train['category'].'.svg') }}">


### PR DESCRIPTION
Closes #22.

**Working Example:**

This train terminates early, in `Berlin Nikolassee`.
![](https://user-images.githubusercontent.com/2796271/75921279-28f1df00-5e61-11ea-8939-e17d89366ff4.png)

"Fast forward" only checks-in until Nikolassee.
![](https://user-images.githubusercontent.com/2796271/75921184-fcd65e00-5e60-11ea-92c0-b69d8d16e506.png)

Check-in did work.
![grafik](https://user-images.githubusercontent.com/2796271/75921433-63f41280-5e61-11ea-909a-d1a07f5715d9.png)