### PR TITLE
:zap: Add caching to the leaderboard

### DIFF
--- a/app/Enum/CacheKey.php
+++ b/app/Enum/CacheKey.php
@@ -10,7 +10,7 @@ class CacheKey
     public const LeaderboardGlobalDistance = "LeaderboardGlobalDistance";
     public const LeaderboardMonth          = "LeaderboardMonth";
 
-    public static function getFriendsLeaderboardKey(int $user_id): string {
-        return self::LeaderboardFriends + '-for-' + $user_id;
+    public static function getFriendsLeaderboardKey(int $userId): string {
+        return self::LeaderboardFriends . '-for-' . $userId;
     }
 }

--- a/app/Enum/CacheKey.php
+++ b/app/Enum/CacheKey.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Enum;
+
+class CacheKey
+{
+    public const LeaderboardFriends        = "LeaderboardFriends";
+    public const LeaderboardGlobalPoints   = "LeaderboardGlobalPoints";
+    public const LeaderboardGlobalDistance = "LeaderboardGlobalDistance";
+    public const LeaderboardMonth          = "LeaderboardMonth";
+
+    public static function getFriendsLeaderboardKey(int $user_id): string {
+        return self::LeaderboardFriends + '-for-' + $user_id;
+    }
+}

--- a/app/Http/Controllers/Frontend/LeaderboardController.php
+++ b/app/Http/Controllers/Frontend/LeaderboardController.php
@@ -2,26 +2,55 @@
 
 namespace App\Http\Controllers\Frontend;
 
+use App\Enum\CacheKey;
 use App\Http\Controllers\Backend\LeaderboardController as LeaderboardBackend;
 use App\Http\Controllers\Controller;
 use Carbon\Carbon;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Facades\Cache;
 
 class LeaderboardController extends Controller
 {
+    private static string $cacheRetentionConfigKey = 'trwl.cache.leaderboard-retention-seconds';
+
     public static function renderMonthlyLeaderboard(string $date): Renderable {
         $date = Carbon::parse($date);
+
+        $leaderboard = Cache::remember(
+            CacheKey::LeaderboardMonth . '-for-' . $date->toISOString(),
+            config(self::$cacheRetentionConfigKey),
+            fn() => LeaderboardBackend::getMonthlyLeaderboard($date));
+
         return view('leaderboard.month', [
-            'leaderboard' => LeaderboardBackend::getMonthlyLeaderboard($date),
+            'leaderboard' => $leaderboard,
             'date'        => Carbon::parse($date)
         ]);
     }
 
     public function renderLeaderboard(): Renderable {
+        $ttl = config(self::$cacheRetentionConfigKey);
+
+        $usersLeaderboard = Cache::remember(
+            CacheKey::LeaderboardGlobalPoints,
+            $ttl,
+            fn() => LeaderboardBackend::getLeaderboard());
+
+        $distanceLeaderboard = Cache::remember(
+            CacheKey::LeaderboardGlobalDistance,
+            $ttl,
+            fn() => LeaderboardBackend::getLeaderboard(orderBy: 'distance'));
+
+        $friendsLeaderboard = auth()->check()
+            ? Cache::remember(
+                CacheKey::getFriendsLeaderboardKey(auth()->id()),
+                $ttl,
+                fn() => LeaderboardBackend::getLeaderboard(onlyFollowings: true))
+            : null;
+
         return view('leaderboard.leaderboard', [
-            'users'    => LeaderboardBackend::getLeaderboard(),
-            'friends'  => auth()->check() ? LeaderboardBackend::getLeaderboard(onlyFollowings: true) : null,
-            'distance' => LeaderboardBackend::getLeaderboard(orderBy: 'distance')
+            'users'    => $usersLeaderboard,
+            'distance' => $distanceLeaderboard,
+            'friends'  => $friendsLeaderboard,
         ]);
     }
 }

--- a/app/Http/Controllers/Frontend/LeaderboardController.php
+++ b/app/Http/Controllers/Frontend/LeaderboardController.php
@@ -19,7 +19,8 @@ class LeaderboardController extends Controller
         $leaderboard = Cache::remember(
             CacheKey::LeaderboardMonth . '-for-' . $date->toISOString(),
             config(self::$cacheRetentionConfigKey),
-            fn() => LeaderboardBackend::getMonthlyLeaderboard($date));
+            fn() => LeaderboardBackend::getMonthlyLeaderboard($date)
+        );
 
         return view('leaderboard.month', [
             'leaderboard' => $leaderboard,
@@ -33,12 +34,14 @@ class LeaderboardController extends Controller
         $usersLeaderboard = Cache::remember(
             CacheKey::LeaderboardGlobalPoints,
             $ttl,
-            fn() => LeaderboardBackend::getLeaderboard());
+            fn() => LeaderboardBackend::getLeaderboard()
+        );
 
         $distanceLeaderboard = Cache::remember(
             CacheKey::LeaderboardGlobalDistance,
             $ttl,
-            fn() => LeaderboardBackend::getLeaderboard(orderBy: 'distance'));
+            fn() => LeaderboardBackend::getLeaderboard(orderBy: 'distance')
+        );
 
         $friendsLeaderboard = auth()->check()
             ? Cache::remember(

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enum\CacheKey;
 use App\Enum\StatusVisibility;
 use App\Exceptions\AlreadyFollowingException;
 use App\Exceptions\PermissionException;
@@ -22,6 +23,7 @@ use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Gate;
@@ -137,6 +139,7 @@ class UserController extends Controller
                                  ]);
         $user->notify(new FollowRequestApproved($follow));
         $userToFollow->fresh();
+        Cache::forget(CacheKey::getFriendsLeaderboardKey($user->id));
         return $userToFollow;
     }
 

--- a/config/trwl.php
+++ b/config/trwl.php
@@ -34,5 +34,8 @@ return [
     ],
     'refresh'           => [
         'max_trips_per_minute' => env('REFRESH_TRIPS_PER_MINUTE', 1)
+    ],
+    'cache'             => [
+        'leaderboard-retention-seconds' => env('LEADERBOARD_CACHE_RETENTION_SECONDS', 5 * 60)
     ]
 ];

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -489,7 +489,7 @@
     "description.leaderboard.main": "Die Top Träweller der letzten 7 Tage.",
     "description.leaderboard.monthly": "Die Top Träweller im :month :year der letzten 7 Tage.",
     "description.en-route": "Übersichtskarte über alle Träweller, welche gerade auf der Welt unterwegs sind.",
-    "leaderboard.notice": "Die hier angezeigten Daten basieren auf den Check-Ins der letzten 7 Tage. Aktualisierungen können bis zu fünf Minuten dauern..",
+    "leaderboard.notice": "Die hier angezeigten Daten basieren auf den Check-Ins der letzten 7 Tage. Aktualisierungen können bis zu fünf Minuten dauern.",
     "localisation.not-available": "Dieser Inhalt steht aktuell leider nicht auf deiner Sprache zur Verfügung.",
     "minutes": "Minuten",
     "support": "Support",

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -489,7 +489,7 @@
     "description.leaderboard.main": "Die Top Träweller der letzten 7 Tage.",
     "description.leaderboard.monthly": "Die Top Träweller im :month :year der letzten 7 Tage.",
     "description.en-route": "Übersichtskarte über alle Träweller, welche gerade auf der Welt unterwegs sind.",
-    "leaderboard.notice": "Die hier angezeigten Daten basieren auf den Check-Ins der letzten 7 Tage.",
+    "leaderboard.notice": "Die hier angezeigten Daten basieren auf den Check-Ins der letzten 7 Tage. Aktualisierungen können bis zu fünf Minuten dauern..",
     "localisation.not-available": "Dieser Inhalt steht aktuell leider nicht auf deiner Sprache zur Verfügung.",
     "minutes": "Minuten",
     "support": "Support",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -461,7 +461,7 @@
     "user.muted.heading2": "Muted users",
     "user.already-unmuted": "The user :username is not muted.",
     "user.unmute-tooltip": "Unmute user",
-    "leaderboard.notice": "The data shown here is based on the check-ins of the last 7 days.",
+    "leaderboard.notice": "The data shown here is based on the check-ins of the last 7 days. Updates to the leaderboard might take up to five minutes.",
     "localisation.not-available": "Sorry, this content is currently not available in your language.",
     "description.leaderboard.main": "The top Träwellers of the past 7 days.",
     "description.leaderboard.monthly": "The top Träwellers in :month :year for the last 7 days.",


### PR DESCRIPTION
The leaderboard page is one of the slowest pages of trwl since it does some very expensive operations. With this PR, the amount of times when these expensive operations are run, is reduced significantly, giving a better experience to almost all users (except for the ones that re-generate the leaderboard every so often).

Per default, the cache expires after five minutes. The database table is cleared and reset with the next request to that key (workflow is select, find out that it's too old, delete, execute closure, insert), however this depends on the used cache driver.

If a user follows another user, the cache entry for the "friends leaderboard" is reset.