### PR TITLE
:mute: silence "file not found" error in VersionController

### DIFF
--- a/app/Http/Controllers/Backend/VersionController.php
+++ b/app/Http/Controllers/Backend/VersionController.php
@@ -15,7 +15,7 @@ abstract class VersionController extends Controller
     }
 
     private static function get_git_HEAD(): bool|string {
-        if ($head = file_get_contents(base_path() . '/.git/HEAD')) {
+        if ($head = @file_get_contents(base_path() . '/.git/HEAD')) {
             return substr($head, 5, -1);
         }
         return false;
@@ -23,7 +23,7 @@ abstract class VersionController extends Controller
 
     private static function getCurrentGitCommit(): bool|string {
         try {
-            if ($hash = file_get_contents(base_path() . '/.git/' . self::get_git_HEAD())) {
+            if ($hash = @file_get_contents(base_path() . '/.git/' . self::get_git_HEAD())) {
                 return $hash;
             }
         } catch (Exception $exception) {


### PR DESCRIPTION
When developing with Docker, the `VersionController` writes a bunch of errors to the log file, since it cannot access the `.git` folder. However, the code already deals with a falsy `file_get_contents` return value, rendering the error unnecessary.

To remove the clutter in the laravel logs and allow for reasonable usage of the log when developing using the Docker image, I propose to [silence](https://www.php.net/manual/en/language.operators.errorcontrol.php) the error at this point.