### PR TITLE
⚡️ Improved performance of notifications

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -36,7 +36,7 @@ class NotificationController extends Controller
                    ->map(function($notification) {
                        $notification->html = $notification->type::render($notification);
 
-                       if ($notification->html != null) {
+                   if ($notification->html != null) {
                            return collect([
                                               'notifiable_type' => $notification->notifiable_type,
                                               'notifiable_id'   => $notification->notifiable_id,
@@ -44,7 +44,7 @@ class NotificationController extends Controller
                                               'html'            => $notification->html,
                                               'read_at'         => $notification->read_at,
                                           ]);
-                       }
+                   }
                        return null;
                    })
                    ->filter(function($notificationOrNull) {

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Exceptions\ShouldDeleteNotificationException;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Response;
 use Throwable;
@@ -28,22 +29,26 @@ class NotificationController extends Controller
             ->values();
     }
 
-    public function renderLatest() {
-        return Auth::user()->notifications
-            ->take(10)
-            ->map(function($notification) {
-                $notification->html = $notification->type::render($notification);
+    public function renderLatest(): Collection {
+        return Auth::user()->notifications()
+                   ->limit(10)
+                   ->get()
+                   ->map(function($notification) {
+                       $notification->html = $notification->type::render($notification);
 
-                if ($notification->html != null) {
-                    return $notification;
-                }
-                return null;
-            })
-            // We don't need empty notifications
-            ->filter(function($notificationOrNull) {
-                return $notificationOrNull != null;
-            })
-            ->values();
+                       if ($notification->html != null) {
+                           return collect([
+                                              'html'    => $notification->html,
+                                              'read_at' => $notification->read_at,
+                                          ]);
+                       }
+                       return null;
+                   })
+                   ->filter(function($notificationOrNull) {
+                       // We don't need empty notifications
+                       return $notificationOrNull != null;
+                   })
+                   ->values();
     }
 
     public static function toggleReadState($notificationId): JsonResponse {

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -38,8 +38,11 @@ class NotificationController extends Controller
 
                        if ($notification->html != null) {
                            return collect([
-                                              'html'    => $notification->html,
-                                              'read_at' => $notification->read_at,
+                                              'notifiable_type' => $notification->notifiable_type,
+                                              'notifiable_id'   => $notification->notifiable_id,
+                                              'type'            => $notification->type,
+                                              'html'            => $notification->html,
+                                              'read_at'         => $notification->read_at,
                                           ]);
                        }
                        return null;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,7 +10,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
@@ -180,5 +182,14 @@ class User extends Authenticatable implements MustVerifyEmail
             }
         }
         return $mastodonUrl;
+    }
+
+    /**
+     * Get the entity's notifications.
+     *
+     * @return MorphMany
+     */
+    public function notifications(): MorphMany {
+        return $this->morphMany(DatabaseNotification::class, 'notifiable')->orderBy('created_at', 'desc');
     }
 }

--- a/app/Notifications/UserJoinedConnection.php
+++ b/app/Notifications/UserJoinedConnection.php
@@ -14,10 +14,10 @@ class UserJoinedConnection extends Notification
 {
     use Queueable;
 
-    private ?int  $statusId;
-    private mixed $linename;
-    private mixed $origin;
-    private mixed $destination;
+    private ?int $statusId;
+    private      $linename;
+    private      $origin;
+    private      $destination;
 
     /**
      * Create a new notification instance

--- a/app/Notifications/UserJoinedConnection.php
+++ b/app/Notifications/UserJoinedConnection.php
@@ -6,23 +6,25 @@ use App\Exceptions\ShouldDeleteNotificationException;
 use App\Models\Status;
 use Illuminate\Bus\Queueable;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Notifications\Notification;
+use stdClass;
 
 class UserJoinedConnection extends Notification
 {
     use Queueable;
 
-    private $statusId;
-    private $linename;
-    private $origin;
-    private $destination;
+    private ?int  $statusId;
+    private mixed $linename;
+    private mixed $origin;
+    private mixed $destination;
 
     /**
      * Create a new notification instance
      *
      * @return void
      */
-    public function __construct($statusId = null, $linename = null, $origin = null, $destination = null) {
+    public function __construct(int $statusId = null, $linename = null, $origin = null, $destination = null) {
         $this->statusId    = $statusId;
         $this->linename    = $linename;
         $this->origin      = $origin;
@@ -32,37 +34,37 @@ class UserJoinedConnection extends Notification
     /**
      * Get the notification's delivery channels.
      *
-     * @param  mixed
      * @return array
      */
-    public function via()
-    {
+    public function via(): array {
         return ['database'];
     }
 
     /**
      * Get the array representation of the notification.
      *
-     * @param  mixed
      * @return array
      */
-    public function toArray()
-    {
+    public function toArray(): array {
         return [
-            'status_id' => $this->statusId,
-            'linename' => $this->linename,
-            'origin' => $this->origin,
+            'status_id'   => $this->statusId,
+            'linename'    => $this->linename,
+            'origin'      => $this->origin,
             'destination' => $this->destination
         ];
     }
 
-    public static function detail($notification)
-    {
+    /**
+     * @param DatabaseNotification $notification
+     * @return stdClass
+     * @throws ShouldDeleteNotificationException
+     */
+    public static function detail(DatabaseNotification $notification): stdClass {
         $data                 = $notification->data;
-        $notification->detail = new \stdClass();
+        $notification->detail = new stdClass();
         try {
-            $status = status::findOrFail($data['status_id']);
-        } catch(ModelNotFoundException $e) {
+            $status = Status::findOrFail($data['status_id']);
+        } catch (ModelNotFoundException) {
             throw new ShouldDeleteNotificationException();
         }
 
@@ -70,33 +72,32 @@ class UserJoinedConnection extends Notification
         return $notification->detail;
     }
 
-    public static function render($notification)
-    {
+    public static function render(DatabaseNotification $notification): ?string {
         try {
             $detail = self::detail($notification);
-        } catch (ShouldDeleteNotificationException $e) {
+        } catch (ShouldDeleteNotificationException) {
             $notification->delete();
             return null;
         }
         $data = $notification->data;
 
         return view("includes.notification", [
-            'color' => "neutral",
-            'icon' => "fa fa-train",
-            'lead' => __('notifications.userJoinedConnection.lead',
-                         ['username' => $detail->status->user->username
-                         ]),
-            "link" => route('statuses.get', ['id' => $detail->status->id]),
-            'notice' => trans_choice('notifications.userJoinedConnection.notice',
-                                     preg_match('/\s/', $data['linename']), [
-                                         'username' => $detail->status->user->username,
-                                         'linename' => $data['linename'],
-                                         'origin' => $data['origin'],
-                                         'destination' => $data['destination']
-                                     ]),
+            'color'           => "neutral",
+            'icon'            => "fa fa-train",
+            'lead'            => __('notifications.userJoinedConnection.lead',
+                                    ['username' => $detail->status->user->username
+                                    ]),
+            "link"            => route('statuses.get', ['id' => $detail->status->id]),
+            'notice'          => trans_choice('notifications.userJoinedConnection.notice',
+                                              preg_match('/\s/', $data['linename']), [
+                                                  'username'    => $detail->status->user->username,
+                                                  'linename'    => $data['linename'],
+                                                  'origin'      => $data['origin'],
+                                                  'destination' => $data['destination']
+                                              ]),
             'date_for_humans' => $notification->created_at->diffForHumans(),
-            'read' => $notification->read_at != null,
-            'notificationId' => $notification->id
+            'read'            => $notification->read_at != null,
+            'notificationId'  => $notification->id
         ])->render();
     }
 }

--- a/tests/Feature/NotificationsTest.php
+++ b/tests/Feature/NotificationsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Http\Controllers\UserController as UserBackend;
 use App\Models\Like;
+use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Notifications\DatabaseNotification;
@@ -13,7 +14,7 @@ class NotificationsTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected $user;
+    protected User $user;
 
     protected function setUp(): void {
         parent::setUp();


### PR DESCRIPTION
The notifications always loaded (in the case of my account) between 3 and 4 seconds and executed more than 280 database queries per request (that poor database 😭)

Now only the required data is loaded. Load time at under 300ms and less than 40 queries (query count still too much, but better than before). 