### PR TITLE
🐛 Fix signup route on APIv1

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -24,7 +24,7 @@ use Illuminate\Support\Facades\Route;
 Route::group(['prefix' => 'v1', 'middleware' => 'return-json'], function() {
     Route::group(['prefix' => 'auth'], function() {
         Route::post('login', [v1Auth::class, 'login']);
-        Route::post('signup', [v1Auth::class, 'signup']);
+        Route::post('signup', [v1Auth::class, 'register']);
         Route::group(['middleware' => 'auth:api'], function() {
             Route::post('refresh', [v1Auth::class, 'refresh']);
             Route::post('logout', [v1Auth::class, 'logout']);


### PR DESCRIPTION
title explains it already, but the signup method currently throws an exception that the method (signup) does not exist.