### PR TITLE
fixed typo of attribute

### DIFF
--- a/resources/views/stationboard.blade.php
+++ b/resources/views/stationboard.blade.php
@@ -39,7 +39,7 @@
                 <div class="card">
                     <div class="card-header">
                         <div class="float-end">
-                            <a href="{{ route('user.setHome', ['ibnr' => $station->idnr]) }}"><i class="fa fa-home"></i></a>
+                            <a href="{{ route('user.setHome', ['ibnr' => $station->ibnr]) }}"><i class="fa fa-home"></i></a>
                         </div>
                         {{ $station->name }} <small><i
                                     class="far fa-clock fa-sm"></i>{{ $when->format('H:i (Y-m-d)') }}</small>


### PR DESCRIPTION
Since @aledjones was a bit too hectic, he overlooked a typo from #279 and merged it into develop. This shall forever be cut in stone as a sign of his shame and punishment!

---

Fixes #278. Thank you very much @EventHorizon8! :)