### PR TITLE
:sparkles: Add minified api logging

### DIFF
--- a/app/Http/Controllers/Frontend/Admin/ApiUsageController.php
+++ b/app/Http/Controllers/Frontend/Admin/ApiUsageController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Frontend\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\ApiLog;
+use App\Models\UserAgent;
+use Carbon\Carbon;
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class ApiUsageController extends Controller
+{
+    public function showUsage(Request $request): Renderable {
+        $validated = $request->validate([
+                                            'start' => ['nullable', 'date', 'before_or_equal:end'],
+                                            'end'   => ['nullable', 'date', 'after_or_equal:start'],
+                                        ]);
+        $start     = isset($validated['start']) ? Carbon::parse($validated['start']) : Carbon::now()->subMonth();
+        $end       = isset($validated['end']) ? Carbon::parse($validated['end']) : Carbon::now();
+
+        $mostUsedRoutes = ApiLog::where('created_at', '>', $start->toIso8601String())
+                                ->where('created_at', '<', $end->toIso8601String())
+                                ->groupBy(['method', 'route'])
+                                ->select(['method', 'route', DB::raw('count(*) as count')])
+                                ->orderBy('count', 'desc')
+                                ->get();
+
+        $mostUsedUserAgents = UserAgent::join('api_logs', 'user_agents.id', '=', 'api_logs.user_agent_id')
+                                       ->where('api_logs.created_at', '>', $start->toIso8601String())
+                                       ->where('api_logs.created_at', '<', $end->toIso8601String())
+                                       ->groupBy(['user_agents.id', 'user_agents.user_agent'])
+                                       ->select(['user_agents.id', 'user_agents.user_agent', DB::raw('count(*) as count')])
+                                       ->orderBy('count', 'desc')
+                                       ->get();
+
+        return view('admin.api.usage', [
+            'start'              => $start,
+            'end'                => $end,
+            'mostUsedRoutes'     => $mostUsedRoutes,
+            'mostUsedUserAgents' => $mostUsedUserAgents,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Frontend/Admin/CheckinController.php
+++ b/app/Http/Controllers/Frontend/Admin/CheckinController.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Backend\Transport\TrainCheckinController;
 use App\Http\Controllers\HafasController;
 use App\Http\Controllers\TransportController as TransportBackend;
 use App\Models\Event;
+use App\Models\Status;
 use App\Models\TrainStation;
 use App\Models\User;
 use Carbon\Carbon;

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Http;
 
+use App\Http\Middleware\ApiLogMiddleware;
 use App\Http\Middleware\SemiGuest;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
@@ -56,6 +57,7 @@ class Kernel extends HttpKernel
      */
     protected $routeMiddleware = [
         'auth'          => \App\Http\Middleware\Authenticate::class,
+        'api.log'       => ApiLogMiddleware::class,
         'semiguest'     => SemiGuest::class,
         'auth.basic'    => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'bindings'      => \Illuminate\Routing\Middleware\SubstituteBindings::class,

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Http;
 
+use App\Http\Middleware\Api\JsonMiddleware;
 use App\Http\Middleware\ApiLogMiddleware;
 use App\Http\Middleware\SemiGuest;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
@@ -44,7 +45,8 @@ class Kernel extends HttpKernel
         'api' => [
             'throttle:60,1',
             'bindings',
-            \App\Http\Middleware\Api\JsonMiddleware::class,
+            JsonMiddleware::class,
+            ApiLogMiddleware::class,
         ],
     ];
 
@@ -70,7 +72,7 @@ class Kernel extends HttpKernel
         'throttle'      => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'userrole'      => \App\Http\Middleware\UserRoleMiddleware::class,
         'verified'      => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
-        'return-json'   => \App\Http\Middleware\Api\JsonMiddleware::class,
+        'return-json'   => JsonMiddleware::class,
     ];
 
     /**

--- a/app/Http/Middleware/ApiLogMiddleware.php
+++ b/app/Http/Middleware/ApiLogMiddleware.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\ApiLog;
+use App\Models\UserAgent;
+use Closure;
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+class ApiLogMiddleware
+{
+
+    private static ?ApiLog $apiLog;
+
+    public function handle(Request $request, Closure $next): mixed {
+        try {
+            $userAgent    = UserAgent::firstOrCreate(['user_agent' => substr($request->userAgent(), 0, 255)]);
+            self::$apiLog = ApiLog::create([
+                                               'method'        => $request->method(),
+                                               'route'         => Route::getCurrentRoute()?->uri() ?? 'unknown',
+                                               'user_agent_id' => $userAgent->id,
+                                           ]);
+
+        } catch (Exception $exception) {
+            report($exception);
+        }
+        return $next($request);
+    }
+
+    public function terminate(Request $request, $response): void {
+        if (self::$apiLog === null) {
+            return;
+        }
+        try {
+            self::$apiLog->update([
+                                      'status_code' => $response->getStatusCode(),
+                                  ]);
+        } catch (Exception $exception) {
+            report($exception);
+        }
+    }
+}

--- a/app/Models/ApiLog.php
+++ b/app/Models/ApiLog.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * We need minified logging for API calls to know which API endpoints are used by which applications,
+ * so we can focus us on developing the most important ones.
+ * We don't save any user information, ip addresses or anything else.
+ * The user agent is required to identify applications.
+ */
+class ApiLog extends Model
+{
+    protected $fillable = ['method', 'route', 'status_code', 'user_agent_id'];
+    protected $casts    = [
+        'method'        => 'string',
+        'route'         => 'string',
+        'status_code'   => 'integer',
+        'user_agent_id' => 'integer',
+    ];
+
+    public function userAgent(): BelongsTo {
+        return $this->belongsTo(UserAgent::class, 'user_agent_id', 'id');
+    }
+}

--- a/app/Models/UserAgent.php
+++ b/app/Models/UserAgent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserAgent extends Model
+{
+    protected $fillable = ['user_agent'];
+    protected $casts    = [
+        'user_agent' => 'string',
+    ];
+}

--- a/database/migrations/2022_04_03_000000_create_user_agents_table.php
+++ b/database/migrations/2022_04_03_000000_create_user_agents_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+
+    public function up(): void {
+        Schema::create('user_agents', static function(Blueprint $table) {
+            $table->id();
+            $table->string('user_agent')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void {
+        Schema::dropIfExists('user_agents');
+    }
+};

--- a/database/migrations/2022_04_03_000001_create_api_logs_table.php
+++ b/database/migrations/2022_04_03_000001_create_api_logs_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+
+    public function up(): void {
+        Schema::create('api_logs', static function(Blueprint $table) {
+            $table->id();
+            $table->string('method');
+            $table->string('route');
+            $table->unsignedTinyInteger('status_code')->nullable();
+            $table->unsignedBigInteger('user_agent_id');
+            $table->timestamps();
+
+            $table->index(['method', 'route']);
+            $table->index(['route']);
+
+            $table->foreign('user_agent_id')->references('id')->on('user_agents');
+        });
+    }
+
+    public function down(): void {
+        Schema::dropIfExists('api_logs');
+    }
+};

--- a/database/migrations/2022_04_03_000001_create_api_logs_table.php
+++ b/database/migrations/2022_04_03_000001_create_api_logs_table.php
@@ -16,8 +16,7 @@ return new class extends Migration
             $table->unsignedBigInteger('user_agent_id');
             $table->timestamps();
 
-            $table->index(['method', 'route']);
-            $table->index(['route']);
+            $table->index(['created_at', 'method', 'route']);
 
             $table->foreign('user_agent_id')->references('id')->on('user_agents');
         });

--- a/resources/views/admin/api/usage.blade.php
+++ b/resources/views/admin/api/usage.blade.php
@@ -1,0 +1,101 @@
+@extends('admin.layout')
+
+@section('title', 'API Usage')
+
+@section('content')
+    <div class="row">
+        <div class="col-12">
+            <div class="card mb-2">
+                <div class="card-body">
+                    <form class="row g-3">
+                        <div class="col-md-6">
+                            <div class="form-floating">
+                                <input type="datetime-local" class="form-control" id="inputStart" name="start"
+                                       value="{{$start->toDateTimeLocalString()}}" placeholder="Von"/>
+                                <label for="inputStart" class="form-label">
+                                    Von
+                                </label>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="form-floating">
+                                <input type="datetime-local" class="form-control" id="inputEnd" name="end"
+                                       value="{{$end->toDateTimeLocalString()}}" placeholder="Bis"/>
+                                <label for="inputEnd" class="form-label">
+                                    Bis
+                                </label>
+                            </div>
+                        </div>
+                        <div class="col-12 text-end">
+                            <button type="submit" class="btn btn-primary">Suchen</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-body">
+                    <h2 class="fs-5" id="titleMostUsedRoutes">Meistgenutzte Routen</h2>
+
+                    @if($mostUsedRoutes->count() === 0)
+                        <p class="text-danger fw-bold">Keine Daten vorhanden</p>
+                    @else
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover" aria-labelledby="titleMostUsedRoutes">
+                                <thead>
+                                    <tr>
+                                        <th>HTTP-Methode</th>
+                                        <th>Route</th>
+                                        <th>Anzahl</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach($mostUsedRoutes as $route)
+                                        <tr>
+                                            <td><code>{{ $route->method }}</code></td>
+                                            <td><code>{{ $route->route }}</code></td>
+                                            <td>{{ $route->count }}x</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-body">
+                    <h2 class="fs-5" id="titleUserAgents">UserAgents</h2>
+
+                    @if($mostUsedUserAgents->count() === 0)
+                        <p class="text-danger fw-bold">Keine Daten vorhanden</p>
+                    @else
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover" aria-labelledby="titleUserAgents">
+                                <thead>
+                                    <tr>
+                                        <th>UserAgent</th>
+                                        <th>Anzahl</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach($mostUsedUserAgents as $userAgentObject)
+                                        <tr>
+                                            <td><code>{{ $userAgentObject->user_agent }}</code></td>
+                                            <td>{{ $userAgentObject->count }}x</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/layout.blade.php
+++ b/resources/views/admin/layout.blade.php
@@ -63,6 +63,13 @@
                             <span class="d-md-none d-lg-inline">Users</span>
                         </a>
                     </li>
+                    <li>
+                        <a href="{{ route('admin.api.usage') }}"
+                           class="nav-link text-white {{ request()->is('admin/api/usage*') ? 'active' : '' }}">
+                            <i class="fa-solid fa-book me-2" aria-hidden="true"></i>
+                            <span class="d-md-none d-lg-inline">API Usage</span>
+                        </a>
+                    </li>
                 </ul>
                 <hr>
                 <div class="dropdown">

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,7 +29,7 @@ use App\Http\Controllers\API\v1\TransportController;
 use App\Http\Controllers\API\v1\UserController;
 use Illuminate\Support\Facades\Route;
 
-Route::group(['prefix' => 'v1', 'middleware' => ['return-json', 'api.log']], static function() {
+Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static function() {
     Route::group(['prefix' => 'auth'], function() {
         Route::post('login', [v1Auth::class, 'login']);
         Route::post('signup', [v1Auth::class, 'register']);
@@ -132,7 +132,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json', 'api.log']], sta
     });
 });
 
-Route::group(['prefix' => 'v0', 'middleware' => ['return-json', 'api.log']], static function() {
+Route::group(['prefix' => 'v0', 'middleware' => ['return-json']], static function() {
     Route::group(['middleware' => ['guest:api']], static function() {
         Route::group(['prefix' => 'auth'], static function() {
             Route::post('login', 'API\AuthController@login')->name('api.v0.auth.login');

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,7 +29,7 @@ use App\Http\Controllers\API\v1\TransportController;
 use App\Http\Controllers\API\v1\UserController;
 use Illuminate\Support\Facades\Route;
 
-Route::group(['prefix' => 'v1', 'middleware' => 'return-json'], static function() {
+Route::group(['prefix' => 'v1', 'middleware' => ['return-json', 'api.log']], static function() {
     Route::group(['prefix' => 'auth'], function() {
         Route::post('login', [v1Auth::class, 'login']);
         Route::post('signup', [v1Auth::class, 'register']);
@@ -132,7 +132,7 @@ Route::group(['prefix' => 'v1', 'middleware' => 'return-json'], static function(
     });
 });
 
-Route::group(['prefix' => 'v0', 'middleware' => 'return-json'], static function() {
+Route::group(['prefix' => 'v0', 'middleware' => ['return-json', 'api.log']], static function() {
     Route::group(['middleware' => ['guest:api']], static function() {
         Route::group(['prefix' => 'auth'], static function() {
             Route::post('login', 'API\AuthController@login')->name('api.v0.auth.login');

--- a/routes/web/admin.php
+++ b/routes/web/admin.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Frontend\Admin\ApiUsageController;
 use App\Http\Controllers\Frontend\Admin\CheckinController;
 use App\Http\Controllers\Frontend\Admin\DashboardController;
 use App\Http\Controllers\Frontend\Admin\EventController as AdminEventController;
@@ -11,9 +12,12 @@ Route::prefix('admin')->middleware(['auth', 'userrole:5'])->group(function() {
     Route::get('/', [DashboardController::class, 'renderDashboard'])
          ->name('admin.dashboard');
 
+    Route::get('/api/usage', [ApiUsageController::class, 'showUsage'])
+         ->name('admin.api.usage');
+
     Route::prefix('checkin')->group(function() {
         Route::get('/', [CheckinController::class, 'renderStationboard'])
-            ->name('admin.stationboard');
+             ->name('admin.stationboard');
         Route::get('/trip/{tripId}', [CheckinController::class, 'renderTrip'])
              ->name('admin.trip');
         Route::post('/checkin', [CheckinController::class, 'checkin'])


### PR DESCRIPTION
We need minified logging for API calls to know which API endpoints are used by which applications, so we can focus us on developing the most important ones. We don't save any user information, ip addresses or anything else. The user agent is required to identify applications.

We need this informations to know which routes from APIv0 can be shut down, as of APIv1 is currently in development.

![image](https://user-images.githubusercontent.com/4103693/161443642-b93081df-a90f-4f58-8997-96ebd20879a2.png)
