### PR TITLE
[API(v1?)] Add application name to API login

### DIFF
--- a/api-swagger-v0.yml
+++ b/api-swagger-v0.yml
@@ -37,6 +37,10 @@ paths:
                 - password
                 - email
               properties:
+                applicationName:
+                  type: string
+                  example: Very nice app
+                  description: The name of your application
                 email:
                   type: string
                   example: gertrud@traewelling.de

--- a/app/Http/Controllers/API/AuthController.php
+++ b/app/Http/Controllers/API/AuthController.php
@@ -45,7 +45,8 @@ class AuthController extends ResponseController
     {
         $validator = Validator::make($request->all(), [
             'email' => 'required|string|email',
-            'password' => 'required'
+            'password' => 'required',
+            'applicationName' => 'required|max:255'
         ]);
 
         if($validator->fails()){
@@ -58,7 +59,8 @@ class AuthController extends ResponseController
             return $this->sendError($error, 401);
         }
         $user             = $request->user();
-        $success['token'] = $user->createToken('token')->accessToken;
+        $token =  $user->createToken(request('applicationName'));
+        $success['token'] = $token->accessToken;
         return $this->sendResponse($success);
     }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -137,7 +137,7 @@ class UserController extends Controller
     public function getAccount() {
         $user     = Auth::user();
         $sessions = array();
-        $tokens   = array();
+        $tokens   = auth()->user()->tokens->where('revoked', 0)->where('expires_at', '>' , Carbon::now());
         foreach($user->sessions as $session) {
             $sessionArray = array();
             $result       = new Agent();
@@ -155,19 +155,6 @@ class UserController extends Controller
             $sessionArray['ip']   = $session->ip_address;
             $sessionArray['last'] = $session->last_activity;
             array_push($sessions, $sessionArray);
-        }
-
-        foreach($user->tokens as $token) {
-            if ($token->revoked != 1) {
-                $tokenInfo               = array();
-                $tokenInfo['id']         = $token->id;
-                $tokenInfo['clientName'] = $token->client->name;
-                $tokenInfo['created_at'] = (String) $token->created_at;
-                $tokenInfo['updated_at'] = (String) $token->updated_at;
-                $tokenInfo['expires_at'] = (String) $token->expires_at;
-
-                array_push($tokens, $tokenInfo);
-            }
         }
 
         return view('settings', compact('user', 'sessions', 'tokens'));

--- a/database/migrations/2020_09_27_210850_change_old_token_name.php
+++ b/database/migrations/2020_09_27_210850_change_old_token_name.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeOldTokenName extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        DB::table('oauth_access_tokens')
+            ->where('name', 'token')
+            ->update([
+                'name' => 'Träwelling Personal Access Client'
+            ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {
+        //cannot undo...
+    }
+}

--- a/resources/views/settings.blade.php
+++ b/resources/views/settings.blade.php
@@ -384,10 +384,10 @@
                                 </thead>
                                 @foreach($tokens as $token)
                                     <tr>
-                                        <td>{{ $token['clientName'] }}</td>
-                                        <td>{{ $token['created_at'] }}</td>
-                                        <td>{{ $token['updated_at'] }}</td>
-                                        <td>{{ $token['expires_at'] }}</td>
+                                        <td>{{ $token->name }}</td>
+                                        <td>{{ $token->created_at }}</td>
+                                        <td>{{ $token->updated_at }}</td>
+                                        <td>{{ $token->expires_at }}</td>
                                         <td>
                                             <a href="{{ route('deltoken', ['id' => $token['id']]) }}"
                                                alt="{{ __('settings.deletetokenfor') }}  {{ $token['clientName'] }}"


### PR DESCRIPTION
Added the parameter applicationName to the API Login so the user can see which application has access to their account. This is a major change, so old applications cannot use the login endpoint. So maybe we should wait merging this (or increase the API version?)

This will fix #71.