### PR TITLE
🧱 Disallow Semrush and BLEX web crawler

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,3 +4,9 @@ Disallow: /legal/privacy-policy
 
 User-agent: ia_archiver
 Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: BLEXBot
+Disallow: /


### PR DESCRIPTION
These crawler each issue over 30000 request pre hour. Let's hope they respect the robots.txt ...