### PR TITLE
:recycle: Add UserCheckedIn event and dispatch PostStatusOn* jobs via this route

### DIFF
--- a/.idea/php-docker-settings.xml
+++ b/.idea/php-docker-settings.xml
@@ -18,6 +18,21 @@
             </DockerContainerSettings>
           </value>
         </entry>
+        <entry key="9111d13a-04fd-4d80-9f00-bc2cc6d38496">
+          <value>
+            <DockerContainerSettings>
+              <option name="version" value="1" />
+              <option name="volumeBindings">
+                <list>
+                  <DockerVolumeBindingImpl>
+                    <option name="containerPath" value="/opt/project" />
+                    <option name="hostPath" value="$PROJECT_DIR$" />
+                  </DockerVolumeBindingImpl>
+                </list>
+              </option>
+            </DockerContainerSettings>
+          </value>
+        </entry>
       </map>
     </list>
   </component>

--- a/.idea/php-test-framework.xml
+++ b/.idea/php-test-framework.xml
@@ -6,6 +6,7 @@
         <cache>
           <versions>
             <info id="Local" version="7.5.20" />
+            <info id="interpreter-9111d13a-04fd-4d80-9f00-bc2cc6d38496" version="9.5.25" />
           </versions>
         </cache>
       </tool>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -204,7 +204,64 @@
       <path value="$PROJECT_DIR$/vendor/symfony/uid" />
       <path value="$PROJECT_DIR$/vendor/symfony/polyfill-uuid" />
       <path value="$PROJECT_DIR$/vendor/romanzipp/laravel-queue-monitor" />
+      <path value="$PROJECT_DIR$/vendor/_laravel_idea" />
     </include_path>
+  </component>
+  <component name="PhpInterpreters">
+    <interpreters>
+      <interpreter id="9111d13a-04fd-4d80-9f00-bc2cc6d38496" name="php:8.1.6" home="docker://DATA" debugger_id="php.debugger.XDebug">
+        <remote_data INTERPRETER_PATH="php" HELPERS_PATH="/opt/.phpstorm_helpers" INITIALIZED="false" VALID="true" RUN_AS_ROOT_VIA_SUDO="false" DOCKER_ACCOUNT_NAME="Docker Local" DOCKER_IMAGE_NAME="php:8.1.6" DOCKER_REMOTE_PROJECT_PATH="/opt/project" />
+      </interpreter>
+    </interpreters>
+  </component>
+  <component name="PhpInterpretersPhpInfoCache">
+    <phpInfoCache>
+      <interpreter name="php:8.1.6">
+        <phpinfo binary_type="PHP" php_cgi="/usr/local/bin/php-cgi" php_cli="/usr/local/bin/php" path_separator=":" version="8.1.6">
+          <additional_php_ini>/usr/local/etc/php/conf.d/docker-php-ext-sodium.ini</additional_php_ini>
+          <configuration_file />
+          <configuration_options>
+            <configuration_option name="include_path" value=".:/usr/local/lib/php" />
+          </configuration_options>
+          <debuggers />
+          <loaded_extensions>
+            <extension name="Core" />
+            <extension name="PDO" />
+            <extension name="Phar" />
+            <extension name="Reflection" />
+            <extension name="SPL" />
+            <extension name="SimpleXML" />
+            <extension name="ctype" />
+            <extension name="curl" />
+            <extension name="date" />
+            <extension name="dom" />
+            <extension name="fileinfo" />
+            <extension name="filter" />
+            <extension name="ftp" />
+            <extension name="hash" />
+            <extension name="iconv" />
+            <extension name="json" />
+            <extension name="libxml" />
+            <extension name="mbstring" />
+            <extension name="mysqlnd" />
+            <extension name="openssl" />
+            <extension name="pcre" />
+            <extension name="pdo_sqlite" />
+            <extension name="posix" />
+            <extension name="readline" />
+            <extension name="session" />
+            <extension name="sodium" />
+            <extension name="sqlite3" />
+            <extension name="standard" />
+            <extension name="tokenizer" />
+            <extension name="xml" />
+            <extension name="xmlreader" />
+            <extension name="xmlwriter" />
+            <extension name="zlib" />
+          </loaded_extensions>
+        </phpinfo>
+      </interpreter>
+    </phpInfoCache>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="8.1" />
   <component name="PhpUnit">

--- a/app/Events/UserCheckedIn.php
+++ b/app/Events/UserCheckedIn.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Status;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class UserCheckedIn
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public Status $status;
+    public bool   $shouldPostOnTwitter;
+    public bool   $shouldPostOnMastodon;
+
+    /**
+     * @param Status $status               The Status that was just checked in.
+     * @param bool   $shouldPostOnTwitter  Whether this Checkin should be posted on Twitter.
+     * @param bool   $shouldPostOnMastodon Whether this Checkin should be posted on Mastodon.
+     */
+    public function __construct(Status $status, bool $shouldPostOnTwitter, bool $shouldPostOnMastodon) {
+        $this->status               = $status;
+        $this->shouldPostOnTwitter  = $shouldPostOnTwitter;
+        $this->shouldPostOnMastodon = $shouldPostOnMastodon;
+
+        Log::info("Dispatching UserCheckedIn event for status#" . $status->id);
+    }
+}

--- a/app/Http/Controllers/Backend/Transport/TrainCheckinController.php
+++ b/app/Http/Controllers/Backend/Transport/TrainCheckinController.php
@@ -84,9 +84,11 @@ abstract class TrainCheckinController extends Controller
                 force:       $force,
             );
 
-            UserCheckedIn::dispatch($status,
-                                    $postOnTwitter && $user?->socialProfile?->twitter_id !== null && config('trwl.post_social') === true,
-                                    $postOnMastodon && $user?->socialProfile?->mastodon_id !== null && config('trwl.post_social') === true);
+            UserCheckedIn::dispatch(
+                $status,
+                $postOnTwitter && $user->socialProfile?->twitter_id !== null && config('trwl.post_social') === true,
+                $postOnMastodon && $user->socialProfile?->mastodon_id !== null && config('trwl.post_social') === true,
+            );
 
             return $trainCheckinResponse;
         } catch (Exception $exception) {

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,8 +2,12 @@
 
 namespace App\Providers;
 
+use App\Events\UserCheckedIn;
+use App\Jobs\PostStatusOnMastodon;
+use App\Jobs\PostStatusOnTwitter;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Event;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -13,9 +17,12 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
-        Registered::class => [
+        Registered::class    => [
             //SendEmailVerificationNotification::class,
         ],
+        UserCheckedIn::class => [
+
+        ]
     ];
 
     /**
@@ -25,5 +32,11 @@ class EventServiceProvider extends ServiceProvider
      */
     public function boot(): void {
         parent::boot();
+
+        // Dispatch Jobs from Events
+        Event::listen(fn(UserCheckedIn $event)
+            => PostStatusOnTwitter::dispatchIf($event->shouldPostOnTwitter, $event->status));
+        Event::listen(fn(UserCheckedIn $event)
+            => PostStatusOnMastodon::dispatchIf($event->shouldPostOnMastodon, $event->status));
     }
 }

--- a/database/migrations/2022_10_11_000000_create_failed_jobs_table.php
+++ b/database/migrations/2022_10_11_000000_create_failed_jobs_table.php
@@ -6,14 +6,9 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
-    public function up()
-    {
-        Schema::create('failed_jobs', function (Blueprint $table) {
+
+    public function up(): void {
+        Schema::create('failed_jobs', static function(Blueprint $table) {
             $table->id();
             $table->string('uuid')->unique();
             $table->text('connection');
@@ -24,13 +19,7 @@ return new class extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
+    public function down(): void {
         Schema::dropIfExists('failed_jobs');
     }
 };

--- a/database/migrations/2022_10_11_224711_create_failed_jobs_table.php
+++ b/database/migrations/2022_10_11_224711_create_failed_jobs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('failed_jobs');
+    }
+};


### PR DESCRIPTION
Das ist zwar gerade nur ein Umweg, ermöglicht uns aber, Dinge "entkoppelter" an den `UserCheckedIn`-Flow zu hängen, die nicht linear im bisherigen Flow hängen.

Außerdem, yay, Events - das ist bestimmt auch toll, wenn wir in Richtung Webhooks gehen wollen (siehe #987).