### PR TITLE
Remove redundant TrainCheckin Deletion

### DIFF
--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -147,7 +147,6 @@ class StatusController extends Controller
         }
         $user->update();
         $status->delete();
-        $trainCheckin->delete();
         return true;
     }
 


### PR DESCRIPTION
Since Trwl is using foreign (cascade) keys it's no longer necessary to delete TrainCheckIn Model. It will remove automatically if the Status Model is deleted.