### PR TITLE
:children_crossing: Make the admin sidebar menu collapse on small devices

### DIFF
--- a/resources/views/admin/layout.blade.php
+++ b/resources/views/admin/layout.blade.php
@@ -18,56 +18,56 @@
                    class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-white text-decoration-none">
                     <img src="{{ asset('images/icons/touch-icon-vector.svg') }}" alt="{{ config('app.name') }} Logo"
                          class="brand-image me-3" style="width: 30px; opacity: 0.8">
-                    <span class="fs-4 d-md-none d-lg-inline">TRWL Admin</span>
+                    <span class="fs-4 d-none d-lg-inline">TRWL Admin</span>
                 </a>
                 <hr>
                 <ul class="nav nav-pills flex-column mb-auto">
                     <li class="nav-item">
                         <a href="{{ route('dashboard') }}" class="nav-link text-muted">
                             <i class="fas fa-backward me-2" aria-hidden="true"></i>
-                            <span class="d-md-none d-lg-inline">Zurück zu Träwelling</span>
+                            <span class="d-none d-lg-inline">Zurück zu Träwelling</span>
                         </a>
                     </li>
                     <li>
                         <a href="{{ route('admin.dashboard') }}"
                            class="nav-link text-white {{ request()->is('admin') ? 'active' : '' }}">
                             <i class="fas fa-tachometer-alt me-2" aria-hidden="true"></i>
-                            <span class="d-md-none d-lg-inline">Dashboard</span>
+                            <span class="d-none d-lg-inline">Dashboard</span>
                         </a>
                     </li>
                     <li>
                         <a href="{{route('admin.events')}}"
                            class="nav-link text-white {{ request()->is('admin/events*') ? 'active' : '' }}">
                             <i class="fas fa-calendar me-2" aria-hidden="true"></i>
-                            <span class="d-md-none d-lg-inline">Veranstaltungen</span>
+                            <span class="d-none d-lg-inline">Veranstaltungen</span>
                         </a>
                     </li>
                     <li>
                         <a href="{{ route('admin.status') }}"
                            class="nav-link text-white {{ request()->is('admin/status*') ? 'active' : '' }}">
                             <i class="fas fa-train me-2" aria-hidden="true"></i>
-                            <span class="d-md-none d-lg-inline">Status</span>
+                            <span class="d-none d-lg-inline">Status</span>
                         </a>
                     </li>
                     <li>
                         <a href="{{ route('admin.stationboard') }}"
                            class="nav-link text-white {{ request()->is('admin/checkin*') ? 'active' : '' }}">
                             <i class="fas fa-ticket-alt me-2" aria-hidden="true"></i>
-                            <span class="d-md-none d-lg-inline">Checkin</span>
+                            <span class="d-none d-lg-inline">Checkin</span>
                         </a>
                     </li>
                     <li>
                         <a href="{{ route('admin.users') }}"
                            class="nav-link text-white {{ request()->is('admin/users*') ? 'active' : '' }}">
                             <i class="fas fa-users me-2" aria-hidden="true"></i>
-                            <span class="d-md-none d-lg-inline">Users</span>
+                            <span class="d-none d-lg-inline">Users</span>
                         </a>
                     </li>
                     <li>
                         <a href="{{ route('admin.api.usage') }}"
                            class="nav-link text-white {{ request()->is('admin/api/usage*') ? 'active' : '' }}">
                             <i class="fa-solid fa-book me-2" aria-hidden="true"></i>
-                            <span class="d-md-none d-lg-inline">API Usage</span>
+                            <span class="d-none d-lg-inline">API Usage</span>
                         </a>
                     </li>
                 </ul>
@@ -78,7 +78,7 @@
                         <img
                             src="{{ \App\Http\Controllers\Backend\User\ProfilePictureController::getUrl(auth()->user()) }}"
                             alt="" width="32" height="32" class="rounded-circle me-2">
-                        <strong class="d-md-none d-lg-inline">{{auth()->user()->name}}</strong>
+                        <strong class="d-none d-lg-inline">{{auth()->user()->name}}</strong>
                     </a>
                     <ul class="dropdown-menu dropdown-menu-dark text-small shadow" aria-labelledby="dropdownUser1">
                         <li>


### PR DESCRIPTION
Now the admin sidebar menu stays collapsed on mobile devices. This makes the admin site on small devices usable again.


Before:
<img width="570" alt="image" src="https://user-images.githubusercontent.com/19869755/189489286-92bf94fe-08f6-4c44-acfb-da35efdf401f.png">


After:
<img width="592" alt="image" src="https://user-images.githubusercontent.com/19869755/189489246-732bdd16-1c9f-4fc7-b321-224f528372e4.png">