### PR TITLE
Queue Monitoring, stripped down

### DIFF
--- a/app/Http/Controllers/Backend/Social/MastodonController.php
+++ b/app/Http/Controllers/Backend/Social/MastodonController.php
@@ -126,6 +126,7 @@ abstract class MastodonController extends Controller
             $mastodonDomain = MastodonServer::find($status->user->socialProfile->mastodon_server)->domain;
             Mastodon::domain($mastodonDomain)->token($status->user->socialProfile->mastodon_token);
             Mastodon::createStatus($statusText, ['visibility' => 'unlisted']);
+            Log::info("Posted on Mastodon (domain=" . $mastodonDomain . "): " . $statusText);
         } catch (RequestException $e) {
             $status->user->notify(new MastodonNotSent($e->getResponse()?->getStatusCode(), $status));
         } catch (Exception $e) {

--- a/app/Http/Controllers/Backend/Social/TwitterController.php
+++ b/app/Http/Controllers/Backend/Social/TwitterController.php
@@ -106,6 +106,7 @@ abstract class TwitterController extends Controller
             if ($connection->getLastHttpCode() !== 200) {
                 $status->user->notify(new TwitterNotSent($connection->getLastHttpCode(), $status));
             }
+            Log::info("Posted on Twitter: " . $socialText);
         } catch (NotConnectedException $exception) {
             throw $exception;
         } catch (Exception $exception) {

--- a/app/Http/Controllers/Backend/Transport/TrainCheckinController.php
+++ b/app/Http/Controllers/Backend/Transport/TrainCheckinController.php
@@ -87,12 +87,12 @@ abstract class TrainCheckinController extends Controller
 
             PostStatusOnTwitter::dispatchIf($postOnTwitter
                                             && $user?->socialProfile?->twitter_id !== null
-                                            && config('trwl.post_social') == true,
+                                            && config('trwl.post_social') === true,
                                             $status);
 
             PostStatusOnMastodon::dispatchIf($postOnMastodon
                                              && $user->socialProfile?->mastodon_id
-                                             && config('trwl.post_social') == true,
+                                             && config('trwl.post_social') === true,
                                              $status);
 
             return $trainCheckinResponse;

--- a/app/Jobs/FetchCarriageSequence.php
+++ b/app/Jobs/FetchCarriageSequence.php
@@ -9,10 +9,11 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use romanzipp\QueueMonitor\Traits\IsMonitored;
 
 class FetchCarriageSequence implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable, InteractsWithQueue, IsMonitored, Queueable, SerializesModels;
 
     private TrainStopover $stopover;
 
@@ -21,6 +22,10 @@ class FetchCarriageSequence implements ShouldQueue
     }
 
     public function handle(): void {
+        $this->queueData([
+                             "stopover" => $this->stopover->id,
+                             "for_trip" => $this->stopover->trip_id
+                         ]);
         CarriageSequenceController::fetchSequence($this->stopover);
     }
 }

--- a/app/Jobs/PostStatusOnMastodon.php
+++ b/app/Jobs/PostStatusOnMastodon.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Exceptions\NotConnectedException;
+use App\Http\Controllers\Backend\Social\MastodonController;
+use App\Models\Status;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use romanzipp\QueueMonitor\Traits\IsMonitored;
+
+class PostStatusOnMastodon implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, IsMonitored, Queueable, SerializesModels;
+
+    protected Status $status;
+
+    public function __construct(Status $status) {
+        $this->status = $status;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     * @throws NotConnectedException
+     */
+    public function handle(): void {
+        $this->queueData([
+                             "status_id" => $this->status->id
+                         ]);
+
+        MastodonController::postStatus($this->status);
+    }
+}

--- a/app/Jobs/PostStatusOnTwitter.php
+++ b/app/Jobs/PostStatusOnTwitter.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Exceptions\NotConnectedException;
+use App\Http\Controllers\Backend\Social\TwitterController;
+use App\Models\Status;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use romanzipp\QueueMonitor\Traits\IsMonitored;
+
+class PostStatusOnTwitter implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, IsMonitored, Queueable, SerializesModels;
+
+    protected Status $status;
+
+    public function __construct(Status $status) {
+        $this->status = $status;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     * @throws NotConnectedException
+     */
+    public function handle(): void {
+        $this->queueData([
+                             "status_id" => $this->status->id
+                         ]);
+
+        TwitterController::postStatus($this->status);
+    }
+}

--- a/app/Jobs/SendVerificationEmail.php
+++ b/app/Jobs/SendVerificationEmail.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use romanzipp\QueueMonitor\Traits\IsMonitored;
+
+/**
+ * Send the Email which verifies a user account asynchronously.
+ * @see https://aregsar.com/blog/2020/how-to-queue-laravel-user-verification-email/
+ */
+class SendVerificationEmail implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, IsMonitored, Queueable, SerializesModels;
+
+    protected User $user;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(User $user) {
+        $this->user = $user;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle() {
+        $this->queueData([
+                             "user_id"  => $this->user->id,
+                             "username" => $this->user->username,
+                         ]);
+
+        $this->user->notify(new VerifyEmail);
+    }
+}

--- a/app/Jobs/SendVerificationEmail.php
+++ b/app/Jobs/SendVerificationEmail.php
@@ -35,7 +35,7 @@ class SendVerificationEmail implements ShouldQueue
      *
      * @return void
      */
-    public function handle() {
+    public function handle(): void {
         $this->queueData([
                              "user_id"  => $this->user->id,
                              "username" => $this->user->username,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enum\StatusVisibility;
 use App\Exceptions\RateLimitExceededException;
+use App\Jobs\SendVerificationEmail;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
@@ -248,7 +249,7 @@ class User extends Authenticatable implements MustVerifyEmail
             key:          'verification-mail-sent-' . $this->id,
             maxAttempts:  1,
             callback: function() {
-                parent::sendEmailVerificationNotification();
+                SendVerificationEmail::dispatch($this);
                 Log::info("Sent the verification email for user#" . $this->id . " successfully.");
             },
             decaySeconds: 5 * 60,

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "laravel/ui": "^4.0",
         "mrkriskrisu/db-wagenreihung-php": "0.2",
         "revolution/laravel-mastodon-api": "^2.0",
+        "romanzipp/laravel-queue-monitor": "^2.3",
         "spatie/icalendar-generator": "^2.0",
         "spatie/laravel-sitemap": "^6.0",
         "trwl/socialite-mastodon": "^1.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dff3067e009da05208285051283cfdc9",
+    "content-hash": "5ea56b3c46c08b718b82bcd62a8c2783",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -1239,24 +1239,24 @@
         },
         {
             "name": "dompdf/dompdf",
-            "version": "v2.0.0",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dompdf/dompdf.git",
-                "reference": "79573d8b8a141ec8a17312515de8740eed014fa9"
+                "reference": "c5310df0e22c758c85ea5288175fc6cd777bc085"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/79573d8b8a141ec8a17312515de8740eed014fa9",
-                "reference": "79573d8b8a141ec8a17312515de8740eed014fa9",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/c5310df0e22c758c85ea5288175fc6cd777bc085",
+                "reference": "c5310df0e22c758c85ea5288175fc6cd777bc085",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
                 "masterminds/html5": "^2.0",
-                "phenx/php-font-lib": "^0.5.4",
-                "phenx/php-svg-lib": "^0.3.3 || ^0.4.0",
+                "phenx/php-font-lib": ">=0.5.4 <1.0.0",
+                "phenx/php-svg-lib": ">=0.3.3 <1.0.0",
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
@@ -1287,25 +1287,17 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Ménager",
-                    "email": "fabien.menager@gmail.com"
-                },
-                {
-                    "name": "Brian Sweeney",
-                    "email": "eclecticgeek@gmail.com"
-                },
-                {
-                    "name": "Gabriel Bull",
-                    "email": "me@gabrielbull.com"
+                    "name": "The Dompdf Community",
+                    "homepage": "https://github.com/dompdf/dompdf/blob/master/AUTHORS.md"
                 }
             ],
             "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
             "homepage": "https://github.com/dompdf/dompdf",
             "support": {
                 "issues": "https://github.com/dompdf/dompdf/issues",
-                "source": "https://github.com/dompdf/dompdf/tree/v2.0.0"
+                "source": "https://github.com/dompdf/dompdf/tree/v2.0.1"
             },
-            "time": "2022-06-21T21:14:57+00:00"
+            "time": "2022-09-22T13:43:41+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -4879,21 +4871,21 @@
         },
         {
             "name": "phenx/php-svg-lib",
-            "version": "0.4.1",
+            "version": "0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dompdf/php-svg-lib.git",
-                "reference": "4498b5df7b08e8469f0f8279651ea5de9626ed02"
+                "reference": "76876c6cf3080bcb6f249d7d59705108166a6685"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/4498b5df7b08e8469f0f8279651ea5de9626ed02",
-                "reference": "4498b5df7b08e8469f0f8279651ea5de9626ed02",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/76876c6cf3080bcb6f249d7d59705108166a6685",
+                "reference": "76876c6cf3080bcb6f249d7d59705108166a6685",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": "^7.1 || ^7.2 || ^7.3 || ^7.4 || ^8.0",
+                "php": "^7.1 || ^8.0",
                 "sabberworm/php-css-parser": "^8.4"
             },
             "require-dev": {
@@ -4919,9 +4911,9 @@
             "homepage": "https://github.com/PhenX/php-svg-lib",
             "support": {
                 "issues": "https://github.com/dompdf/php-svg-lib/issues",
-                "source": "https://github.com/dompdf/php-svg-lib/tree/0.4.1"
+                "source": "https://github.com/dompdf/php-svg-lib/tree/0.5.0"
             },
-            "time": "2022-03-07T12:52:04+00:00"
+            "time": "2022-09-06T12:16:56+00:00"
         },
         {
             "name": "php-http/message-factory",
@@ -5482,16 +5474,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.24",
+            "version": "9.5.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "d0aa6097bef9fd42458a9b3c49da32c6ce6129c5"
+                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d0aa6097bef9fd42458a9b3c49da32c6ce6129c5",
-                "reference": "d0aa6097bef9fd42458a9b3c49da32c6ce6129c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
+                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
                 "shasum": ""
             },
             "require": {
@@ -5513,14 +5505,14 @@
                 "phpunit/php-timer": "^5.0.2",
                 "sebastian/cli-parser": "^1.0.1",
                 "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.5",
+                "sebastian/comparator": "^4.0.8",
                 "sebastian/diff": "^4.0.3",
                 "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.3",
+                "sebastian/exporter": "^4.0.5",
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.1",
+                "sebastian/type": "^3.2",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -5564,7 +5556,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.24"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.25"
             },
             "funding": [
                 {
@@ -5574,9 +5566,13 @@
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-08-30T07:42:16+00:00"
+            "time": "2022-09-25T03:44:45+00:00"
         },
         {
             "name": "psr/cache",
@@ -6345,6 +6341,75 @@
                 "source": "https://github.com/kawax/laravel-mastodon-api/tree/2.4.0"
             },
             "time": "2021-01-01T09:05:44+00:00"
+        },
+        {
+            "name": "romanzipp/laravel-queue-monitor",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/romanzipp/Laravel-Queue-Monitor.git",
+                "reference": "818cecb89d8fcaedc1919da062d7cec6ac1d35bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/romanzipp/Laravel-Queue-Monitor/zipball/818cecb89d8fcaedc1919da062d7cec6ac1d35bd",
+                "reference": "818cecb89d8fcaedc1919da062d7cec6ac1d35bd",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "illuminate/database": "^5.5|^6.0|^7.0|^8.0|^9.0",
+                "illuminate/queue": "^5.5|^6.0|^7.0|^8.0|^9.0",
+                "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0",
+                "nesbot/carbon": "^2.0",
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "laravel/framework": "^5.5|^6.0|^7.0|^8.0|^9.0",
+                "mockery/mockery": "^1.3.2",
+                "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0",
+                "phpstan/phpstan": "^0.12.99|^1.0",
+                "phpunit/phpunit": "^8.0|^9.0",
+                "romanzipp/php-cs-fixer-config": "^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "romanzipp\\QueueMonitor\\Providers\\QueueMonitorProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "romanzipp\\QueueMonitor\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "romanzipp",
+                    "email": "ich@ich.wtf",
+                    "homepage": "https://ich.wtf"
+                }
+            ],
+            "description": "Queue Monitoring for Laravel Database Job Queue",
+            "support": {
+                "issues": "https://github.com/romanzipp/Laravel-Queue-Monitor/issues",
+                "source": "https://github.com/romanzipp/Laravel-Queue-Monitor/tree/2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/romanzipp",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-08T16:25:09+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -11625,12 +11690,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "264a5085afd6e127daba3f47751fa971d3c29c3d"
+                "reference": "50a6bc0d820c35aab4d7818208f5ec815dff1fe1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/264a5085afd6e127daba3f47751fa971d3c29c3d",
-                "reference": "264a5085afd6e127daba3f47751fa971d3c29c3d",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/50a6bc0d820c35aab4d7818208f5ec815dff1fe1",
+                "reference": "50a6bc0d820c35aab4d7818208f5ec815dff1fe1",
                 "shasum": ""
             },
             "conflict": {
@@ -11692,7 +11757,7 @@
                 "contao/core-bundle": "<4.9.18|>=4.10,<4.11.7|>=4.13,<4.13.3|= 4.10.0",
                 "contao/listing-bundle": ">=4,<4.4.8",
                 "contao/managed-edition": "<=1.5",
-                "craftcms/cms": "<3.7.36",
+                "craftcms/cms": "<3.7.55.2|>= 4.0.0-RC1, < 4.2.1",
                 "croogo/croogo": "<3.0.7",
                 "cuyz/valinor": "<0.12",
                 "czproject/git-php": "<4.0.3",
@@ -11828,7 +11893,7 @@
                 "league/commonmark": "<0.18.3",
                 "league/flysystem": "<1.1.4|>=2,<2.1.1",
                 "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
-                "librenms/librenms": "<22.4",
+                "librenms/librenms": "<=22.8",
                 "limesurvey/limesurvey": "<3.27.19",
                 "livehelperchat/livehelperchat": "<=3.91",
                 "livewire/livewire": ">2.2.4,<2.2.6",
@@ -11844,7 +11909,7 @@
                 "mautic/core": "<4.3|= 2.13.1",
                 "mediawiki/core": ">=1.27,<1.27.6|>=1.29,<1.29.3|>=1.30,<1.30.2|>=1.31,<1.31.9|>=1.32,<1.32.6|>=1.32.99,<1.33.3|>=1.33.99,<1.34.3|>=1.34.99,<1.35",
                 "mezzio/mezzio-swoole": "<3.7|>=4,<4.3",
-                "microweber/microweber": "<1.3.1",
+                "microweber/microweber": "<=1.3.1",
                 "miniorange/miniorange-saml": "<1.4.3",
                 "mittwald/typo3_forum": "<1.2.1",
                 "modx/revolution": "<= 2.8.3-pl|<2.8",
@@ -11907,7 +11972,7 @@
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
                 "pimcore/data-hub": "<1.2.4",
-                "pimcore/pimcore": "<10.5.6",
+                "pimcore/pimcore": "<=10.5.6",
                 "pocketmine/bedrock-protocol": "<8.0.2",
                 "pocketmine/pocketmine-mp": "<4.7.2|>= 4.0.0-BETA5, < 4.4.2",
                 "pressbooks/pressbooks": "<5.18",
@@ -12067,7 +12132,7 @@
                 "wpanel/wpanel4-cms": "<=4.3.1",
                 "wwbn/avideo": "<=11.6",
                 "yeswiki/yeswiki": "<4.1",
-                "yetiforce/yetiforce-crm": "<6.4",
+                "yetiforce/yetiforce-crm": "<=6.4",
                 "yidashi/yii2cmf": "<=2",
                 "yii2mod/yii2-cms": "<1.9.2",
                 "yiisoft/yii": ">=1.1.14,<1.1.15",
@@ -12141,7 +12206,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-16T22:04:31+00:00"
+            "time": "2022-09-23T21:04:15+00:00"
         },
         {
             "name": "spatie/backtrace",

--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -1,0 +1,55 @@
+<?php
+
+return [
+    /*
+     * Set the table to be used for monitoring data.
+     */
+    'table' => 'queue_monitor',
+    'connection' => null,
+
+    /*
+     * Set the model used for monitoring.
+     * If using a custom model, be sure to implement the
+     *   romanzipp\QueueMonitor\Models\Contracts\MonitorContract
+     * interface or extend the base model.
+     */
+    'model' => \romanzipp\QueueMonitor\Models\Monitor::class,
+
+    /*
+     * Specify the max character length to use for storing exception backtraces.
+     */
+    'db_max_length_exception' => 4294967295,
+    'db_max_length_exception_message' => 65535,
+
+    /*
+     * The optional UI settings.
+     */
+    'ui' => [
+        /*
+         * Set the monitored jobs count to be displayed per page.
+         */
+        'per_page' => 35,
+
+        /*
+         *  Show custom data stored on model
+         */
+        'show_custom_data' => true,
+
+        /**
+         * Allow the deletion of single monitor items.
+         */
+        'allow_deletion' => true,
+
+        /**
+         * Allow purging all monitor entries.
+         */
+        'allow_purge' => true,
+
+        'show_metrics' => true,
+
+        /**
+         * Time frame used to calculate metrics values (in days).
+         */
+        'metrics_time_frame' => 14,
+    ],
+];

--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -4,8 +4,8 @@ return [
     /*
      * Set the table to be used for monitoring data.
      */
-    'table' => 'queue_monitor',
-    'connection' => null,
+    'table'                           => 'queue_monitor',
+    'connection'                      => null,
 
     /*
      * Set the model used for monitoring.
@@ -13,22 +13,22 @@ return [
      *   romanzipp\QueueMonitor\Models\Contracts\MonitorContract
      * interface or extend the base model.
      */
-    'model' => \romanzipp\QueueMonitor\Models\Monitor::class,
+    'model'                           => \romanzipp\QueueMonitor\Models\Monitor::class,
 
     /*
      * Specify the max character length to use for storing exception backtraces.
      */
-    'db_max_length_exception' => 4294967295,
+    'db_max_length_exception'         => 4294967295,
     'db_max_length_exception_message' => 65535,
 
     /*
      * The optional UI settings.
      */
-    'ui' => [
+    'ui'                              => [
         /*
          * Set the monitored jobs count to be displayed per page.
          */
-        'per_page' => 35,
+        'per_page'         => 35,
 
         /*
          *  Show custom data stored on model
@@ -38,14 +38,14 @@ return [
         /**
          * Allow the deletion of single monitor items.
          */
-        'allow_deletion' => true,
+        'allow_deletion'   => true,
 
         /**
          * Allow purging all monitor entries.
          */
-        'allow_purge' => true,
+        'allow_purge'      => true,
 
-        'show_metrics' => true,
+        'show_metrics'       => true,
 
         /**
          * Time frame used to calculate metrics values (in days).

--- a/database/migrations/2018_02_05_000000_create_queue_monitor_table.php
+++ b/database/migrations/2018_02_05_000000_create_queue_monitor_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateQueueMonitorTable extends Migration
+{
+    public function up()
+    {
+        Schema::create(config('queue-monitor.table'), function (Blueprint $table) {
+            $table->increments('id');
+
+            $table->string('job_id')->index();
+            $table->string('name')->nullable();
+            $table->string('queue')->nullable();
+
+            $table->timestamp('started_at')->nullable()->index();
+            $table->string('started_at_exact')->nullable();
+
+            $table->timestamp('finished_at')->nullable();
+            $table->string('finished_at_exact')->nullable();
+
+            $table->float('time_elapsed', 12, 6)->nullable()->index();
+
+            $table->boolean('failed')->default(false)->index();
+
+            $table->integer('attempt')->default(0);
+            $table->integer('progress')->nullable();
+
+            $table->longText('exception')->nullable();
+            $table->text('exception_message')->nullable();
+            $table->text('exception_class')->nullable();
+
+            $table->longText('data')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::drop(config('queue-monitor.table'));
+    }
+}

--- a/database/migrations/2018_02_05_000000_create_queue_monitor_table.php
+++ b/database/migrations/2018_02_05_000000_create_queue_monitor_table.php
@@ -6,10 +6,10 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateQueueMonitorTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create(config('queue-monitor.table'), function (Blueprint $table) {
-            $table->increments('id');
+            $table->id();
 
             $table->string('job_id')->index();
             $table->string('name')->nullable();
@@ -36,7 +36,7 @@ class CreateQueueMonitorTable extends Migration
         });
     }
 
-    public function down()
+    public function down(): void
     {
         Schema::drop(config('queue-monitor.table'));
     }


### PR DESCRIPTION
After the responses in #1058, I decided to re-do the queue monitoring and close the old PR. This PR diff's to the other one in few distinct points:

1. We're back to using the old library, not our fork.
2. The library only writes to the database, and the interface to show the statistics have been removed in favour of the recent monitoring efforts at Trwl.
3. This PR adds the `IsMonitored` trait to the existing `FetchCarriageSequence` job
4. It moves the Twitter and Mastodon posting off the request path into a job
5. From now on, Trwl sends the verification email asynchronously. This code change has been merged with the rate limiting changes in #1062, whereas the `dispatch` is rate limited.

I hope that this PR is clearer now, and that we can start monitoring our queue soon.

To review, I advice to go commit-by-commit, and to rebase all commits as separate commits onto the `develop` branch, since the separate commits can be used as a template for further jobification efforts.