### PR TITLE
🧐 Reduced query count

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -262,7 +262,7 @@ class UserController extends Controller
         'kilometers' => "Illuminate\\Support\\Collection"
     ])]
     public static function getLeaderboard(): array {
-        $checkIns = TrainCheckin::with('status.user')
+        $checkIns = TrainCheckin::with(['status.user', 'HafasTrip.stopoversNEW.trainStation', 'Origin', 'Destination'])
                                 ->where('departure', '>=', Carbon::now()->subDays(7)->toIso8601String())
                                 ->get();
 


### PR DESCRIPTION
This will reduce the database query count on the leaderboard page from 3975 to 14. 

It also improves page load time from about 3.09 seconds to 2.2 seconds. It is still slow because a lot is calculated in the PHP code. That should offload even more to the database. It's faster.