### PR TITLE
⚡ Improve access times for every status with an event

### DIFF
--- a/app/Http/Controllers/API/v1/EventController.php
+++ b/app/Http/Controllers/API/v1/EventController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\API\ResponseController;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\Backend\EventController as EventBackend;
 use App\Http\Resources\EventResource;
+use App\Http\Resources\EventDetailsResource;
 use App\Http\Resources\StatusResource;
 use App\Models\Event;
 use App\Models\User;
@@ -21,7 +22,9 @@ class EventController extends ResponseController
 {
     /**
      * Returns model of Event
+     *
      * @param string $slug
+     *
      * @return EventResource
      */
     public function show(string $slug): EventResource {
@@ -30,8 +33,22 @@ class EventController extends ResponseController
     }
 
     /**
-     * Returns paginated statuses for user
+     * Returns stats for event
+     *
      * @param string $slug
+     *
+     * @return EventDetailsResource
+     */
+    public function showDetails(string $slug): EventDetailsResource {
+        $event = EventBackend::getBySlug($slug);
+        return new EventDetailsResource($event);
+    }
+
+    /**
+     * Returns paginated statuses for user
+     *
+     * @param string $slug
+     *
      * @return AnonymousResourceCollection
      */
     public static function statuses(string $slug): AnonymousResourceCollection {

--- a/app/Http/Resources/EventDetailsResource.php
+++ b/app/Http/Resources/EventDetailsResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class EventDetailsResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param Request $request
+     *
+     * @return array
+     */
+    public function toArray($request): array {
+        return [
+            "id"            => $this->id,
+            "slug"          => $this->slug,
+            "trainDistance" => $this->trainDistance,
+            "trainDuration" => $this->trainDuration,
+        ];
+    }
+}

--- a/app/Http/Resources/EventResource.php
+++ b/app/Http/Resources/EventResource.php
@@ -24,8 +24,6 @@ class EventResource extends JsonResource
             "url"           => $this->url,
             "begin"         => $this->begin?->toIso8601String(),
             "end"           => $this->end?->toIso8601String(),
-            "trainDistance" => 0, //ToDo remove once properly migrated
-            "trainDuration" => 0, //ToDo remove once properly migrated
             "station"       => new TrainStationResource($this->station)
         ];
     }

--- a/app/Http/Resources/EventResource.php
+++ b/app/Http/Resources/EventResource.php
@@ -24,8 +24,8 @@ class EventResource extends JsonResource
             "url"           => $this->url,
             "begin"         => $this->begin?->toIso8601String(),
             "end"           => $this->end?->toIso8601String(),
-            "trainDistance" => $this->trainDistance,
-            "trainDuration" => $this->trainDuration,
+            "trainDistance" => 0, //ToDo remove once properly migrated
+            "trainDuration" => 0, //ToDo remove once properly migrated
             "station"       => new TrainStationResource($this->station)
         ];
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -123,6 +123,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
         Route::get('stopovers/{parameters}', [StatusController::class, 'getStopovers']);
         Route::get('polyline/{parameters}', [StatusController::class, 'getPolyline']);
         Route::get('event/{slug}', [EventController::class, 'show']);
+        Route::get('event/{slug}/details', [EventController::class, 'showDetails']);
         Route::get('event/{slug}/statuses', [EventController::class, 'statuses']);
         Route::get('events', [EventController::class, 'upcoming']);
         Route::get('user/{username}', [UserController::class, 'show']);


### PR DESCRIPTION
Due to very slow calculation times while adding up the traveled kilometers/hours for an event, the dashboard and single statuses got extremely slow. 

Closes #961 