### PR TITLE
:zap: Evaluate leaderboard cache every five minutes

### DIFF
--- a/app/Console/Commands/CacheLeaderboard.php
+++ b/app/Console/Commands/CacheLeaderboard.php
@@ -15,7 +15,7 @@ class CacheLeaderboard extends Command
      *
      * @var string
      */
-    protected $signature = 'trwl:leaderboard:cache';
+    protected $signature = 'trwl:cache:leaderboard';
 
     /**
      * The console command description.

--- a/app/Console/Commands/CacheLeaderboard.php
+++ b/app/Console/Commands/CacheLeaderboard.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enum\CacheKey;
+use App\Http\Controllers\Frontend\LeaderboardController;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+class CacheLeaderboard extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'trwl:leaderboard:cache';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a cache of the Leaderboard so the requests';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(LeaderboardController $leaderboardController): int {
+        DB::beginTransaction();
+        Cache::forget(CacheKey::LeaderboardGlobalPoints);
+        Cache::forget(CacheKey::LeaderboardGlobalDistance);
+        $leaderboardController->renderLeaderboard();
+        DB::commit();
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -31,7 +31,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('trwl:cleanUpDatabase')->dailyAt('1:50');
         $schedule->command('trwl:refreshTrips')->withoutOverlapping()->everyMinute();
         $schedule->command('trwl:hideStatus')->daily();
-        $schedule->command("trwl:leaderboard:cache")->withoutOverlapping()->everyFiveMinutes();
+        $schedule->command('trwl:cache:leaderboard')->withoutOverlapping()->everyFiveMinutes();
     }
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -31,6 +31,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('trwl:cleanUpDatabase')->dailyAt('1:50');
         $schedule->command('trwl:refreshTrips')->withoutOverlapping()->everyMinute();
         $schedule->command('trwl:hideStatus')->daily();
+        $schedule->command("trwl:leaderboard:cache")->withoutOverlapping()->everyFiveMinutes();
     }
 
     /**


### PR DESCRIPTION
This removes the burden of filling the leaderboard cache from the first user that visits the page every five minutes.