### PR TITLE
:bug: Fix "fast check in" button not correctly selecting last stop if train end prematurely

### DIFF
--- a/app/Http/Controllers/FrontendTransportController.php
+++ b/app/Http/Controllers/FrontendTransportController.php
@@ -121,7 +121,7 @@ class FrontendTransportController extends Controller
 
         // Find out where this train terminates and offer this as a "fast check-in" option.
         $terminalStopIndex = count($TrainTripResponse['stopovers']) - 1;
-        while ($terminalStopIndex >= 1 && @$TrainTripResponse['stopovers'][$terminalStopIndex]['cancelled'] == true) {
+        while ($terminalStopIndex >= 1 && @$this->is_cancelled($TrainTripResponse['stopovers'][$terminalStopIndex])) {
             $terminalStopIndex--;
         }
         $terminalStop = $TrainTripResponse['stopovers'][$terminalStopIndex];
@@ -224,5 +224,9 @@ class FrontendTransportController extends Controller
         } catch (HafasException) {
             return redirect()->back()->with(['error' => __('messages.exception.generalHafas')]);
         }
+    }
+
+    private function is_cancelled(mixed $param): bool {
+        return $param['cancelled'] && $param['arrival'] == null && $param['departure'] == null;
     }
 }

--- a/app/Http/Controllers/FrontendTransportController.php
+++ b/app/Http/Controllers/FrontendTransportController.php
@@ -121,7 +121,7 @@ class FrontendTransportController extends Controller
 
         // Find out where this train terminates and offer this as a "fast check-in" option.
         $terminalStopIndex = count($TrainTripResponse['stopovers']) - 1;
-        while ($terminalStopIndex >= 1 && @$this->is_cancelled($TrainTripResponse['stopovers'][$terminalStopIndex])) {
+        while ($terminalStopIndex >= 1 && @$this->isCancelled($TrainTripResponse['stopovers'][$terminalStopIndex])) {
             $terminalStopIndex--;
         }
         $terminalStop = $TrainTripResponse['stopovers'][$terminalStopIndex];
@@ -226,7 +226,7 @@ class FrontendTransportController extends Controller
         }
     }
 
-    private function is_cancelled(mixed $param): bool {
+    private function isCancelled(mixed $param): bool {
         return $param['cancelled'] && $param['arrival'] == null && $param['departure'] == null;
     }
 }


### PR DESCRIPTION
Seemingly, db rest also cancels the last stop of a train; therefore we also check for departure/arrival for the trip station list but we don't for the fast check in

https://github.com/Traewelling/traewelling/blob/f3ab90f01ff09281293eb723302baaa0f7f6c833/resources/views/admin/checkin/trip.blade.php#L30