### PR TITLE
fixed database structure on train_stations

### DIFF
--- a/database/migrations/2020_08_05_151702_change_train_station_table.php
+++ b/database/migrations/2020_08_05_151702_change_train_station_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ChangeTrainStationTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('train_stations', function (Blueprint $table) {
+            $table->decimal('latitude', 9, 6)->change();
+            $table->decimal('longitude', 9, 6)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('train_stations', function (Blueprint $table) {
+            $table->decimal('latitude', 8, 6)->change();
+            $table->decimal('longitude', 8, 6)->change();
+        });
+    }
+}


### PR DESCRIPTION
The current structure of ``train_stations`` allows only coordinates up to 2 digits. Numbers over 99 cause an error. So I have created an migration which change the database structure to accept 3 digits.