### PR TITLE
:sparkles: Add only authenticated users visibility

### DIFF
--- a/app/Enum/StatusVisibility.php
+++ b/app/Enum/StatusVisibility.php
@@ -9,4 +9,5 @@ enum StatusVisibility: int
     case UNLISTED = 1;
     case FOLLOWERS = 2;
     case PRIVATE = 3;
+    case AUTHENTICATED = 4;
 }

--- a/app/Http/Controllers/Backend/User/DashboardController.php
+++ b/app/Http/Controllers/Backend/User/DashboardController.php
@@ -29,6 +29,7 @@ abstract class DashboardController extends Controller
                      ->whereIn('visibility', [
                          StatusVisibility::PUBLIC->value,
                          StatusVisibility::FOLLOWERS->value,
+                         StatusVisibility::AUTHENTICATED->value
                      ])
                      ->orWhere('statuses.user_id', $user->id)
                      ->withCount('likes')
@@ -50,7 +51,10 @@ abstract class DashboardController extends Controller
                          //Option 1: User is public AND status is public
                          $query->where(function(Builder $query) {
                              $query->where('users.private_profile', 0)
-                                   ->where('visibility', StatusVisibility::PUBLIC->value);
+                                   ->whereIn('visibility', [
+                                       StatusVisibility::PUBLIC->value,
+                                       StatusVisibility::AUTHENTICATED->value
+                                   ]);
                          });
 
                          //Option 2: Status is from oneself

--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -240,14 +240,20 @@ class StatusController extends Controller
                           ->join('train_checkins', 'statuses.id', '=', 'train_checkins.status_id')
                           ->where(function($query) {
                               $query->where('users.private_profile', 0)
-                                    ->where('statuses.visibility', StatusVisibility::PUBLIC->value);
+                                    ->whereIn('statuses.visibility', [
+                                        StatusVisibility::PUBLIC->value,
+                                        StatusVisibility::AUTHENTICATED->value
+                                    ]);
                               if (auth()->check()) {
                                   $query->orWhere('statuses.user_id', auth()->user()->id)
                                         ->orWhere(function($query) {
                                             $followIds = auth()->user()->follows()->select('follow_id');
                                             $query->where('statuses.visibility', StatusVisibility::FOLLOWERS->value)
                                                   ->whereIn('statuses.user_id', $followIds)
-                                                  ->orWhere('statuses.visibility', StatusVisibility::PUBLIC->value);
+                                                  ->orWhereIn('statuses.visibility', [
+                                                      StatusVisibility::PUBLIC->value,
+                                                      StatusVisibility::AUTHENTICATED->value
+                                                  ]);
                                         });
                               }
                           })

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -89,6 +89,11 @@ class UserController extends Controller
                                   $followings = Auth::check() ? auth()->user()->follows()->select('follow_id') : [];
                                   $query->where('statuses.visibility', StatusVisibility::FOLLOWERS->value)
                                         ->whereIn('statuses.user_id', $followings);
+                                  if (Auth::check()) {
+                                      $query->orWhere(function($query) {
+                                          $query->where('statuses.visibility', StatusVisibility::AUTHENTICATED->value);
+                                      });
+                                  }
                               });
                     })
                     ->select('statuses.*')

--- a/app/Policies/StatusPolicy.php
+++ b/app/Policies/StatusPolicy.php
@@ -54,8 +54,8 @@ class StatusPolicy
         // Case 5: Status is unlisted
         // This isn't checked here. This is done in the query from the (global/private) dashboard.
 
-        // Case 6: Status is public
-        if ($status->visibility === StatusVisibility::PUBLIC) {
+        // Case 6: Status is public or authenticated
+        if ($status->visibility === StatusVisibility::PUBLIC || $status->visibility === StatusVisibility::AUTHENTICATED) {
             return Response::allow(); //TODO: How to handle with private profile?
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "traewelling",
             "dependencies": {
                 "@fortawesome/fontawesome-free": "^6.1.1",
                 "@tarekraafat/autocomplete.js": "^10.2.7",

--- a/resources/js/APImodels.js
+++ b/resources/js/APImodels.js
@@ -142,6 +142,11 @@ export let visibility = [
         desc: "_.status.visibility.3",
         detail: "_.status.visibility.3.detail"
     },
+    {
+        icon: "fa fa-user-check",
+        desc: "_.status.visibility.4",
+        detail: "_.status.visibility.4.detail"
+    }
 ];
 
 export let profileNotifications = [

--- a/resources/js/components/business-check-in.js
+++ b/resources/js/components/business-check-in.js
@@ -9,7 +9,7 @@ let businessButton      = $("#businessDropdownButton");
 const businessIcons     = ["fa-user", "fa-briefcase", "fa-building"];
 let visibilityFormInput = $("#checkinVisibility");
 let visibilityButton    = $("#visibilityDropdownButton");
-const visibilityIcons   = ["fa-globe-americas", "fa-lock-open", "fa-user-friends", "fa-lock"];
+const visibilityIcons   = ["fa-globe-americas", "fa-lock-open", "fa-user-friends", "fa-lock", "fa-user-check"];
 
 function setIconForDropdown(value, button, inputFieldValue, icons) {
     let number  = parseInt(value, 10);

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -428,6 +428,8 @@
     "status.visibility.2.detail": "Nur für (akzeptierte) Follower sichtbar",
     "status.visibility.3": "Privat",
     "status.visibility.3.detail": "Nur für dich sichtbar",
+    "status.visibility.4": "Nur angemeldete Nutzer",
+    "status.visibility.4.detail": "Nur für angemeldete Nutzer sichtbar",
     "time-format": "HH:mm",
     "time-format.with-day": "HH:mm (DD.MM.YYYY)",
     "datetime-format": "DD.MM.YYYY HH:mm",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -405,6 +405,8 @@
     "status.visibility.2.detail": "Only visible for (approved) followers",
     "status.visibility.3": "Private",
     "status.visibility.3.detail": "Only visible for you",
+    "status.visibility.4": "Only logged-in users",
+    "status.visibility.4.detail": "Only visible for logged-in users",
     "transport_types.bus": "bus",
     "transport_types.business": "Business Trip",
     "transport_types.businessPlural": "Business Trips",

--- a/resources/views/includes/status.blade.php
+++ b/resources/views/includes/status.blade.php
@@ -129,7 +129,7 @@
     <div class="card-footer text-muted interaction">
         <span class="float-end like-text">
             <i class="fas
-{{["fa-globe-americas", "fa-lock-open", "fa-user-friends", "fa-lock"][$status->visibility->value]}} visibility-icon text-small"
+{{["fa-globe-americas", "fa-lock-open", "fa-user-friends", "fa-lock", "fa-user-check"][$status->visibility->value]}} visibility-icon text-small"
                aria-hidden="true" title="{{__('status.visibility.'.$status->visibility->value)}}"
                data-mdb-toggle="tooltip"
                data-mdb-placement="top"></i>

--- a/resources/views/includes/visibility-dropdown.blade.php
+++ b/resources/views/includes/visibility-dropdown.blade.php
@@ -5,14 +5,14 @@
             data-mdb-toggle="dropdown"
             aria-expanded="false"
     >
-        <i class="fa fa-{{['globe-americas', 'lock-open', 'user-friends', 'lock'][auth()->user()?->default_status_visibility->value ?? 0]}}"
+        <i class="fa fa-{{['globe-americas', 'lock-open', 'user-friends', 'lock', 'user-check'][auth()->user()?->default_status_visibility->value ?? 0]}}"
            aria-hidden="true"></i>
     </button>
     <ul class="dropdown-menu" aria-labelledby="visibilityDropdownButton">
         @foreach(\App\Enum\StatusVisibility::cases() as $visibility)
             @if(auth()->check() && auth()->user()->default_status_visibility?->value <= $visibility->value)
                 <li class="dropdown-item trwl-visibility-item" data-trwl-visibility="{{$visibility->value}}">
-                    <i class="fa fa-{{['globe-americas', 'lock-open', 'user-friends', 'lock'][$visibility->value]}}"
+                    <i class="fa fa-{{['globe-americas', 'lock-open', 'user-friends', 'lock', 'user-check'][$visibility->value]}}"
                        aria-hidden="true"></i> {{ __('status.visibility.' . $visibility->value) }}
                     <br/>
                     <span class="text-muted"> {{ __('status.visibility.' . $visibility->value . '.detail') }}</span>

--- a/tests/Feature/Privacy/Status/ViewTest.php
+++ b/tests/Feature/Privacy/Status/ViewTest.php
@@ -59,6 +59,17 @@ class ViewTest extends TestCase
         $statusRequest->assertStatus(403);
     }
 
+    public function testUnauthenticatedViewOnlyAuthenticatedUsersStatus(): void {
+        $user   = User::factory()->create();
+        $status = Status::factory(['user_id' => $user->id, 'visibility' => StatusVisibility::AUTHENTICATED])
+                        ->has(TrainCheckin::factory())
+                        ->create();
+
+        $this->assertGuest();
+        $statusRequest = $this->get(route('statuses.get', ['id' => $status->id]));
+        $statusRequest->assertStatus(403);
+    }
+
     public function testViewOwnStatus(): void {
         $user   = User::factory()->create();
         $status = Status::factory(['user_id' => $user->id])->create();
@@ -107,5 +118,15 @@ class ViewTest extends TestCase
                                            'visibility' => StatusVisibility::PRIVATE,
                                        ])->create();
         $this->assertFalse($user->can('view', $status));
+    }
+
+    public function testViewForeignOnlyAuthenticatedUsersStatus(): void {
+        $user        = User::factory()->create();
+        $foreignUser = User::factory()->create();
+        $status      = Status::factory([
+                                           'user_id'    => $foreignUser->id,
+                                           'visibility' => StatusVisibility::AUTHENTICATED
+                                       ])->create();
+        $this->assertTrue($user->can('view', $status));
     }
 }


### PR DESCRIPTION
This PR adds a new status visibility which allows users to only show their status to users which are logged in.
This is useful for users who may be a bit paranoid about random website visitors, but still want to participate publicly and let other people know when they are on the same train.