### PR TITLE
🚀 add queue runner for the docker-compose setup

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,6 +35,20 @@ services:
     networks:
       - internal
 
+  queue:
+    image: ghcr.io/traewelling/traewelling:latest
+    container_name: traewelling-queue
+    restart: always
+    depends_on:
+      - db
+      - db-rest
+    environment:
+      - CONTAINER_ROLE=queue
+    env_file:
+      - .env.app
+    networks:
+      - internal
+
   db:
     image: mariadb:10
     container_name: traewelling-db


### PR DESCRIPTION
Was previously missing from the `docker/docker-compose.yml`, although it was added in the `docker-entrypoint.sh` file.