### PR TITLE
🐛 Fixed Malfunctioning CheckInTests

### DIFF
--- a/tests/Feature/ExportTripsTest.php
+++ b/tests/Feature/ExportTripsTest.php
@@ -19,8 +19,8 @@ class ExportTripsTest extends TestCase
 
         $this->user = $this->createGDPRAckedUser();
 
-        $this->checkin("Frankfurt(M) Flughafen Fernbf", "8070003", new DateTime("+1 day 8:00"));
-        $this->checkin("Essen Hbf", "8000098", new DateTime("+2 day 7:30"));
+        $this->checkin("Frankfurt(M) Flughafen Fernbf", new DateTime("+1 day 8:00"));
+        $this->checkin("Essen Hbf", new DateTime("+2 day 7:45"));
     }
 
     /**

--- a/tests/Feature/ExportTripsTest.php
+++ b/tests/Feature/ExportTripsTest.php
@@ -12,7 +12,7 @@ class ExportTripsTest extends TestCase
 {
     use RefreshDatabase;
 
-    private $user;
+    protected $user;
 
     protected function setUp(): void {
         parent::setUp();
@@ -21,55 +21,6 @@ class ExportTripsTest extends TestCase
 
         $this->checkin("Frankfurt(M) Flughafen Fernbf", new DateTime("+1 day 8:00"));
         $this->checkin("Essen Hbf", new DateTime("+2 day 7:45"));
-    }
-
-    /**
-     * This is mostly copied from Checkin Test
-     * @param $stationName
-     * @param $ibnr
-     * @param DateTime $now
-     */
-    protected function checkin($stationName, $ibnr, DateTime $now) {
-        $trainStationboard = TransportController::TrainStationboard(
-            $stationName,
-            Carbon::createFromTimestamp($now->format('U')),
-            'express'
-        );
-        $countDepartures   = count($trainStationboard['departures']);
-        if ($countDepartures == 0) {
-            $this->markTestSkipped("Unable to find matching trains. Is it night in $stationName?");
-            return;
-        }
-
-        // Second: We don't like broken or cancelled trains.
-        $i = 0;
-        while ((isset($trainStationboard['departures'][$i]->cancelled)
-                && $trainStationboard['departures'][$i]->cancelled)
-            || count($trainStationboard['departures'][$i]->remarks) != 0) {
-            $i++;
-            if ($i == $countDepartures) {
-                $this->markTestSkipped("Unable to find unbroken train. Is it stormy in $stationName?");
-                return;
-            }
-        }
-        $departure = $trainStationboard['departures'][$i];
-        CheckinTest::isCorrectHafasTrip($departure, $now);
-
-        // Third: Get the trip information
-        $trip = TransportController::TrainTrip(
-            $departure->tripId,
-            $departure->line->name,
-            $departure->stop->location->id
-        );
-
-        // WHEN: User tries to check-in
-        $this->actingAs($this->user)
-             ->post(route('trains.checkin'), [
-                 'body'        => 'Example Body',
-                 'tripID'      => $departure->tripId,
-                 'start'       => $ibnr,
-                 'destination' => $trip['stopovers'][0]['stop']['location']['id'],
-             ]);
     }
 
     public function test_two_checkins_have_been_created_at_setup() {

--- a/tests/Feature/NotificationsTest.php
+++ b/tests/Feature/NotificationsTest.php
@@ -24,60 +24,6 @@ class NotificationsTest extends TestCase
         $this->user = $this->createGDPRAckedUser();
     }
 
-    /**
-     * This is mostly copied from Checkin Test and exactly copied from ExportTripsTest.
-     * @param $stationname
-     * @param $ibnr
-     * @param DateTime $now
-     * @param User|null $user
-     * @throws Exception
-     */
-    protected function checkin($stationname, $ibnr, DateTime $now, User $user = null) {
-        if ($user == null) {
-            $user = $this->user;
-        }
-        $trainStationboard = TransportController::TrainStationboard($stationname,
-                                                                    Carbon::createFromTimestamp($now->format('U')),
-                                                                    'express');
-
-        $countDepartures = count($trainStationboard['departures']);
-        if ($countDepartures == 0) {
-            $this->markTestSkipped("Unable to find matching trains. Is it night in $stationname?");
-            return;
-        }
-
-        // Second: We don't like broken or cancelled trains.
-        $i = 0;
-        while ((isset($trainStationboard['departures'][$i]->cancelled)
-                && $trainStationboard['departures'][$i]->cancelled)
-            || count($trainStationboard['departures'][$i]->remarks) != 0) {
-            $i++;
-            if ($i == $countDepartures) {
-                $this->markTestSkipped("Unable to find unbroken train.
-                Is it stormy in $stationname?");
-                return;
-            }
-        }
-        $departure = $trainStationboard['departures'][$i];
-        CheckinTest::isCorrectHafasTrip($departure, $now);
-
-        // Third: Get the trip information
-        $trip = TransportController::TrainTrip(
-            $departure->tripId,
-            $departure->line->name,
-            $departure->stop->location->id
-        );
-
-        // WHEN: User tries to check-in
-        $this->actingAs($user)
-             ->post(route('trains.checkin'), [
-                 'body'        => 'Example Body',
-                 'tripID'      => $departure->tripId,
-                 'start'       => $ibnr,
-                 'destination' => $trip['stopovers'][0]['stop']['location']['id'],
-             ]);
-    }
-
     /** @test */
     public function likes_appear_in_notifications() {
         // Given: There is a likable status

--- a/tests/Feature/NotificationsTest.php
+++ b/tests/Feature/NotificationsTest.php
@@ -81,8 +81,8 @@ class NotificationsTest extends TestCase
     /** @test */
     public function likes_appear_in_notifications() {
         // Given: There is a likable status
-        $now = new DateTime("+2 day 7:30");
-        $this->checkin("Essen Hbf", "8000098", $now);
+        $now = new DateTime("+2 day 7:45");
+        $this->checkin("Essen Hbf", $now);
 
         $status = $this->user->statuses->first();
 
@@ -106,8 +106,8 @@ class NotificationsTest extends TestCase
     /** @test */
     public function removed_likes_dont_appear_in_notifications() {
         // Given: There is a likable status
-        $now = new DateTime("+2 day 7:30");
-        $this->checkin("Essen Hbf", "8000098", $now);
+        $now = new DateTime("+2 day 7:45");
+        $this->checkin("Essen Hbf", $now);
 
         $status = $this->user->statuses->first();
         $like   = $this->actingAs($this->user)
@@ -169,12 +169,12 @@ class NotificationsTest extends TestCase
     public function bob_joining_on_alices_connection_should_spawn_a_notification() {
         // GIVEN: Alice checked-into a train.
         $alice = $this->createGDPRAckedUser();
-        $now   = new DateTime("+2 day 7:30");
-        $this->checkin("Essen Hbf", "8000098", $now, $alice);
+        $now   = new DateTime("+2 day 7:45");
+        $this->checkin("Essen Hbf", $now, $alice);
 
         // WHEN: Bob also checks into the train
         $bob = $this->createGDPRAckedUser();
-        $this->checkin("Essen Hbf", "8000098", $now, $bob);
+        $this->checkin("Essen Hbf", $now, $bob);
 
         // THEN: Alice should see that in their notification
         $notifications = $this->actingAs($alice)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,15 @@
 
 namespace Tests;
 
+use App\Exceptions\CheckInCollisionException;
+use App\Exceptions\StationNotOnTripException;
+use App\Http\Controllers\TransportController;
 use App\Models\User;
+use Carbon\Carbon;
+use DateTime;
+use Exception;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Tests\Feature\CheckinTest;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -68,4 +75,63 @@ abstract class TestCase extends BaseTestCase
         $response->assertRedirect('/dashboard');
     }
 
+
+    /**
+     * This is mostly copied from Checkin Test and exactly copied from ExportTripsTest.
+     * @param $stationname
+     * @param DateTime $now
+     * @param User|null $user
+     * @throws Exception
+     */
+    protected function checkin($stationname, DateTime $now, User $user = null) {
+        if ($user == null) {
+            $user = $this->user;
+        }
+        $trainStationboard = TransportController::TrainStationboard($stationname,
+                                                                    Carbon::createFromTimestamp($now->format('U')),
+                                                                    'express');
+        $countDepartures   = count($trainStationboard['departures']);
+        if ($countDepartures == 0) {
+            $this->markTestSkipped("Unable to find matching trains. Is it night in $stationname?");
+            return;
+        }
+
+        // Second: We don't like broken or cancelled trains.
+        $i = 0;
+        while ((isset($trainStationboard['departures'][$i]->cancelled)
+                && $trainStationboard['departures'][$i]->cancelled)
+            || count($trainStationboard['departures'][$i]->remarks) != 0) {
+            $i++;
+            if ($i == $countDepartures) {
+                $this->markTestSkipped("Unable to find unbroken train.
+                Is it stormy in $stationname?");
+                return;
+            }
+        }
+        $departure = $trainStationboard['departures'][$i];
+        CheckinTest::isCorrectHafasTrip($departure, $now);
+
+        // Third: Get the trip information
+        $trip = TransportController::TrainTrip(
+            $departure->tripId,
+            $departure->line->name,
+            $departure->stop->location->id
+        );
+
+        // WHEN: User tries to check-in
+        try {
+            TransportController::TrainCheckin($trip['train']['trip_id'],
+                                              $trip['stopovers'][0]['stop']['id'],
+                                              end($trip['stopovers'])['stop']['id'],
+                                              '',
+                                              $user,
+                                              0,
+                                              0,
+                                              0);
+        } catch (StationNotOnTripException) {
+            $this->markTestSkipped("failure in checkin creation for " . $stationname . ": Station not in stopovers");
+        } catch (CheckInCollisionException) {
+            $this->markTestSkipped("failure for " . $now->format('Y-m-d H:i:s') . ": Collision");
+        }
+    }
 }


### PR DESCRIPTION
Moved the checkin-method to TestCase so that duplicate code is avoided. Fixed the way a checkin is created to the backend-method with better accuracy (Check in until the last stop instead of the first. Caused unhandled Exceptions)