### PR TITLE
Fixed a bug wherein a login would redirect to /notifications/latest.

### DIFF
--- a/.github/workflows/nodejs-dev.yml
+++ b/.github/workflows/nodejs-dev.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v1
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: npm install
     - name: Run dev build
-      run: npm run dev 
+      run: npm run dev
 
       env:
         CI: true

--- a/.github/workflows/nodejs-prod.yml
+++ b/.github/workflows/nodejs-prod.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v1
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: npm install
     - name: Run production build
-      run: npm run production  
+      run: npm run production
 
       env:
         CI: true

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,10 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PhpCSValidationInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="CODING_STANDARD" value="Custom" />
+      <option name="CUSTOM_RULESET_PATH" value="$PROJECT_DIR$/phpcs.xml" />
+      <option name="EXTENSIONS" value="php,js,css,inc" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/resources/js/components/notifications-board.js
+++ b/resources/js/components/notifications-board.js
@@ -1,11 +1,19 @@
-fetch('/notifications/latest', {
-    credentials: 'same-origin'
-})
+document.getElementById('notifications-toggle').addEventListener('click', () => {
+    let list = document.getElementById('notifications-list')
+    let empty = document.getElementById('notifications-empty')
+    empty.classList.remove('d-none')
+
+    while (list.childNodes.length > 3) {
+        list.removeChild(list.firstChild)
+    }
+    fetch('/notifications/latest', {
+        credentials: 'same-origin'
+    })
     .then(res => res.json())
     .then(notifications => {
         // If there are no notifications, we can just quit here. Else, show the items.
         if (notifications.length == 0) return;
-        document.getElementById('notifications-empty').classList.add('d-none');
+        empty.classList.add('d-none');
 
         // if there are unread notifications, make the bell ring.
         if (notifications.some(n => n.read_at == null)) {
@@ -17,7 +25,7 @@ fetch('/notifications/latest', {
             return sum + add.html;
         }, "");
 
-        document.getElementById('notifications-list').insertAdjacentHTML('afterbegin', html);
+        list.insertAdjacentHTML('afterbegin', html);
     })
     .then(() => { // After the notification rows have been created, we can add eventlisteners for them
         Array.from(document.getElementsByClassName('toggleReadState')).forEach(btn =>
@@ -37,6 +45,8 @@ fetch('/notifications/latest', {
             })
         );
     });
+});
+
 
 document.getElementById('mark-all-read').addEventListener('click', () => {
     fetch('/notifications/readAll', {

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -105,7 +105,7 @@
                             @endif
                         @else
                             <li class="nav-item d-none d-md-inline-block">
-                                <a href="#" class="nav-link" data-toggle="modal" data-target="#notifications-board">
+                                <a href="#" id="notifications-toggle" class="nav-link" data-toggle="modal" data-target="#notifications-board">
                                     <span class="notifications-bell far fa-bell"></span>
                                 </a>
                             </li>


### PR DESCRIPTION
fetch() seems to pick up the 302 redirect to /dashboard and translates it to a 302-"request" to /notifications/latest while logging in.

"fixed" by only loading notifications on button-click.

Closes #28