### PR TITLE
🩹 Fixed ring-lines in API

### DIFF
--- a/api-swagger-v0.yml
+++ b/api-swagger-v0.yml
@@ -584,6 +584,14 @@ paths:
                   type: boolean
                 toot:
                   type: boolean
+                departure:
+                  description: Time of departure at the start station
+                  nullable: true
+                  example: "2021-01-01T12:00:00+01:00"
+                arrival:
+                  description: Time of arrival at the destination station
+                  nullable: true
+                  example: "2021-01-01T12:00:00+01:00"
       responses:
         200:
           description: OK

--- a/app/Http/Controllers/API/TransportController.php
+++ b/app/Http/Controllers/API/TransportController.php
@@ -89,12 +89,16 @@ class TransportController extends ResponseController
     public function TrainCheckin(Request $request) {
         $validator = Validator::make($request->all(), [
             'tripID'      => 'required',
-            'lineName'    => ['nullable'], //Should be required in future API Releases due to DB Rest
+            //Should be required in future API Releases due to DB Rest
+            'lineName'    => ['nullable'],
             'start'       => 'required',
             'destination' => 'required',
             'body'        => 'max:280',
             'tweet'       => 'boolean',
-            'toot'        => 'boolean'
+            'toot'        => 'boolean',
+            //nullable, so that it is not a breaking change
+            'departure'   => ['nullable', 'date'],
+            'arrival'     => ['nullable', 'date'],
         ]);
         if ($validator->fails()) {
             return $this->sendError($validator->errors(), 400);
@@ -116,7 +120,10 @@ class TransportController extends ResponseController
                 auth()->user(),
                 0,
                 $request->input('tweet'),
-                $request->input('toot')
+                $request->input('toot'),
+                0,
+                isset($request->departure) ? Carbon::parse($request->input('departure')) : null,
+                isset($request->arrival) ? Carbon::parse($request->input('arrival')) : null,
             );
 
             return $this->sendResponse([


### PR DESCRIPTION
fixes #202

The new attributes are nullable so this is not a breaking change. The API is functional without these parameters but maybe inaccurate at ring-lines.