### PR TITLE
🌐 add translation key which was missing (#398)

### DIFF
--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -383,6 +383,7 @@
     "transport_types.private": "Private Reise",
     "transport_types.privatePlural": "Private Reisen",
     "transport_types.regional": "Regional",
+    "transport_types.regionalExp": "Regionalexpress",
     "transport_types.suburban": "S-Bahn",
     "transport_types.subway": "U-Bahn",
     "transport_types.tram": "Tram",


### PR DESCRIPTION
This PR will add a key for `transport_types.regionalExp` in Weblate, which will then motivate other people to add more translations.

