### PR TITLE
Add queue monitor to get insights in jobs system

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -31,6 +31,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('trwl:cleanUpDatabase')->dailyAt('1:50');
         $schedule->command('trwl:refreshTrips')->withoutOverlapping()->everyMinute();
         $schedule->command('trwl:hideStatus')->daily();
+        $schedule->command('queue_monitoring:cleanup')->daily();
     }
 
     /**

--- a/app/Jobs/FetchCarriageSequence.php
+++ b/app/Jobs/FetchCarriageSequence.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use romanzipp\QueueMonitor\Traits\IsMonitored;
+use Traewelling\QueueMonitor\Traits\IsMonitored;
 
 class FetchCarriageSequence implements ShouldQueue
 {

--- a/app/Jobs/FetchCarriageSequence.php
+++ b/app/Jobs/FetchCarriageSequence.php
@@ -9,10 +9,11 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use romanzipp\QueueMonitor\Traits\IsMonitored;
 
 class FetchCarriageSequence implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable, InteractsWithQueue, IsMonitored, Queueable, SerializesModels;
 
     private TrainStopover $stopover;
 
@@ -21,6 +22,10 @@ class FetchCarriageSequence implements ShouldQueue
     }
 
     public function handle(): void {
+        $this->queueData([
+                             "stopover" => $this->stopover->id,
+                             "for_trip" => $this->stopover->trip_id
+                         ]);
         CarriageSequenceController::fetchSequence($this->stopover);
     }
 }

--- a/app/Jobs/SendVerificationEmail.php
+++ b/app/Jobs/SendVerificationEmail.php
@@ -26,8 +26,7 @@ class SendVerificationEmail implements ShouldQueue
      *
      * @return void
      */
-    public function __construct(User $user)
-    {
+    public function __construct(User $user) {
         $this->user = $user;
     }
 
@@ -36,10 +35,9 @@ class SendVerificationEmail implements ShouldQueue
      *
      * @return void
      */
-    public function handle()
-    {
+    public function handle(): void {
         $this->queueData([
-                             "user_id" => $this->user->id,
+                             "user_id"  => $this->user->id,
                              "username" => $this->user->username,
                          ]);
 

--- a/app/Jobs/SendVerificationEmail.php
+++ b/app/Jobs/SendVerificationEmail.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Traewelling\QueueMonitor\Traits\IsMonitored;
+
+/**
+ * Send the Email which verifies a user account asynchronously.
+ * @see https://aregsar.com/blog/2020/how-to-queue-laravel-user-verification-email/
+ */
+class SendVerificationEmail implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, IsMonitored, Queueable, SerializesModels;
+
+    protected User $user;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(User $user)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->queueData([
+                             "user_id" => $this->user->id,
+                             "username" => $this->user->username,
+                         ]);
+
+        // This queued job sends
+        // Illuminate\Auth\Notifications\VerifyEmail verification
+        // to the user by triggering the notification
+        $this->user->notify(new VerifyEmail);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enum\StatusVisibility;
+use App\Jobs\SendVerificationEmail;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
@@ -234,5 +235,9 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     public function notifications(): MorphMany {
         return $this->morphMany(DatabaseNotification::class, 'notifiable')->orderBy('created_at', 'desc');
+    }
+
+    public function sendEmailVerificationNotification() {
+        SendVerificationEmail::dispatch($this);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -237,7 +237,7 @@ class User extends Authenticatable implements MustVerifyEmail
         return $this->morphMany(DatabaseNotification::class, 'notifiable')->orderBy('created_at', 'desc');
     }
 
-    public function sendEmailVerificationNotification() {
+    public function sendEmailVerificationNotification(): void {
         SendVerificationEmail::dispatch($this);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "laravel/ui": "^3.0",
         "mrkriskrisu/db-wagenreihung-php": "0.2",
         "revolution/laravel-mastodon-api": "^2.0",
+        "romanzipp/laravel-queue-monitor": "^2.3",
         "spatie/icalendar-generator": "^2.0",
         "spatie/laravel-sitemap": "^6.0",
         "trwl/socialite-mastodon": "^1.2"

--- a/composer.json
+++ b/composer.json
@@ -36,9 +36,9 @@
         "laravel/ui": "^3.0",
         "mrkriskrisu/db-wagenreihung-php": "0.2",
         "revolution/laravel-mastodon-api": "^2.0",
-        "romanzipp/laravel-queue-monitor": "^2.3",
         "spatie/icalendar-generator": "^2.0",
         "spatie/laravel-sitemap": "^6.0",
+        "trwl/laravel-queue-monitor": "2.1.1",
         "trwl/socialite-mastodon": "^1.2"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e14ab6e7409f719dd4fd82349cdf959",
+    "content-hash": "d03b1b96ada2592f311ee7490298ca6d",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -6346,6 +6346,75 @@
                 "source": "https://github.com/kawax/laravel-mastodon-api/tree/2.4.0"
             },
             "time": "2021-01-01T09:05:44+00:00"
+        },
+        {
+            "name": "romanzipp/laravel-queue-monitor",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/romanzipp/Laravel-Queue-Monitor.git",
+                "reference": "818cecb89d8fcaedc1919da062d7cec6ac1d35bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/romanzipp/Laravel-Queue-Monitor/zipball/818cecb89d8fcaedc1919da062d7cec6ac1d35bd",
+                "reference": "818cecb89d8fcaedc1919da062d7cec6ac1d35bd",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "illuminate/database": "^5.5|^6.0|^7.0|^8.0|^9.0",
+                "illuminate/queue": "^5.5|^6.0|^7.0|^8.0|^9.0",
+                "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0",
+                "nesbot/carbon": "^2.0",
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "laravel/framework": "^5.5|^6.0|^7.0|^8.0|^9.0",
+                "mockery/mockery": "^1.3.2",
+                "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0",
+                "phpstan/phpstan": "^0.12.99|^1.0",
+                "phpunit/phpunit": "^8.0|^9.0",
+                "romanzipp/php-cs-fixer-config": "^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "romanzipp\\QueueMonitor\\Providers\\QueueMonitorProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "romanzipp\\QueueMonitor\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "romanzipp",
+                    "email": "ich@ich.wtf",
+                    "homepage": "https://ich.wtf"
+                }
+            ],
+            "description": "Queue Monitoring for Laravel Database Job Queue",
+            "support": {
+                "issues": "https://github.com/romanzipp/Laravel-Queue-Monitor/issues",
+                "source": "https://github.com/romanzipp/Laravel-Queue-Monitor/tree/2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/romanzipp",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-08T16:25:09+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d03b1b96ada2592f311ee7490298ca6d",
+    "content-hash": "9dac7017da0a004ec68fbf67045d46b7",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -6348,75 +6348,6 @@
             "time": "2021-01-01T09:05:44+00:00"
         },
         {
-            "name": "romanzipp/laravel-queue-monitor",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/romanzipp/Laravel-Queue-Monitor.git",
-                "reference": "818cecb89d8fcaedc1919da062d7cec6ac1d35bd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/romanzipp/Laravel-Queue-Monitor/zipball/818cecb89d8fcaedc1919da062d7cec6ac1d35bd",
-                "reference": "818cecb89d8fcaedc1919da062d7cec6ac1d35bd",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "illuminate/database": "^5.5|^6.0|^7.0|^8.0|^9.0",
-                "illuminate/queue": "^5.5|^6.0|^7.0|^8.0|^9.0",
-                "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0",
-                "nesbot/carbon": "^2.0",
-                "php": "^7.2|^8.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.0",
-                "laravel/framework": "^5.5|^6.0|^7.0|^8.0|^9.0",
-                "mockery/mockery": "^1.3.2",
-                "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0",
-                "phpstan/phpstan": "^0.12.99|^1.0",
-                "phpunit/phpunit": "^8.0|^9.0",
-                "romanzipp/php-cs-fixer-config": "^3.0"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "romanzipp\\QueueMonitor\\Providers\\QueueMonitorProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "romanzipp\\QueueMonitor\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "romanzipp",
-                    "email": "ich@ich.wtf",
-                    "homepage": "https://ich.wtf"
-                }
-            ],
-            "description": "Queue Monitoring for Laravel Database Job Queue",
-            "support": {
-                "issues": "https://github.com/romanzipp/Laravel-Queue-Monitor/issues",
-                "source": "https://github.com/romanzipp/Laravel-Queue-Monitor/tree/2.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/romanzipp",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-02-08T16:25:09+00:00"
-        },
-        {
             "name": "sabberworm/php-css-parser",
             "version": "8.4.0",
             "source": {
@@ -10619,6 +10550,85 @@
                 "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/2.2.5"
             },
             "time": "2022-09-12T13:28:28+00:00"
+        },
+        {
+            "name": "trwl/laravel-queue-monitor",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Traewelling/Laravel-Queue-Monitor.git",
+                "reference": "963f5d2f3189eac54cd7015ad0754f477dcdad70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Traewelling/Laravel-Queue-Monitor/zipball/963f5d2f3189eac54cd7015ad0754f477dcdad70",
+                "reference": "963f5d2f3189eac54cd7015ad0754f477dcdad70",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "illuminate/console": "^5.5|^6.0|^7.0|^8.0|^9.0",
+                "illuminate/database": "^5.5|^6.0|^7.0|^8.0|^9.0",
+                "illuminate/queue": "^5.5|^6.0|^7.0|^8.0|^9.0",
+                "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0",
+                "nesbot/carbon": "^2.0",
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "laravel/framework": "^5.5|^6.0|^7.0|^8.0|^9.0",
+                "mockery/mockery": "^1.3.2",
+                "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0",
+                "phpstan/phpstan": "^0.12.99|^1.0",
+                "phpunit/phpunit": "^8.0|^9.0",
+                "romanzipp/php-cs-fixer-config": "^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Traewelling\\QueueMonitor\\Providers\\QueueMonitorProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Traewelling\\QueueMonitor\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "romanzipp",
+                    "email": "ich@ich.wtf",
+                    "homepage": "https://ich.wtf"
+                },
+                {
+                    "name": "Jannik",
+                    "email": "jannik@outlook.com",
+                    "homepage": "https://traewelling.de"
+                },
+                {
+                    "name": "The Träwelling Team",
+                    "email": "support@traewelling.de",
+                    "homepage": "https://traewelling.de"
+                }
+            ],
+            "description": "Queue Monitoring for Laravel Database Job Queue",
+            "support": {
+                "source": "https://github.com/Traewelling/Laravel-Queue-Monitor/tree/v2.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/romanzipp",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-19T21:43:00+00:00"
         },
         {
             "name": "trwl/socialite-mastodon",

--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -1,0 +1,55 @@
+<?php
+
+return [
+    /*
+     * Set the table to be used for monitoring data.
+     */
+    'table' => 'queue_monitor',
+    'connection' => null,
+
+    /*
+     * Set the model used for monitoring.
+     * If using a custom model, be sure to implement the
+     *   romanzipp\QueueMonitor\Models\Contracts\MonitorContract
+     * interface or extend the base model.
+     */
+    'model' => \romanzipp\QueueMonitor\Models\Monitor::class,
+
+    /*
+     * Specify the max character length to use for storing exception backtraces.
+     */
+    'db_max_length_exception' => 4294967295,
+    'db_max_length_exception_message' => 65535,
+
+    /*
+     * The optional UI settings.
+     */
+    'ui' => [
+        /*
+         * Set the monitored jobs count to be displayed per page.
+         */
+        'per_page' => 35,
+
+        /*
+         *  Show custom data stored on model
+         */
+        'show_custom_data' => true,
+
+        /**
+         * Allow the deletion of single monitor items.
+         */
+        'allow_deletion' => true,
+
+        /**
+         * Allow purging all monitor entries.
+         */
+        'allow_purge' => true,
+
+        'show_metrics' => true,
+
+        /**
+         * Time frame used to calculate metrics values (in days).
+         */
+        'metrics_time_frame' => 14,
+    ],
+];

--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -13,13 +13,19 @@ return [
      *   romanzipp\QueueMonitor\Models\Contracts\MonitorContract
      * interface or extend the base model.
      */
-    'model' => \romanzipp\QueueMonitor\Models\Monitor::class,
+    'model' => \Traewelling\QueueMonitor\Models\Monitor::class,
 
     /*
      * Specify the max character length to use for storing exception backtraces.
      */
     'db_max_length_exception' => 4294967295,
     'db_max_length_exception_message' => 65535,
+
+    /*
+     * Set the retention time of the monitoring logs. To create accurate aggregations, this number
+     * should at least be double the `metrics_time_frame`.
+     */
+    'delete_old_items_after_days' => 28,
 
     /*
      * The optional UI settings.

--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -4,8 +4,8 @@ return [
     /*
      * Set the table to be used for monitoring data.
      */
-    'table' => 'queue_monitor',
-    'connection' => null,
+    'table'                           => 'queue_monitor',
+    'connection'                      => null,
 
     /*
      * Set the model used for monitoring.
@@ -13,45 +13,48 @@ return [
      *   romanzipp\QueueMonitor\Models\Contracts\MonitorContract
      * interface or extend the base model.
      */
-    'model' => \Traewelling\QueueMonitor\Models\Monitor::class,
+    'model'                           => \Traewelling\QueueMonitor\Models\Monitor::class,
 
     /*
      * Specify the max character length to use for storing exception backtraces.
      */
-    'db_max_length_exception' => 4294967295,
+    'db_max_length_exception'         => 4294967295,
     'db_max_length_exception_message' => 65535,
 
     /*
      * Set the retention time of the monitoring logs. To create accurate aggregations, this number
      * should at least be double the `metrics_time_frame`.
      */
-    'delete_old_items_after_days' => 28,
+    'delete_old_items_after_days'     => 28,
 
     /*
      * The optional UI settings.
      */
-    'ui' => [
+    'ui'                              => [
         /*
          * Set the monitored jobs count to be displayed per page.
          */
-        'per_page' => 35,
+        'per_page'           => 35,
 
         /*
          *  Show custom data stored on model
          */
-        'show_custom_data' => true,
+        'show_custom_data'   => true,
 
         /**
          * Allow the deletion of single monitor items.
          */
-        'allow_deletion' => true,
+        'allow_deletion'     => true,
 
         /**
          * Allow purging all monitor entries.
          */
-        'allow_purge' => true,
+        'allow_purge'        => true,
 
-        'show_metrics' => true,
+        /**
+         * Show the aggregation metrics in the dashboard.
+         */
+        'show_metrics'       => true,
 
         /**
          * Time frame used to calculate metrics values (in days).

--- a/database/migrations/2018_02_05_000000_create_queue_monitor_table.php
+++ b/database/migrations/2018_02_05_000000_create_queue_monitor_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateQueueMonitorTable extends Migration
+{
+    public function up()
+    {
+        Schema::create(config('queue-monitor.table'), function (Blueprint $table) {
+            $table->increments('id');
+
+            $table->string('job_id')->index();
+            $table->string('name')->nullable();
+            $table->string('queue')->nullable();
+
+            $table->timestamp('started_at')->nullable()->index();
+            $table->string('started_at_exact')->nullable();
+
+            $table->timestamp('finished_at')->nullable();
+            $table->string('finished_at_exact')->nullable();
+
+            $table->float('time_elapsed', 12, 6)->nullable()->index();
+
+            $table->boolean('failed')->default(false)->index();
+
+            $table->integer('attempt')->default(0);
+            $table->integer('progress')->nullable();
+
+            $table->longText('exception')->nullable();
+            $table->text('exception_message')->nullable();
+            $table->text('exception_class')->nullable();
+
+            $table->longText('data')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::drop(config('queue-monitor.table'));
+    }
+}

--- a/database/migrations/2018_02_05_000000_create_queue_monitor_table.php
+++ b/database/migrations/2018_02_05_000000_create_queue_monitor_table.php
@@ -6,10 +6,10 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateQueueMonitorTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create(config('queue-monitor.table'), function (Blueprint $table) {
-            $table->increments('id');
+            $table->id();
 
             $table->string('job_id')->index();
             $table->string('name')->nullable();
@@ -36,7 +36,7 @@ class CreateQueueMonitorTable extends Migration
         });
     }
 
-    public function down()
+    public function down(): void
     {
         Schema::drop(config('queue-monitor.table'));
     }

--- a/resources/views/admin/layout.blade.php
+++ b/resources/views/admin/layout.blade.php
@@ -66,7 +66,7 @@
                     <li>
                         <a href="{{ route('admin.locations') }}"
                            class="nav-link text-white {{ request()->is('admin/locations*') ? 'active' : '' }}">
-                            <i class="fa-solid fa-location-dot" aria-hidden="true"></i>
+                            <i class="fa-solid fa-map-location-dot me-2" aria-hidden="true"></i>
                             <span class="d-md-none d-lg-inline">Locations</span>
                         </a>
                     </li>
@@ -75,6 +75,12 @@
                            class="nav-link text-white {{ request()->is('admin/api/usage*') ? 'active' : '' }}">
                             <i class="fa-solid fa-book me-2" aria-hidden="true"></i>
                             <span class="d-none d-lg-inline">API Usage</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="{{ route("queue-monitor::index") }}" class="nav-link text-white }}">
+                            <i class="fa-solid fa-list-check me-2" aria-hidden="true"></i>
+                            <span class="d-none d-lg-inline">Queue Monitoring</span>
                         </a>
                     </li>
                 </ul>

--- a/resources/views/vendor/queue-monitor/jobs.blade.php
+++ b/resources/views/vendor/queue-monitor/jobs.blade.php
@@ -1,0 +1,334 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>@lang('Queue Monitor')</title>
+
+    <link href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css" rel="stylesheet">
+
+</head>
+
+<body class="font-sans p-6 pb-64 bg-gray-100">
+
+    <h1 class="mb-6 text-5xl text-blue-900 font-bold">
+        @lang('Queue Monitor')
+    </h1>
+
+    @isset($metrics)
+
+        <div class="flex flex-wrap -mx-4 mb-2">
+
+            @foreach($metrics->all() as $metric)
+
+                @include('queue-monitor::partials.metrics-card', [
+                    'metric' => $metric,
+                ])
+
+            @endforeach
+
+        </div>
+
+    @endisset
+
+    <div class="px-6 py-4 mb-6 pl-4 bg-white rounded-md shadow-md">
+
+        <h2 class="mb-4 text-2xl font-bold text-blue-900">
+            @lang('Filter')
+        </h2>
+
+        <form action="" method="get">
+
+            <div class="flex items-center my-2 -mx-2">
+
+                <div class="px-2 w-1/4">
+                    <label for="filter_show" class="block mb-1 text-xs uppercase font-semibold text-gray-600">
+                        @lang('Show jobs')
+                    </label>
+                    <select name="type" id="filter_show" class="w-full p-2 bg-gray-200 border-2 border-gray-300 rounded">
+                        <option @if($filters['type'] === 'all') selected @endif value="all">@lang('All')</option>
+                        <option @if($filters['type'] === 'running') selected @endif value="running">@lang('Running')</option>
+                        <option @if($filters['type'] === 'failed') selected @endif value="failed">@lang('Failed')</option>
+                        <option @if($filters['type'] === 'succeeded') selected @endif value="succeeded">@lang('Succeeded')</option>
+                    </select>
+                </div>
+
+                <div class="px-2 w-1/4">
+                    <label for="filter_queues" class="block mb-1 text-xs uppercase font-semibold text-gray-600">
+                        @lang('Queues')
+                    </label>
+                    <select name="queue" id="filter_queues" class="w-full p-2 bg-gray-200 border-2 border-gray-300 rounded">
+                        <option value="all">All</option>
+                        @foreach($queues as $queue)
+                            <option @if($filters['queue'] === $queue) selected @endif value="{{ $queue }}">
+                                {{ __($queue) }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+
+            </div>
+
+            <div class="mt-4">
+
+                <button type="submit" class="px-5 py-2 bg-blue-600 hover:bg-blue-700 text-xs font-medium uppercase tracking-wider text-white rounded">
+                    @lang('Filter')
+                </button>
+
+            </div>
+
+        </form>
+
+    </div>
+
+    <div class="overflow-x-auto shadow-lg">
+
+        <table class="w-full rounded whitespace-no-wrap">
+
+            <thead class="bg-gray-200">
+
+                <tr>
+                    <th class="px-4 py-3 font-medium text-left text-xs text-gray-600 uppercase border-b border-gray-200">@lang('Status')</th>
+                    <th class="px-4 py-3 font-medium text-left text-xs text-gray-600 uppercase border-b border-gray-200">@lang('Job')</th>
+                    <th class="px-4 py-3 font-medium text-left text-xs text-gray-600 uppercase border-b border-gray-200">@lang('Details')</th>
+
+                    @if(config('queue-monitor.ui.show_custom_data'))
+                        <th class="px-4 py-3 font-medium text-left text-xs text-gray-600 uppercase border-b border-gray-200">@lang('Custom Data')</th>
+                    @endif
+
+                    <th class="px-4 py-3 font-medium text-left text-xs text-gray-600 uppercase border-b border-gray-200">@lang('Progress')</th>
+                    <th class="px-4 py-3 font-medium text-left text-xs text-gray-600 uppercase border-b border-gray-200">@lang('Duration')</th>
+                    <th class="px-4 py-3 font-medium text-left text-xs text-gray-600 uppercase border-b border-gray-200">@lang('Started')</th>
+                    <th class="px-4 py-3 font-medium text-left text-xs text-gray-600 uppercase border-b border-gray-200">@lang('Error')</th>
+
+                    @if(config('queue-monitor.ui.allow_deletion'))
+                        <th class="px-4 py-3 font-medium text-left text-xs text-gray-600 uppercase border-b border-gray-200">@lang('Action')</th>
+                    @endif
+                </tr>
+
+            </thead>
+
+            <tbody class="bg-white">
+
+                @forelse($jobs as $job)
+
+                    <tr class="font-sm leading-relaxed">
+
+                        <td class="p-4 text-gray-800 text-sm leading-5 border-b border-gray-200">
+
+                            @if(!$job->isFinished())
+
+                                <div class="inline-flex flex-1 px-2 text-xs font-medium leading-5 rounded-full bg-blue-200 text-blue-800">
+                                    @lang('Running')
+                                </div>
+
+                            @elseif($job->hasSucceeded())
+
+                                <div class="inline-flex flex-1 px-2 text-xs font-medium leading-5 rounded-full bg-green-200 text-green-800">
+                                    @lang('Success')
+                                </div>
+
+                            @else
+
+                                <div class="inline-flex flex-1 px-2 text-xs font-medium leading-5 rounded-full bg-red-200 text-red-800">
+                                    @lang('Failed')
+                                </div>
+
+                            @endif
+
+                        </td>
+
+                        <td class="p-4 text-gray-800 text-sm leading-5 font-medium border-b border-gray-200">
+
+                            {{ $job->getBaseName() }}
+
+                            <span class="ml-1 text-xs text-gray-600">
+                                #{{ $job->job_id }}
+                            </span>
+
+                        </td>
+
+                        <td class="p-4 text-gray-800 text-sm leading-5 border-b border-gray-200">
+
+                            <div class="text-xs">
+                                <span class="text-gray-600 font-medium">@lang('Queue'):</span>
+                                <span class="font-semibold">{{ $job->queue }}</span>
+                            </div>
+
+                            <div class="text-xs">
+                                <span class="text-gray-600 font-medium">@lang('Attempt'):</span>
+                                <span class="font-semibold">{{ $job->attempt }}</span>
+                            </div>
+
+                        </td>
+
+                        @if(config('queue-monitor.ui.show_custom_data'))
+
+                            <td class="p-4 text-gray-800 text-sm leading-5 border-b border-gray-200">
+
+                                    <textarea rows="4"
+                                              class="w-64 text-xs p-1 border rounded"
+                                              readonly>{{ json_encode($job->getData(), JSON_PRETTY_PRINT) }}
+                                    </textarea>
+
+                            </td>
+
+                        @endif
+
+                        <td class="p-4 text-gray-800 text-sm leading-5 border-b border-gray-200">
+
+                            @if($job->progress !== null)
+
+                                <div class="w-32">
+
+                                    <div class="flex items-stretch h-3 rounded-full bg-gray-300 overflow-hidden">
+                                        <div class="h-full bg-green-500" style="width: {{ $job->progress }}%"></div>
+                                    </div>
+
+                                    <div class="flex justify-center mt-1 text-xs text-gray-800 font-semibold">
+                                        {{ $job->progress }}%
+                                    </div>
+
+                                </div>
+
+                            @else
+                                -
+                            @endif
+
+                        </td>
+
+                        <td class="p-4 text-gray-800 text-sm leading-5 border-b border-gray-200">
+                            {{ $job->getElapsedInterval()->format('%H:%I:%S') }}
+                        </td>
+
+                        <td class="p-4 text-gray-800 text-sm leading-5 border-b border-gray-200">
+                            {{ $job->started_at->diffForHumans() }}
+                        </td>
+
+                        <td class="p-4 text-gray-800 text-sm leading-5 border-b border-gray-200">
+
+                            @if($job->hasFailed() && $job->exception_message !== null)
+
+                                <textarea rows="4" class="w-64 text-xs p-1 border rounded" readonly>{{ $job->exception_message }}</textarea>
+
+                            @else
+                                -
+                            @endif
+
+                        </td>
+
+                        @if(config('queue-monitor.ui.allow_deletion'))
+
+                            <td class="p-4 text-gray-800 text-sm leading-5 border-b border-gray-200">
+
+                                <form action="{{ route('queue-monitor::destroy', [$job]) }}" method="post">
+
+                                    @csrf
+                                    @method('delete')
+
+                                    <button class="px-3 py-1 bg-red-200 hover:bg-red-300 text-red-800 text-xs font-medium uppercase tracking-wider text-white rounded">
+                                        @lang('Delete')
+                                    </button>
+
+                                </form>
+
+                            </td>
+
+                        @endif
+
+                    </tr>
+
+                @empty
+
+                    <tr>
+
+                        <td colspan="100" class="">
+
+                            <div class="my-6">
+
+                                <div class="text-center">
+
+                                    <div class="text-gray-500 text-lg">
+                                        @lang('No Jobs')
+                                    </div>
+
+                                </div>
+
+                            </div>
+
+                        </td>
+
+                    </tr>
+
+                @endforelse
+
+            </tbody>
+
+            <tfoot class="bg-white">
+
+                <tr>
+
+                    <td colspan="100" class="px-6 py-4 text-gray-700 font-sm border-t-2 border-gray-200">
+
+                        <div class="flex justify-between">
+
+                            <div>
+                                @lang('Showing')
+                                @if($jobs->total() > 0)
+                                    <span class="font-medium">{{ $jobs->firstItem() }}</span> @lang('to')
+                                    <span class="font-medium">{{ $jobs->lastItem() }}</span> @lang('of')
+                                @endif
+                                <span class="font-medium">{{ $jobs->total() }}</span> @lang('result')
+                            </div>
+
+                            <div>
+
+                                <a class="py-2 px-4 mx-1 text-xs font-medium @if(!$jobs->onFirstPage()) bg-gray-200 hover:bg-gray-300 cursor-pointer @else text-gray-600 bg-gray-100 cursor-not-allowed @endif rounded"
+                                   @if(!$jobs->onFirstPage()) href="{{ $jobs->previousPageUrl() }}" @endif>
+                                    @lang('Previous')
+                                </a>
+
+                                <a class="py-2 px-4 mx-1 text-xs font-medium @if($jobs->hasMorePages()) bg-gray-200 hover:bg-gray-300 cursor-pointer @else text-gray-600 bg-gray-100 cursor-not-allowed @endif rounded"
+                                   @if($jobs->hasMorePages()) href="{{ $jobs->url($jobs->currentPage() + 1) }}" @endif>
+                                    @lang('Next')
+                                </a>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+
+                </tr>
+
+            </tfoot>
+
+        </table>
+
+    </div>
+
+    @if(config('queue-monitor.ui.allow_purge'))
+
+        <div class="mt-12">
+
+            <form action="{{ route('queue-monitor::purge') }}" method="post">
+
+                @csrf
+                @method('delete')
+
+                <button class="px-3 py-1 bg-red-200 hover:bg-red-300 text-red-800 text-xs font-medium uppercase tracking-wider text-white rounded">
+                    @lang('Delete all entries')
+                </button>
+
+            </form>
+
+        </div>
+
+    @endif
+
+</body>
+
+</html>

--- a/resources/views/vendor/queue-monitor/jobs.blade.php
+++ b/resources/views/vendor/queue-monitor/jobs.blade.php
@@ -201,7 +201,7 @@
                         </td>
 
                         <td class="p-4 text-gray-800 text-sm leading-5 border-b border-gray-200">
-                            {{ $job->getElapsedInterval()->format('%H:%I:%S') }}
+                            {{ $job->getElapsedInterval()->format('%H:%I:%S.%F') }}
                         </td>
 
                         <td class="p-4 text-gray-800 text-sm leading-5 border-b border-gray-200">

--- a/resources/views/vendor/queue-monitor/partials/metrics-card.blade.php
+++ b/resources/views/vendor/queue-monitor/partials/metrics-card.blade.php
@@ -1,0 +1,39 @@
+<div class="w-full md:w-1/3 px-4 mb-4">
+
+    <div class="h-full flex flex-col justify-between p-6 bg-white rounded shadow-md">
+
+        <div class="font-semibold text-sm text-gray-600"
+             title="{{ __('Last :days days', ['days' => config('queue-monitor.ui.metrics_time_frame') ?? 14]) }}">
+            {{ __($metric->title) }}
+        </div>
+
+        <div>
+
+            <div class="mt-2 text-3xl">
+                {{ $metric->format($metric->value) }}
+            </div>
+
+            @if($metric->previousValue !== null)
+
+                <div class="mt-2 text-sm font-semibold {{ $metric->hasChanged() ? ($metric->hasIncreased() ? 'text-green-700' : 'text-red-800') : 'text-gray-800' }}">
+
+                    @if($metric->hasChanged())
+                        @if($metric->hasIncreased())
+                            @lang('Up from')
+                        @else
+                            @lang('Down from')
+                        @endif
+                    @else
+                        @lang('No change from')
+                    @endif
+
+                    {{ $metric->format($metric->previousValue) }}
+                </div>
+
+            @endif
+
+        </div>
+
+    </div>
+
+</div>

--- a/routes/web/admin.php
+++ b/routes/web/admin.php
@@ -78,4 +78,8 @@ Route::prefix('admin')->middleware(['auth', 'userrole:5'])->group(function() {
              ->name('admin.events.edit');
         Route::post('/edit/{id}', [AdminEventController::class, 'edit']);
     });
+
+    Route::prefix('queue-monitor')->group(function() {
+        Route::queueMonitor();
+    });
 });


### PR DESCRIPTION
Uses [laravel-queue-monitor](https://github.com/Traewelling/Laravel-Queue-Monitor) instead of [Laravel Horizon](https://github.com/laravel/horizon) since its simpler, and doesn't rely on Redis. 

Here is how the system could look like:
![screenshot_queue-monitor](https://user-images.githubusercontent.com/2796271/191224377-95d47796-66e2-452d-9ee2-55bd9d81e076.png)


~~Open issues (that could be mitigated by sending PRs to the package):~~
* ~~sub-second jobs are not displayed properly. I think this is a problem with the package that can be fixed through a package update later. The database holds the `time_elapsed` correctly though (see screenshot below), so we could still use the data to observe performance issues.~~
* ~~As far as I can tell, there is no autopurge of old messages (i.e. after two weeks). _Dadurch Gefahr des Datenbank Vollscheißens 💩 ._ We could build this manually as another scheduled job or [add the scheduled job to the package](https://laracasts.com/discuss/channels/laravel/task-scheduling-in-packages?page=1&replyId=181270).~~

<img width="500" alt="image" src="https://user-images.githubusercontent.com/2796271/191012462-f21854d2-5686-4cd4-a13c-2f9ac74c30a3.png">

This will obviously get better once we make other tasks async (see Discord discussion).