### PR TITLE
Reindex departure array after sort

### DIFF
--- a/app/Http/Controllers/TransportController.php
+++ b/app/Http/Controllers/TransportController.php
@@ -98,7 +98,7 @@ class TransportController extends Controller
             return $departure->when ?? $departure->plannedWhen;
         });
 
-        return ['station' => $station, 'departures' => $departures, 'times' => $times];
+        return ['station' => $station, 'departures' => $departures->values(), 'times' => $times];
     }
 
     /**


### PR DESCRIPTION
fixes #584

When sorting the departure array by the departure/plannedDeparture, the keys in the collection get mixed up.

Because of this, the output JSON is encoded as an object instead of an array. The collection keys needs to be reindexed so that it can be encoded correctly.