### PR TITLE
🚑 Location-API fix

### DIFF
--- a/app/Http/Controllers/HafasController.php
+++ b/app/Http/Controllers/HafasController.php
@@ -116,13 +116,13 @@ abstract class HafasController extends Controller
             $stations = collect();
             foreach ($data as $hafasStation) {
                 $station           = self::parseHafasStopObject($hafasStation);
-                $station->distance = $hafasStation->distance;
+                $station->distance = $hafasStation->distance ?? 0;
                 $stations->push($station);
             }
 
             return $stations;
         } catch (GuzzleException $e) {
-            $response = $e->getResponse()->getBody()->getContents();
+            $response = $e->getMessage();
             throw new HafasException($response->msg ?? $e->getMessage());
         }
     }


### PR DESCRIPTION
Fixes a rare bug wherein the API doesn't return the distance value if your coordinates are exactly on the station.

Closes #430.