### PR TITLE
🐛 Catch server error

### DIFF
--- a/app/Http/Controllers/HafasController.php
+++ b/app/Http/Controllers/HafasController.php
@@ -11,6 +11,7 @@ use Carbon\Carbon;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
+use PDOException;
 use stdClass;
 
 abstract class HafasController extends Controller
@@ -291,13 +292,16 @@ abstract class HafasController extends Controller
                     $updatePayload['departure_platform_real'] = $stopover->departurePlatform;
                 }
             }
-
-            TrainStopover::updateOrCreate(
-                [
-                    'trip_id'          => $tripID,
-                    'train_station_id' => $hafasStop->id
-                ], $updatePayload
-            );
+            try {
+                TrainStopover::updateOrCreate(
+                    [
+                        'trip_id'          => $tripID,
+                        'train_station_id' => $hafasStop->id
+                    ], $updatePayload
+                );
+            } catch (PDOException $exception) {
+                report($exception);
+            }
         }
 
         return $hafasTrip;


### PR DESCRIPTION
This PR catches the error from Issue #239. The error only ever occurs at second 0 and 1, so it probably overlaps with the insertion of the stopovers from the cronjob. I'm not sure yet how exactly to fix the error, however this PR would already make everything more user friendly and not show server error (500) anymore.