### PR TITLE
:bug: Suppress exception

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -5,6 +5,7 @@ namespace App\Exceptions;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use Throwable;
 
 class Handler extends ExceptionHandler
@@ -15,7 +16,7 @@ class Handler extends ExceptionHandler
      * @var array
      */
     protected $dontReport = [
-        //
+        OAuthServerException::class
     ];
 
     /**
@@ -32,6 +33,7 @@ class Handler extends ExceptionHandler
      * Report or log an exception.
      *
      * @param Throwable $exception
+     *
      * @return void
      * @throws Throwable
      */
@@ -42,8 +44,9 @@ class Handler extends ExceptionHandler
     /**
      * Render an exception into an HTTP response.
      *
-     * @param Request $request
+     * @param Request   $request
      * @param Throwable $exception
+     *
      * @return Response
      * @throws Throwable
      */


### PR DESCRIPTION
fixes #697

The error occurs when the API is called with a revoked or expired bearer token.
We can't catch this any other way, since the error doesn't occur in our code....
see https://laracasts.com/discuss/channels/laravel/error-log-problems-when-using-laravel-passport-for-user-login-authentication?page=1#reply=389574

---------------------------
Since we do not log the requests, we do not know who is making so many unauthenticated requests.
@derf can you maybe see if that is you? You may receive HTTP 401 with the "message": "Unauthenticated."