### PR TITLE
Changed database column positions for new migrations

### DIFF
--- a/database/migrations/2019_08_09_003647_create_statuses_table.php
+++ b/database/migrations/2019_08_09_003647_create_statuses_table.php
@@ -14,13 +14,12 @@ class CreateStatusesTable extends Migration
     public function up()
     {
         Schema::create('statuses', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->timestamps();
+            $table->id();
             $table->text('body')->nullable();
             $table->integer('user_id')->unsigned();
             $table->boolean('business')->nullable();
             $table->string('type')->default('hafas');
-
+            $table->timestamps();
         });
     }
 

--- a/database/migrations/2019_08_09_003837_create_follows_table.php
+++ b/database/migrations/2019_08_09_003837_create_follows_table.php
@@ -14,11 +14,10 @@ class CreateFollowsTable extends Migration
     public function up()
     {
         Schema::create('follows', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->timestamps();
+            $table->id();
             $table->integer('user_id')->unsigned();
             $table->integer('follow_id');
-
+            $table->timestamps();
         });
     }
 
@@ -29,6 +28,6 @@ class CreateFollowsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('follow');
+        Schema::dropIfExists('follows');
     }
 }

--- a/database/migrations/2019_12_18_222050_connect_statuses_and_events.php
+++ b/database/migrations/2019_12_18_222050_connect_statuses_and_events.php
@@ -14,7 +14,7 @@ class ConnectStatusesAndEvents extends Migration
     public function up()
     {
         Schema::table('statuses', function (Blueprint $table) {
-            $table->bigInteger('event_id')->nullable(true)->unsigned();
+            $table->bigInteger('event_id')->nullable(true)->unsigned()->after('type');
         });
     }
 

--- a/database/migrations/2019_12_20_221724_create_user_roles.php
+++ b/database/migrations/2019_12_20_221724_create_user_roles.php
@@ -14,7 +14,7 @@ class CreateUserRoles extends Migration
     public function up()
     {
         Schema::table("users", function (Blueprint $table) {
-            $table->tinyInteger('role')->default('0');
+            $table->tinyInteger('role')->default('0')->after('home_id');
         });
     }
 


### PR DESCRIPTION
This doesnt affect actual installations and doesn't break anything.

The database columns are not in a beautiful order. but unfortunately this can't be changed later within an migration