### PR TITLE
:sparkles: Offer pre-filled DB Passenger Rights Claim form when trip is delayed.

### DIFF
--- a/app/Http/Controllers/Backend/Export/RightsClaimFormController.php
+++ b/app/Http/Controllers/Backend/Export/RightsClaimFormController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Backend\Export;
+
+use App\Models\Status;
+use Illuminate\Support\Facades\Auth;
+
+class RightsClaimFormController
+{
+    public function render(int $id) {
+        $status = Status::findOrFail($id);
+
+        if (Auth::user()->cannot('update', $status)) {
+            abort(403);
+        }
+
+        $originStopover      = $status->trainCheckin->origin_stopover;
+        $plannedDeparture    = $originStopover->departure_planned;
+        $destinationStopover = $status->trainCheckin->destination_stopover;
+        $plannedArrival      = $destinationStopover->arrival_planned;
+        $realArrival         = $destinationStopover->arrival_real;
+
+        $fields = [
+            "S1F1" => $status->trainCheckin->departure->format("d"), // Reisedatum Tag (TT)
+            "S1F2" => $status->trainCheckin->departure->format("m"), // Reisedatum Monat (MM)
+            "S1F3" => $status->trainCheckin->departure->format("y"), // Reisedatum Jahr (JJ)
+
+            "S1F4" => substr($originStopover->trainStation->name, 0, 26), // Startbahnhof
+            "S1F5" => $plannedDeparture->format("H"), // Abfahrt laut Fahrplan Stunde (HH)
+            "S1F6" => $plannedDeparture->format("i"), // Abfahrt laut Fahrplan Minute (MM)
+
+            "S1F7" => substr($destinationStopover->trainStation->name, 0, 26), // Zielbahnhof
+            "S1F8" => $plannedArrival->format("H"), // Ankunft laut Fahrplan Stunde (HH)
+            "S1F9" => $plannedArrival->format("i"), // Ankunft laut Fahrplan Minute (MM)
+
+            "S1F10" => $realArrival->format("d"),  // Ankunftsdatum Tag (TT)
+            "S1F11" => $realArrival->format("m"),  // Ankunftsdatum Monat (MM)
+            "S1F12" => $realArrival->format("y"),  // Ankunftsdatum Jahr (JJ)
+
+            "S1F13" => substr(explode(" ", $status->trainCheckin->hafasTrip->linename)[0], 0, 3), // Zugart Angekommen mit
+            "S1F14" => str_pad(explode(" ", $status->trainCheckin->hafasTrip->linename)[1], 5, " ", STR_PAD_LEFT), // Zugnummer Angekommener mit
+
+            "S1F15" => $realArrival->format("H"), // Reale Ankunftszeit Stunde (HH)
+            "S1F16" => $realArrival->format("i"), // Reale Ankunftszeit Minute (MM)
+
+            "S1F17" => substr(explode(" ", $status->trainCheckin->hafasTrip->linename)[0], 0, 3), // Zugart Erster versp. / ausgefallener Zug
+            "S1F18" => str_pad(explode(" ", $status->trainCheckin->hafasTrip->linename)[1], 5, " ", STR_PAD_LEFT), // Zugnummer Erster versp. / ausgefallener Zug
+
+            "S1F19" => $plannedDeparture->format("H"), // Abfahrt laut Fahrplan Stunde (HH) Erster versp. / ausgefallener Zug
+            "S1F20" => $plannedDeparture->format("i"), // Abfahrt laut Fahrplan Minute (MM) Erster versp. / ausgefallener Zug
+
+            "S2F5"  => substr($status->user->name, 0, 18), // Vorname
+            "S2F19" => substr($status->user->email ?? "", 0, 37), // Emailadresse
+        ];
+
+        $pdf = new \FPDM(resource_path('views/pdf/fahrgastrechteformular.pdf'));
+        $pdf->Load($fields, true); // second parameter: false if field values are in ISO-8859-1, true if UTF-8
+        $pdf->Merge();
+        $pdf->Output();
+        exit;
+    }
+}

--- a/app/Models/TrainCheckin.php
+++ b/app/Models/TrainCheckin.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -139,5 +140,16 @@ class TrainCheckin extends Model
                    ->filter(function($status) {
                        return $status !== null && Gate::forUser(Auth::user())->allows('view', $status);
                    });
+    }
+
+    public function getIsDestinationDelayedEnoughForRightsClaimAttribute(): bool {
+        if (!$this->destination_stopover->isArrivalDelayed) {
+            return false;
+        }
+
+        $diffInMinutes = (new Carbon($this->destination_stopover->arrival_real))
+            ->diffInMinutes(new Carbon($this->destination_stopover->arrival_planned));
+
+        return $diffInMinutes >= config('trwl.rights-claim-delay-minimum');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "romanzipp/laravel-queue-monitor": "^2.3",
         "spatie/icalendar-generator": "^2.0",
         "spatie/laravel-sitemap": "^6.0",
+        "tmw/fpdm": "^2.9",
         "trwl/socialite-mastodon": "^1.2"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9207ab69e53f3c88f2d0224444b47de2",
+    "content-hash": "35b33a422ed6e87b63db6eee5a2811af",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -295,16 +295,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "30897edbfb15e784fe55587b4f73ceefd3c4d98c"
+                "reference": "69098eca243998b53eed7a48d82dedd28b447cd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/30897edbfb15e784fe55587b4f73ceefd3c4d98c",
-                "reference": "30897edbfb15e784fe55587b4f73ceefd3c4d98c",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/69098eca243998b53eed7a48d82dedd28b447cd5",
+                "reference": "69098eca243998b53eed7a48d82dedd28b447cd5",
                 "shasum": ""
             },
             "require": {
@@ -351,7 +351,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.3.3"
+                "source": "https://github.com/composer/ca-bundle/tree/1.3.4"
             },
             "funding": [
                 {
@@ -367,7 +367,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-20T07:14:26+00:00"
+            "time": "2022-10-12T12:08:29+00:00"
         },
         {
             "name": "darkaonline/l5-swagger",
@@ -2313,16 +2313,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v9.34.0",
+            "version": "v9.35.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "b7af7ff35497eb1c4e61652f522a862164dbba5a"
+                "reference": "79aed20f54b6ab75f926bf7d0dd7a5043ceb774a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/b7af7ff35497eb1c4e61652f522a862164dbba5a",
-                "reference": "b7af7ff35497eb1c4e61652f522a862164dbba5a",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/79aed20f54b6ab75f926bf7d0dd7a5043ceb774a",
+                "reference": "79aed20f54b6ab75f926bf7d0dd7a5043ceb774a",
                 "shasum": ""
             },
             "require": {
@@ -2495,7 +2495,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-10-04T13:33:43+00:00"
+            "time": "2022-10-11T17:30:47+00:00"
         },
         {
             "name": "laravel/passport",
@@ -7821,16 +7821,16 @@
         },
         {
             "name": "spatie/laravel-package-tools",
-            "version": "1.13.5",
+            "version": "1.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-package-tools.git",
-                "reference": "163ee3bc6c0a987535d8a99722a7dbcc5471a140"
+                "reference": "c377cc7223655c2278c148c1685b8b5a78af5c65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/163ee3bc6c0a987535d8a99722a7dbcc5471a140",
-                "reference": "163ee3bc6c0a987535d8a99722a7dbcc5471a140",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/c377cc7223655c2278c148c1685b8b5a78af5c65",
+                "reference": "c377cc7223655c2278c148c1685b8b5a78af5c65",
                 "shasum": ""
             },
             "require": {
@@ -7868,7 +7868,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-package-tools/issues",
-                "source": "https://github.com/spatie/laravel-package-tools/tree/1.13.5"
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.13.6"
             },
             "funding": [
                 {
@@ -7876,7 +7876,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-07T14:31:31+00:00"
+            "time": "2022-10-11T06:37:42+00:00"
         },
         {
             "name": "spatie/laravel-sitemap",
@@ -8121,16 +8121,16 @@
         },
         {
             "name": "swagger-api/swagger-ui",
-            "version": "v4.14.2",
+            "version": "v4.14.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swagger-api/swagger-ui.git",
-                "reference": "775d307d5634de376efab8fc2d993bd353843795"
+                "reference": "278dc05c886ce9d5d91860d56d9b57f3ab53ad5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/775d307d5634de376efab8fc2d993bd353843795",
-                "reference": "775d307d5634de376efab8fc2d993bd353843795",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/278dc05c886ce9d5d91860d56d9b57f3ab53ad5b",
+                "reference": "278dc05c886ce9d5d91860d56d9b57f3ab53ad5b",
                 "shasum": ""
             },
             "type": "library",
@@ -8176,22 +8176,22 @@
             ],
             "support": {
                 "issues": "https://github.com/swagger-api/swagger-ui/issues",
-                "source": "https://github.com/swagger-api/swagger-ui/tree/v4.14.2"
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v4.14.3"
             },
-            "time": "2022-09-29T17:30:08+00:00"
+            "time": "2022-10-11T09:13:18+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.1.5",
+            "version": "v6.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "17524a64ebcfab68d237bbed247e9a9917747096"
+                "reference": "7fa3b9cf17363468795e539231a5c91b02b608fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/17524a64ebcfab68d237bbed247e9a9917747096",
-                "reference": "17524a64ebcfab68d237bbed247e9a9917747096",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7fa3b9cf17363468795e539231a5c91b02b608fc",
+                "reference": "7fa3b9cf17363468795e539231a5c91b02b608fc",
                 "shasum": ""
             },
             "require": {
@@ -8258,7 +8258,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.1.5"
+                "source": "https://github.com/symfony/console/tree/v6.1.6"
             },
             "funding": [
                 {
@@ -8274,7 +8274,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-03T14:24:42+00:00"
+            "time": "2022-10-07T08:04:03+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -8480,16 +8480,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v6.1.3",
+            "version": "v6.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "736e42db3fd586d91820355988698e434e1d8419"
+                "reference": "49f718e41f1b6f0fd5730895ca5b1c37defd828d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/736e42db3fd586d91820355988698e434e1d8419",
-                "reference": "736e42db3fd586d91820355988698e434e1d8419",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/49f718e41f1b6f0fd5730895ca5b1c37defd828d",
+                "reference": "49f718e41f1b6f0fd5730895ca5b1c37defd828d",
                 "shasum": ""
             },
             "require": {
@@ -8531,7 +8531,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v6.1.3"
+                "source": "https://github.com/symfony/error-handler/tree/v6.1.6"
             },
             "funding": [
                 {
@@ -8547,7 +8547,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-29T07:42:06+00:00"
+            "time": "2022-10-07T08:04:03+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -8777,16 +8777,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.1.5",
+            "version": "v6.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "90f5d9726942db69490fe467a3acb5e7154fd555"
+                "reference": "3ae8e9c57155fc48930493a629da293b32efbde0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/90f5d9726942db69490fe467a3acb5e7154fd555",
-                "reference": "90f5d9726942db69490fe467a3acb5e7154fd555",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/3ae8e9c57155fc48930493a629da293b32efbde0",
+                "reference": "3ae8e9c57155fc48930493a629da293b32efbde0",
                 "shasum": ""
             },
             "require": {
@@ -8832,7 +8832,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.1.5"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.1.6"
             },
             "funding": [
                 {
@@ -8848,20 +8848,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-17T07:55:45+00:00"
+            "time": "2022-10-02T08:30:52+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.1.5",
+            "version": "v6.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "bf433ef30c2dfbf1f47449d5dce8be243e8a0012"
+                "reference": "102f99bf81799e93f61b9a73b2f38b309c587a94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/bf433ef30c2dfbf1f47449d5dce8be243e8a0012",
-                "reference": "bf433ef30c2dfbf1f47449d5dce8be243e8a0012",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/102f99bf81799e93f61b9a73b2f38b309c587a94",
+                "reference": "102f99bf81799e93f61b9a73b2f38b309c587a94",
                 "shasum": ""
             },
             "require": {
@@ -8942,7 +8942,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.1.5"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.1.6"
             },
             "funding": [
                 {
@@ -8958,7 +8958,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-30T08:10:57+00:00"
+            "time": "2022-10-12T07:48:47+00:00"
         },
         {
             "name": "symfony/mailer",
@@ -9036,16 +9036,16 @@
         },
         {
             "name": "symfony/mime",
-            "version": "v6.1.5",
+            "version": "v6.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "d521b2204f7dcebe81c1b5fb99ed70dfb6f34b4b"
+                "reference": "5ae192b9a39730435cfec025a499f79d05ac68a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/d521b2204f7dcebe81c1b5fb99ed70dfb6f34b4b",
-                "reference": "d521b2204f7dcebe81c1b5fb99ed70dfb6f34b4b",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/5ae192b9a39730435cfec025a499f79d05ac68a3",
+                "reference": "5ae192b9a39730435cfec025a499f79d05ac68a3",
                 "shasum": ""
             },
             "require": {
@@ -9057,7 +9057,8 @@
                 "egulias/email-validator": "~3.0.0",
                 "phpdocumentor/reflection-docblock": "<3.2.2",
                 "phpdocumentor/type-resolver": "<1.4.0",
-                "symfony/mailer": "<5.4"
+                "symfony/mailer": "<5.4",
+                "symfony/serializer": "<5.4.14|>=6.0,<6.0.14|>=6.1,<6.1.6"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3.1",
@@ -9065,7 +9066,7 @@
                 "symfony/dependency-injection": "^5.4|^6.0",
                 "symfony/property-access": "^5.4|^6.0",
                 "symfony/property-info": "^5.4|^6.0",
-                "symfony/serializer": "^5.4|^6.0"
+                "symfony/serializer": "^5.4.14|~6.0.14|^6.1.6"
             },
             "type": "library",
             "autoload": {
@@ -9097,7 +9098,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v6.1.5"
+                "source": "https://github.com/symfony/mime/tree/v6.1.6"
             },
             "funding": [
                 {
@@ -9113,7 +9114,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-02T08:05:20+00:00"
+            "time": "2022-10-07T08:04:03+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -10176,16 +10177,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.1.5",
+            "version": "v6.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "17c08b068176996a1d7db8d00ffae3c248267016"
+                "reference": "7e7e0ff180d4c5a6636eaad57b65092014b61864"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/17c08b068176996a1d7db8d00ffae3c248267016",
-                "reference": "17c08b068176996a1d7db8d00ffae3c248267016",
+                "url": "https://api.github.com/repos/symfony/string/zipball/7e7e0ff180d4c5a6636eaad57b65092014b61864",
+                "reference": "7e7e0ff180d4c5a6636eaad57b65092014b61864",
                 "shasum": ""
             },
             "require": {
@@ -10241,7 +10242,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.1.5"
+                "source": "https://github.com/symfony/string/tree/v6.1.6"
             },
             "funding": [
                 {
@@ -10257,20 +10258,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-02T08:05:20+00:00"
+            "time": "2022-10-10T09:34:31+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v6.1.4",
+            "version": "v6.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "45d0f5bb8df7255651ca91c122fab604e776af03"
+                "reference": "e6cd330e5a072518f88d65148f3f165541807494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/45d0f5bb8df7255651ca91c122fab604e776af03",
-                "reference": "45d0f5bb8df7255651ca91c122fab604e776af03",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/e6cd330e5a072518f88d65148f3f165541807494",
+                "reference": "e6cd330e5a072518f88d65148f3f165541807494",
                 "shasum": ""
             },
             "require": {
@@ -10337,7 +10338,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v6.1.4"
+                "source": "https://github.com/symfony/translation/tree/v6.1.6"
             },
             "funding": [
                 {
@@ -10353,7 +10354,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-02T16:17:38+00:00"
+            "time": "2022-10-07T08:04:03+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -10512,16 +10513,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v6.1.5",
+            "version": "v6.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "d0833493fb2413a86f522fb54a1896a7718e98ec"
+                "reference": "0f0adde127f24548e23cbde83bcaeadc491c551f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/d0833493fb2413a86f522fb54a1896a7718e98ec",
-                "reference": "d0833493fb2413a86f522fb54a1896a7718e98ec",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/0f0adde127f24548e23cbde83bcaeadc491c551f",
+                "reference": "0f0adde127f24548e23cbde83bcaeadc491c551f",
                 "shasum": ""
             },
             "require": {
@@ -10580,7 +10581,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v6.1.5"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.1.6"
             },
             "funding": [
                 {
@@ -10596,20 +10597,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-08T09:34:40+00:00"
+            "time": "2022-10-07T08:04:03+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.1.4",
+            "version": "v6.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "86ee4d8fa594ed45e40d86eedfda1bcb66c8d919"
+                "reference": "66c6b0cf52b00f74614a2cf7ae7db08ea1095931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/86ee4d8fa594ed45e40d86eedfda1bcb66c8d919",
-                "reference": "86ee4d8fa594ed45e40d86eedfda1bcb66c8d919",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/66c6b0cf52b00f74614a2cf7ae7db08ea1095931",
+                "reference": "66c6b0cf52b00f74614a2cf7ae7db08ea1095931",
                 "shasum": ""
             },
             "require": {
@@ -10654,7 +10655,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.1.4"
+                "source": "https://github.com/symfony/yaml/tree/v6.1.6"
             },
             "funding": [
                 {
@@ -10670,7 +10671,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-02T16:17:38+00:00"
+            "time": "2022-10-07T08:04:03+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -10774,6 +10775,64 @@
                 "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/2.2.5"
             },
             "time": "2022-09-12T13:28:28+00:00"
+        },
+        {
+            "name": "tmw/fpdm",
+            "version": "2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/codeshell/fpdm.git",
+                "reference": "2db6f6a8cf7f0d593c13dbbe10df0737d9526313"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/codeshell/fpdm/zipball/2db6f6a8cf7f0d593c13dbbe10df0737d9526313",
+                "reference": "2db6f6a8cf7f0d593c13dbbe10df0737d9526313",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/fpdm.php",
+                    "src/filters/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Olivier Plathey",
+                    "email": "oliver@fpdf.org",
+                    "homepage": "http://www.fpdf.org/",
+                    "role": "Author"
+                },
+                {
+                    "name": "codeshell",
+                    "homepage": "https://github.com/codeshell/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PDF form filling using FPDM Class written by FPDF author Olivier",
+            "homepage": "https://github.com/codeshell/fpdm",
+            "keywords": [
+                "Forms",
+                "fields",
+                "fill",
+                "fpdf",
+                "fpdm",
+                "pdf",
+                "populate"
+            ],
+            "support": {
+                "issues": "https://github.com/codeshell/fpdm/issues",
+                "source": "https://github.com/codeshell/fpdm/tree/master"
+            },
+            "time": "2019-06-11T23:37:41+00:00"
         },
         {
             "name": "trwl/socialite-mastodon",
@@ -11694,12 +11753,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "b311503298c072e565411e3ef61c04519272473f"
+                "reference": "2e0b4657407c945bc54a1d73910fcf81fca58ec6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/b311503298c072e565411e3ef61c04519272473f",
-                "reference": "b311503298c072e565411e3ef61c04519272473f",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/2e0b4657407c945bc54a1d73910fcf81fca58ec6",
+                "reference": "2e0b4657407c945bc54a1d73910fcf81fca58ec6",
                 "shasum": ""
             },
             "conflict": {
@@ -11913,6 +11972,9 @@
                 "matyhtf/framework": "<3.0.6",
                 "mautic/core": "<4.3|= 2.13.1",
                 "mediawiki/core": ">=1.27,<1.27.6|>=1.29,<1.29.3|>=1.30,<1.30.2|>=1.31,<1.31.9|>=1.32,<1.32.6|>=1.32.99,<1.33.3|>=1.33.99,<1.34.3|>=1.34.99,<1.35",
+                "melisplatform/melis-asset-manager": "<5.0.1",
+                "melisplatform/melis-cms": "<5.0.1",
+                "melisplatform/melis-front": "<5.0.1",
                 "mezzio/mezzio-swoole": "<3.7|>=4,<4.3",
                 "microweber/microweber": "<=1.3.1",
                 "miniorange/miniorange-saml": "<1.4.3",
@@ -12211,7 +12273,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-06T20:04:40+00:00"
+            "time": "2022-10-11T21:05:01+00:00"
         },
         {
             "name": "spatie/backtrace",

--- a/config/trwl.php
+++ b/config/trwl.php
@@ -38,5 +38,6 @@ return [
     'cache'             => [
         'global-statistics-retention-seconds' => env('GLOBAL_STATISTICS_CACHE_RETENTION_SECONDS', 60 * 60),
         'leaderboard-retention-seconds' => env('LEADERBOARD_CACHE_RETENTION_SECONDS', 5 * 60)
-    ]
+    ],
+    'rights-claim-delay-minimum' => 60,
 ];

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -437,6 +437,7 @@
     "status.visibility.3.detail": "Nur für dich sichtbar",
     "status.visibility.4": "Nur angemeldete Nutzer",
     "status.visibility.4.detail": "Nur für angemeldete Nutzer sichtbar",
+    "status.get-rights-claim-form": "Fahrgastrechteformular abrufen",
     "time-format": "HH:mm",
     "time-format.with-day": "HH:mm (DD.MM.YYYY)",
     "datetime-format": "DD.MM.YYYY HH:mm",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -413,6 +413,7 @@
     "status.visibility.3.detail": "Only visible for you",
     "status.visibility.4": "Only logged-in users",
     "status.visibility.4.detail": "Only visible for logged-in users",
+    "status.get-rights-claim-form": "Generate Passenger Rights Claim Form",
     "transport_types.bus": "bus",
     "transport_types.business": "Business Trip",
     "transport_types.businessPlural": "Business Trips",

--- a/resources/views/includes/status.blade.php
+++ b/resources/views/includes/status.blade.php
@@ -99,6 +99,15 @@
                             </a>
                         </p>
                     @endif
+
+                    @if(auth()->user()->can('update', $status) && $status->trainCheckin->isDestinationDelayedEnoughForRightsClaim)
+                        <p>
+                            <a class="btn" href="{{ route('export.rights-claim', ["id" => $status?->id]) }}">
+                                <i class="fa-solid fa-file-circle-exclamation pe-2"></i>
+                                {{ __('status.get-rights-claim-form') }}
+                            </a>
+                        </p>
+                    @endif
                 </li>
                 <li>
                     <i class="trwl-bulletpoint" aria-hidden="true"></i>

--- a/resources/views/pdf/fahrgastrechteformular-datafields.txt
+++ b/resources/views/pdf/fahrgastrechteformular-datafields.txt
@@ -1,0 +1,371 @@
+--- Result of `pdftk fahrgastrechteformular.pdf dump_data_fields > fahrgastrechteformular-datafields.txt`
+--- Just for documentation, is not saved anywhere.
+
+---
+FieldType: Text
+FieldName: S1F1
+FieldNameAlt: Reisedatum Tag (TT)
+FieldFlags: 29360130
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Text
+FieldName: S1F2
+FieldNameAlt: Reisedatum Monat (MM)
+FieldFlags: 29360130
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Text
+FieldName: S1F3
+FieldNameAlt: Reisedatum Jahr (JJ)
+FieldFlags: 29360130
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Text
+FieldName: S1F4
+FieldNameAlt: Startbahnhof
+FieldFlags: 29360130
+FieldJustification: Left
+FieldMaxLength: 26
+---
+FieldType: Text
+FieldName: S1F5
+FieldNameAlt: Abfahrt laut Fahrplan Stunde (HH)
+FieldFlags: 29360130
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Text
+FieldName: S1F6
+FieldNameAlt: Abfahrt laut Fahrplan Minute (MM)
+FieldFlags: 29360130
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Text
+FieldName: S1F7
+FieldNameAlt: Zielbahnhof
+FieldFlags: 29360130
+FieldJustification: Left
+FieldMaxLength: 26
+---
+FieldType: Text
+FieldName: S1F8
+FieldNameAlt: Ankunftszeit laut Fahrplan Stunde (HH)
+FieldFlags: 29360130
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Text
+FieldName: S1F9
+FieldNameAlt: Ankunftszeit laut Fahrplan Minute (MM)
+FieldFlags: 29360130
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Text
+FieldName: S1F10
+FieldNameAlt: Ankunftsdatum Tag (TT)
+FieldFlags: 29360130
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Text
+FieldName: S1F11
+FieldNameAlt: Ankunftsdatum Monat (MM)
+FieldFlags: 29360130
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Text
+FieldName: S1F12
+FieldNameAlt: Ankunftsdatum Jahr (JJ)
+FieldFlags: 29360130
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Text
+FieldName: S1F13
+FieldNameAlt: Angekommen bin ich mit Zug &#8211; Zugart (ICE/IC/RE/RB etc.)
+FieldFlags: 29360130
+FieldJustification: Left
+FieldMaxLength: 3
+---
+FieldType: Text
+FieldName: S1F14
+FieldNameAlt: Angekommen bin ich mit Zug &#8211; Zugnummer
+FieldFlags: 29360130
+FieldJustification: Left
+FieldMaxLength: 5
+---
+FieldType: Text
+FieldName: S1F15
+FieldNameAlt: tats&#228;chliche Ankunft Stunde (HH)
+FieldFlags: 29360130
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Text
+FieldName: S1F16
+FieldNameAlt: tats&#228;chliche Ankunft Minute (MM)
+FieldFlags: 29360130
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Text
+FieldName: S1F17
+FieldNameAlt: Erster versp&#228;teter/ausgefallener Zug &#8211; Zugart (ICE/IC/RE/RB etc.)
+FieldFlags: 29360130
+FieldJustification: Left
+FieldMaxLength: 3
+---
+FieldType: Text
+FieldName: S1F18
+FieldNameAlt: Erster versp&#228;teter/ausgefallener Zug &#8211; Zugnummer
+FieldFlags: 29360130
+FieldJustification: Left
+FieldMaxLength: 5
+---
+FieldType: Text
+FieldName: S1F19
+FieldNameAlt: Erster versp&#228;teter/ausgefallener Zug &#8211; Abfahrt laut Fahrplan Stunde (HH)
+FieldFlags: 29360130
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Text
+FieldName: S1F20
+FieldNameAlt: Erster versp&#228;teter/ausgefallener Zug &#8211; Abfahrt laut Fahrplan Minute (MM)
+FieldFlags: 29360130
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Button
+FieldName: S1F21
+FieldNameAlt: Ich habe den Anschlusszug verpasst im Bahnhof
+FieldFlags: 0
+FieldJustification: Left
+FieldStateOption: Ja
+FieldStateOption: Off
+---
+FieldType: Text
+FieldName: S1F22
+FieldNameAlt: Bahnhofsname
+FieldFlags: 29360128
+FieldJustification: Left
+FieldMaxLength: 14
+---
+FieldType: Button
+FieldName: S1F23
+FieldNameAlt: Der letzte Umstieg erfolgte im Bahnhof
+FieldFlags: 0
+FieldJustification: Left
+FieldStateOption: Ja
+FieldStateOption: Off
+---
+FieldType: Text
+FieldName: S1F24
+FieldNameAlt: Bahnhofsname
+FieldFlags: 29360128
+FieldJustification: Left
+FieldMaxLength: 14
+---
+FieldType: Button
+FieldName: S1F25
+FieldNameAlt: Ich habe meine Reise wegen dieser Versp&#228;tung nicht angetreten oder habe sie im nachfolgenden Bahnhof abgebrochen (und bin gegebenenfalls zur&#252;ckgefahren) bitte Originalbelege beif&#252;gen
+FieldFlags: 0
+FieldJustification: Left
+FieldStateOption: Ja
+FieldStateOption: Off
+---
+FieldType: Text
+FieldName: S1F26
+FieldNameAlt: Bahnhofsname
+FieldFlags: 29360128
+FieldJustification: Left
+FieldMaxLength: 14
+---
+FieldType: Button
+FieldName: S1F27
+FieldNameAlt: Ich habe meine Reise wegen dieser Versp&#228;tung im nachfolgenden Bahnhof unterbrochen und musste mit einem anderen Verkehrsmittel/Zug weiterfahren, f&#252;r das/den zus&#228;tzliche Kosten entstanden sind &#8211; bitte Originalbelege beif&#252;gen
+FieldFlags: 0
+FieldJustification: Left
+FieldStateOption: Ja
+FieldStateOption: Off
+---
+FieldType: Text
+FieldName: S1F28
+FieldNameAlt: Bahnhofsname
+FieldFlags: 29360128
+FieldJustification: Left
+FieldMaxLength: 14
+---
+FieldType: Button
+FieldName: S1F29
+FieldFlags: 49152
+FieldValue: null
+FieldJustification: Left
+FieldStateOption: Auszahlung oder &#220;berweisung
+FieldStateOption: Gutschein
+FieldStateOption: Off
+---
+FieldType: Text
+FieldName: S2F20
+FieldNameAlt: Kontoinhaber (Name, Vorname)
+FieldFlags: 29360128
+FieldJustification: Left
+FieldMaxLength: 37
+---
+FieldType: Text
+FieldName: S2F21
+FieldNameAlt: IBAN
+FieldFlags: 29360128
+FieldJustification: Left
+FieldMaxLength: 34
+---
+FieldType: Text
+FieldName: S2F22
+FieldNameAlt: BIC
+FieldFlags: 29360128
+FieldJustification: Left
+FieldMaxLength: 11
+---
+FieldType: Button
+FieldName: S2F1
+FieldFlags: 49154
+FieldValue: null
+FieldJustification: Left
+FieldStateOption: Frau
+FieldStateOption: Herr
+FieldStateOption: Off
+---
+FieldType: Text
+FieldName: S2F2
+FieldNameAlt: Titel
+FieldFlags: 29360128
+FieldJustification: Left
+FieldMaxLength: 10
+---
+FieldType: Text
+FieldName: S2F3
+FieldNameAlt: Firma
+FieldFlags: 29360128
+FieldJustification: Left
+FieldMaxLength: 37
+---
+FieldType: Text
+FieldName: S2F4
+FieldNameAlt: Name (Nachname)
+FieldFlags: 29360130
+FieldJustification: Left
+FieldMaxLength: 18
+---
+FieldType: Text
+FieldName: S2F5
+FieldNameAlt: Vorname
+FieldFlags: 29360130
+FieldJustification: Left
+FieldMaxLength: 18
+---
+FieldType: Text
+FieldName: S2F6
+FieldNameAlt: c/o (wohnhaft bei) oder Adresszusatz
+FieldFlags: 29360128
+FieldJustification: Left
+FieldMaxLength: 18
+---
+FieldType: Text
+FieldName: S2F7
+FieldNameAlt: Telefonnummer (f&#252;r R&#252;ckfragen)
+FieldFlags: 29360128
+FieldJustification: Left
+FieldMaxLength: 18
+---
+FieldType: Text
+FieldName: S2F8
+FieldNameAlt: Stra&#223;e
+FieldFlags: 29360130
+FieldJustification: Left
+FieldMaxLength: 32
+---
+FieldType: Text
+FieldName: S2F9
+FieldNameAlt: Hausnummer
+FieldFlags: 29360130
+FieldJustification: Left
+FieldMaxLength: 4
+---
+FieldType: Text
+FieldName: S2F10
+FieldNameAlt: Staat (wenn nicht D)
+FieldFlags: 29360128
+FieldJustification: Left
+FieldMaxLength: 3
+---
+FieldType: Text
+FieldName: S2F11
+FieldNameAlt: PLZ
+FieldFlags: 29360130
+FieldJustification: Left
+FieldMaxLength: 5
+---
+FieldType: Text
+FieldName: S2F12
+FieldNameAlt: Wohnort
+FieldFlags: 29360130
+FieldJustification: Left
+FieldMaxLength: 23
+---
+FieldType: Button
+FieldName: S2F13
+FieldFlags: 49152
+FieldValue: null
+FieldJustification: Left
+FieldStateOption: BahnCard 100-Nr.
+FieldStateOption: Off
+FieldStateOption: Zeitkarten-Nr.
+---
+FieldType: Text
+FieldName: S2F15
+FieldNameAlt: BahnCard 100-/Zeitkarten-Nr.
+FieldFlags: 29360128
+FieldJustification: Left
+FieldMaxLength: 18
+---
+FieldType: Text
+FieldName: S2F16
+FieldNameAlt: Geburtsdatum Tag (TT)
+FieldFlags: 29360128
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Text
+FieldName: S2F17
+FieldNameAlt: Geburtsdatum Monat (MM)
+FieldFlags: 29360128
+FieldJustification: Right
+FieldMaxLength: 2
+---
+FieldType: Text
+FieldName: S2F18
+FieldNameAlt: Geburtsdatum Jahr (JJJJ)
+FieldFlags: 29360128
+FieldJustification: Right
+FieldMaxLength: 4
+---
+FieldType: Text
+FieldName: S2F19
+FieldNameAlt: E-Mail Adresse
+FieldFlags: 29360128
+FieldJustification: Left
+FieldMaxLength: 37
+---
+FieldType: Button
+FieldName: S2F23
+FieldNameAlt: Ich bin einverstanden, dass meine Kontaktdaten f&#252;r Marktforschungen im Zusammenhang mit den Fahrgastrechten verwendet anonymisiert genutzt werden (bei Zustimmung bitte ankreuzen)
+FieldFlags: 0
+FieldJustification: Left
+FieldStateOption: Ja
+FieldStateOption: Off

--- a/resources/views/pdf/fahrgastrechteformular.pdf
+++ b/resources/views/pdf/fahrgastrechteformular.pdf
@@ -1,0 +1,5184 @@
+%PDF-1.6
+%âãÏÓ
+1 0 obj 
+<<
+/StructTreeRoot 2 0 R
+/ViewerPreferences 
+<<
+/DisplayDocTitle true
+/Direction /L2R
+>>
+/AcroForm 3 0 R
+/PageLayout /TwoPageLeft
+/MarkInfo 4 0 R
+/Outlines 5 0 R
+/Lang (de)
+/OpenAction 6 0 R
+/Pages 7 0 R
+/Type /Catalog
+/Names 8 0 R
+/OCProperties 
+<<
+/OCGs [9 0 R 10 0 R 11 0 R]
+/D 
+<<
+/Order [9 0 R 10 0 R 11 0 R]
+/ON [9 0 R 10 0 R 11 0 R]
+/RBGroups []
+/Locked [9 0 R 10 0 R 11 0 R]
+/AS [
+<<
+/OCGs [9 0 R]
+/Category [/Print]
+/Event /Print
+>>]
+>>
+>>
+/Metadata 12 0 R
+>>
+endobj 
+3 0 obj 
+<<
+/DR 
+<<
+/Font 
+<<
+/Cour 13 0 R
+/Helv 14 0 R
+/ZaDb 15 0 R
+>>
+/Encoding 
+<<
+/PDFDocEncoding 16 0 R
+>>
+>>
+/DA (/Helv 0 Tf 0 g )
+/Fields [17 0 R 18 0 R 19 0 R 20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R 36 0 R 37 0 R 38 0 R 39 0 R 40 0 R 41 0 R 42 0 R 43 0 R 44 0 R 45 0 R 46 0 R 47 0 R 48 0 R 49 0 R 50 0 R 51 0 R 52 0 R 53 0 R 54 0 R 55 0 R 56 0 R 57 0 R 58 0 R 59 0 R 60 0 R 61 0 R 62 0 R 63 0 R 64 0 R 65 0 R 66 0 R 67 0 R]
+>>
+endobj 
+4 0 obj 
+<<
+/Marked true
+>>
+endobj 
+8 0 obj 
+<<
+/JavaScript 68 0 R
+>>
+endobj 
+68 0 obj 
+<<
+/Names [(bankTransfer) 69 0 R (formats) 70 0 R (nextOnFull) 71 0 R (validators) 72 0 R]
+>>
+endobj 
+69 0 obj 
+<<
+/JS 73 0 R
+/S /JavaScript
+>>
+endobj 
+70 0 obj 
+<<
+/JS (\nfunction format2digits\(\) {\r\n  if\( event.value=="" \) return;\r\n  var v=parseInt\(event.value, 10\);\r\n  if\(v<10\) event.value="0"+v;\r\n}\r)
+/S /JavaScript
+>>
+endobj 
+71 0 obj 
+<<
+/JS 74 0 R
+/S /JavaScript
+>>
+endobj 
+72 0 obj 
+<<
+/JS 75 0 R
+/S /JavaScript
+>>
+endobj 
+9 0 obj 
+<<
+/Name (nichtausdrucken)
+/Type /OCG
+/Usage 
+<<
+/Print 
+<<
+/PrintState /OFF
+>>
+>>
+>>
+endobj 
+10 0 obj 
+<<
+/Name (Codes)
+/Type /OCG
+>>
+endobj 
+76 0 obj [77 0 R 78 0 R 17 0 R 18 0 R 19 0 R 20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R 36 0 R 37 0 R 38 0 R 39 0 R 40 0 R 41 0 R 42 0 R 43 0 R 44 0 R 79 0 R 80 0 R]
+endobj 
+77 0 obj 
+<<
+/Subtype /Link
+/Border [0 0 0]
+/Type /Annot
+/H /N
+/Rect [366.11 589.672 485.237 601.017]
+/StructParent 80
+/A 81 0 R
+/P 82 0 R
+/BS 
+<<
+/Type /Border
+/W 0
+/S /S
+>>
+>>
+endobj 
+78 0 obj 
+<<
+/Subtype /Link
+/Border [0 0 0]
+/Type /Annot
+/H /N
+/Rect [29.0182 575.053 171.055 589.017]
+/StructParent 81
+/A 83 0 R
+/P 82 0 R
+/BS 
+<<
+/Type /Border
+/W 0
+/S /S
+>>
+>>
+endobj 
+17 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 84 0 R
+/V 85 0 R
+/F 86 0 R
+>>
+/T (S1F1)
+/Rect [442.375 421.068 468.34 436.959]
+/MaxLen 2
+/Q 2
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 116
+/MK 
+<<
+>>
+/F 4
+/TU (Reisedatum Tag \(TT\))
+/FT /Tx
+>>
+endobj 
+18 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 87 0 R
+/V 88 0 R
+/F 89 0 R
+>>
+/T (S1F2)
+/Rect [481.314 421.068 507.279 436.959]
+/MaxLen 2
+/Q 2
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 117
+/MK 
+<<
+>>
+/F 4
+/TU (Reisedatum Monat \(MM\))
+/FT /Tx
+>>
+endobj 
+19 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 90 0 R
+/V 91 0 R
+/F 92 0 R
+>>
+/T (S1F3)
+/Rect [519.518 421.068 545.484 436.959]
+/MaxLen 2
+/Q 2
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 118
+/MK 
+<<
+>>
+/F 4
+/TU (Reisedatum Jahr \(JJ\))
+/FT /Tx
+>>
+endobj 
+20 0 obj 
+<<
+/Subtype /Widget
+/T (S1F4)
+/Rect [98.5784 393.211 429.809 409.103]
+/MaxLen 26
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 119
+/MK 
+<<
+>>
+/F 4
+/TU (Startbahnhof)
+/FT /Tx
+>>
+endobj 
+21 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 93 0 R
+/V 94 0 R
+/F 95 0 R
+>>
+/T (S1F5)
+/Rect [480.212 393.618 507.28 409.51]
+/MaxLen 2
+/Q 2
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 121
+/MK 
+<<
+>>
+/F 4
+/TU (Abfahrt laut Fahrplan Stunde \(HH\))
+/FT /Tx
+>>
+endobj 
+22 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 96 0 R
+/V 97 0 R
+/F 98 0 R
+>>
+/T (S1F6)
+/Rect [518.415 393.618 545.484 409.51]
+/MaxLen 2
+/Q 2
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 120
+/MK 
+<<
+>>
+/F 4
+/TU (Abfahrt laut Fahrplan Minute \(MM\))
+/FT /Tx
+>>
+endobj 
+23 0 obj 
+<<
+/Subtype /Widget
+/T (S1F7)
+/Rect [98.1713 350.537 429.402 366.428]
+/MaxLen 26
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 122
+/MK 
+<<
+>>
+/F 4
+/TU (Zielbahnhof)
+/FT /Tx
+>>
+endobj 
+24 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 99 0 R
+/V 100 0 R
+/F 101 0 R
+>>
+/T (S1F8)
+/Rect [480.212 350.537 507.28 366.428]
+/MaxLen 2
+/Q 2
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 124
+/MK 
+<<
+>>
+/F 4
+/TU (Ankunftszeit laut Fahrplan Stunde \(HH\))
+/FT /Tx
+>>
+endobj 
+25 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 102 0 R
+/V 103 0 R
+/F 104 0 R
+>>
+/T (S1F9)
+/Rect [518.415 350.537 545.484 366.428]
+/MaxLen 2
+/Q 2
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 123
+/MK 
+<<
+>>
+/F 4
+/TU (Ankunftszeit laut Fahrplan Minute \(MM\))
+/FT /Tx
+>>
+endobj 
+26 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 105 0 R
+/V 106 0 R
+/F 107 0 R
+>>
+/T (S1F10)
+/Rect [98.327 308.496 123.9 324.388]
+/MaxLen 2
+/Q 2
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 127
+/MK 
+<<
+>>
+/F 4
+/TU (Ankunftsdatum Tag \(TT\))
+/FT /Tx
+>>
+endobj 
+27 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 108 0 R
+/V 109 0 R
+/F 110 0 R
+>>
+/T (S1F11)
+/Rect [136.545 308.496 162.117 324.388]
+/MaxLen 2
+/Q 2
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 126
+/MK 
+<<
+>>
+/F 4
+/TU (Ankunftsdatum Monat \(MM\))
+/FT /Tx
+>>
+endobj 
+28 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 111 0 R
+/V 112 0 R
+/F 113 0 R
+>>
+/T (S1F12)
+/Rect [174.763 308.496 200.335 324.388]
+/MaxLen 2
+/Q 2
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 125
+/MK 
+<<
+>>
+/F 4
+/TU (Ankunftsdatum Jahr \(JJ\))
+/FT /Tx
+>>
+endobj 
+29 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 114 0 R
+>>
+/T (S1F13)
+/Rect [289.735 308.951 328.925 324.842]
+/MaxLen 3
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 130
+/MK 
+<<
+>>
+/F 4
+/TU (Angekommen bin ich mit Zug … Zugart \(ICE/IC/RE/RB etc.\))
+/FT /Tx
+>>
+endobj 
+30 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 115 0 R
+>>
+/T (S1F14)
+/Rect [366.347 308.951 430.884 324.842]
+/MaxLen 5
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 131
+/MK 
+<<
+>>
+/F 4
+/TU (Angekommen bin ich mit Zug … Zugnummer)
+/FT /Tx
+>>
+endobj 
+31 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 116 0 R
+/V 117 0 R
+/F 118 0 R
+>>
+/T (S1F15)
+/Rect [481.326 308.951 508.149 324.842]
+/MaxLen 2
+/Q 2
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 133
+/MK 
+<<
+>>
+/F 4
+/TU (tatsächliche Ankunft Stunde \(HH\))
+/FT /Tx
+>>
+endobj 
+32 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 119 0 R
+/V 120 0 R
+/F 121 0 R
+>>
+/T (S1F16)
+/Rect [519.53 308.951 546.353 324.842]
+/MaxLen 2
+/Q 2
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 132
+/MK 
+<<
+>>
+/F 4
+/TU (tatsächliche Ankunft Minute \(MM\))
+/FT /Tx
+>>
+endobj 
+33 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 122 0 R
+>>
+/T (S1F17)
+/Rect [289.28 266.175 328.47 282.068]
+/MaxLen 3
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 134
+/MK 
+<<
+>>
+/F 4
+/TU (Erster verspäteter/ausgefallener Zug … Zugart \(ICE/IC/RE/RB etc.\))
+/FT /Tx
+>>
+endobj 
+34 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 123 0 R
+>>
+/T (S1F18)
+/Rect [366.802 266.175 431.339 282.068]
+/MaxLen 5
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 135
+/MK 
+<<
+>>
+/F 4
+/TU (Erster verspäteter/ausgefallener Zug … Zugnummer)
+/FT /Tx
+>>
+endobj 
+35 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 124 0 R
+/V 125 0 R
+/F 126 0 R
+>>
+/T (S1F19)
+/Rect [480.781 266.175 507.603 282.068]
+/MaxLen 2
+/Q 2
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 137
+/MK 
+<<
+>>
+/F 4
+/TU (Erster verspäteter/ausgefallener Zug … Abfahrt laut Fahrplan Stunde \(HH\))
+/FT /Tx
+>>
+endobj 
+36 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/V 127 0 R
+/F 128 0 R
+>>
+/T (S1F20)
+/Rect [518.985 266.175 545.808 282.068]
+/MaxLen 2
+/Q 2
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 136
+/MK 
+<<
+>>
+/F 4
+/TU (Erster verspäteter/ausgefallener Zug … Abfahrt laut Fahrplan Minute \(MM\))
+/FT /Tx
+>>
+endobj 
+37 0 obj 
+<<
+/Subtype /Widget
+/T (S1F21)
+/Rect [35.0775 215.555 46.8326 231.717]
+/P 82 0 R
+/DA (/ZaDb 12 Tf 0 g)
+/Type /Annot
+/StructParent 139
+/MK 
+<<
+/CA (4)
+>>
+/AS /Off
+/F 4
+/TU (Ich habe den Anschlusszug verpasst im Bahnhof)
+/AP 
+<<
+/N 
+<<
+/Ja 129 0 R
+>>
+/D 
+<<
+/Ja 130 0 R
+/Off 131 0 R
+>>
+>>
+/FT /Btn
+>>
+endobj 
+132 0 obj 
+<<
+/Subtype /Type1
+/Name /ZaDb
+/Type /Font
+/BaseFont /ZapfDingbats
+>>
+endobj 
+38 0 obj 
+<<
+/Subtype /Widget
+/T (S1F22)
+/Rect [367.415 215.306 544.811 231.198]
+/MaxLen 14
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 138
+/MK 
+<<
+>>
+/F 4
+/TU (Bahnhofsname)
+/FT /Tx
+>>
+endobj 
+39 0 obj 
+<<
+/Subtype /Widget
+/T (S1F23)
+/Rect [35.0775 181.473 46.8326 197.637]
+/P 82 0 R
+/DA (/ZaDb 12 Tf 0 g)
+/Type /Annot
+/StructParent 141
+/MK 
+<<
+/CA (4)
+>>
+/AS /Off
+/F 4
+/TU (Der letzte Umstieg erfolgte im Bahnhof)
+/AP 
+<<
+/N 
+<<
+/Ja 133 0 R
+>>
+/D 
+<<
+/Ja 134 0 R
+/Off 135 0 R
+>>
+>>
+/FT /Btn
+>>
+endobj 
+136 0 obj 
+<<
+/Subtype /Type1
+/Name /ZaDb
+/Type /Font
+/BaseFont /ZapfDingbats
+>>
+endobj 
+40 0 obj 
+<<
+/Subtype /Widget
+/T (S1F24)
+/Rect [367.415 181.583 544.811 197.474]
+/MaxLen 14
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 140
+/MK 
+<<
+>>
+/F 4
+/TU (Bahnhofsname)
+/FT /Tx
+>>
+endobj 
+41 0 obj 
+<<
+/Subtype /Widget
+/T (S1F25)
+/Rect [35.0775 147.112 46.8326 163.275]
+/P 82 0 R
+/DA (/ZaDb 12 Tf 0 g)
+/Type /Annot
+/StructParent 143
+/MK 
+<<
+/CA (4)
+>>
+/AS /Off
+/F 4
+/TU (Ich habe meine Reise wegen dieser Verspätung nicht angetreten oder habe sie im nachfolgenden Bahnhof abgebrochen \(und bin gegebenenfalls zurückgefahren\) bitte Originalbelege beifügen)
+/AP 
+<<
+/N 
+<<
+/Ja 137 0 R
+>>
+/D 
+<<
+/Ja 138 0 R
+/Off 139 0 R
+>>
+>>
+/FT /Btn
+>>
+endobj 
+140 0 obj 
+<<
+/Subtype /Type1
+/Name /ZaDb
+/Type /Font
+/BaseFont /ZapfDingbats
+>>
+endobj 
+42 0 obj 
+<<
+/Subtype /Widget
+/T (S1F26)
+/Rect [367.415 146.999 544.811 162.891]
+/MaxLen 14
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 142
+/MK 
+<<
+>>
+/F 4
+/TU (Bahnhofsname)
+/FT /Tx
+>>
+endobj 
+43 0 obj 
+<<
+/Subtype /Widget
+/T (S1F27)
+/Rect [35.0775 112.983 46.8326 129.146]
+/P 82 0 R
+/DA (/ZaDb 12 Tf 0 g)
+/Type /Annot
+/StructParent 145
+/MK 
+<<
+/CA (4)
+>>
+/AS /Off
+/F 4
+/TU (Ich habe meine Reise wegen dieser Verspätung im nachfolgenden Bahnhof unterbrochen und musste mit einem anderen Verkehrsmittel/Zug weiterfahren, für das/den zusätzliche Kosten entstanden sind … bitte Originalbelege beifügen)
+/AP 
+<<
+/N 
+<<
+/Ja 141 0 R
+>>
+/D 
+<<
+/Ja 142 0 R
+/Off 143 0 R
+>>
+>>
+/FT /Btn
+>>
+endobj 
+144 0 obj 
+<<
+/Subtype /Type1
+/Name /ZaDb
+/Type /Font
+/BaseFont /ZapfDingbats
+>>
+endobj 
+44 0 obj 
+<<
+/Subtype /Widget
+/T (S1F28)
+/Rect [367.415 113.234 544.811 129.125]
+/MaxLen 14
+/P 82 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 144
+/MK 
+<<
+>>
+/F 4
+/TU (Bahnhofsname)
+/FT /Tx
+>>
+endobj 
+79 0 obj 
+<<
+/AA 
+<<
+/D 145 0 R
+>>
+/AP 
+<<
+/N 
+<<
+/Auszahlung#20oder#20#dcberweisung 146 0 R
+>>
+/D 
+<<
+/Auszahlung#20oder#20#dcberweisung 147 0 R
+/Off 148 0 R
+>>
+>>
+/MK 
+<<
+/CA (8)
+>>
+/Subtype /Widget
+/Type /Annot
+/Parent 45 0 R
+/F 4
+/Rect [34.4087 35.1768 47.6113 50.9507]
+/StructParent 146
+/A 149 0 R
+/P 82 0 R
+/AS /Off
+>>
+endobj 
+80 0 obj 
+<<
+/AA 
+<<
+/D 150 0 R
+>>
+/AP 
+<<
+/N 
+<<
+/Gutschein 151 0 R
+>>
+/D 
+<<
+/Gutschein 152 0 R
+/Off 153 0 R
+>>
+>>
+/MK 
+<<
+/CA (8)
+>>
+/Subtype /Widget
+/Type /Annot
+/Parent 45 0 R
+/F 4
+/Rect [366.438 35.1768 379.64 50.9507]
+/StructParent 147
+/A 154 0 R
+/P 82 0 R
+/AS /Off
+>>
+endobj 
+155 0 obj [/ICCBased 156 0 R]
+endobj 
+157 0 obj 
+<<
+/ca 1.0
+/CA 1.0
+/Type /ExtGState
+>>
+endobj 
+158 0 obj 
+<<
+/ca 1.0
+/SA false
+/OPM 0
+/CA 1.0
+/AIS false
+/BM /Normal
+/Type /ExtGState
+/op false
+/SMask /None
+/OP false
+>>
+endobj 
+159 0 obj 
+<<
+/ca 1.0
+/SA true
+/OPM 0
+/CA 1.0
+/AIS false
+/BM /Normal
+/Type /ExtGState
+/op true
+/SMask /None
+/OP true
+>>
+endobj 
+160 0 obj 
+<<
+/ca 1.0
+/SA true
+/OPM 1
+/CA 1.0
+/AIS false
+/BM /Normal
+/Type /ExtGState
+/op false
+/SMask /None
+/OP false
+>>
+endobj 
+161 0 obj 
+<<
+/Descent -226
+/StemV 160
+/FontStretch /Normal
+/FontWeight 700
+/Ascent 1000
+/FontName /UIRLSN+DBSans-Bold
+/ItalicAngle 0
+/CharSet (/space/comma/period/slash/zero/one/two/three/four/six/seven/A/B/C/D/E/F/G/I/K/M/O/R/S/U/V/W/Z/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/r/s/t/u/v/w/z/Udieresis/germandbls/adieresis/odieresis/udieresis)
+/Type /FontDescriptor
+/FontBBox [-240 -226 1141 1000]
+/CapHeight 727
+/Flags 34
+/FontFile3 162 0 R
+/FontFamily (DB Sans)
+/XHeight 532
+>>
+endobj 
+163 0 obj 
+<<
+/Encoding /WinAnsiEncoding
+/ToUnicode 164 0 R
+/Widths [300 0 0 0 0 0 0 0 0 0 0 0 300 0 300 477 600 600 600 600 600 0 600 600 0 0 0 0 0 0 0 0 0 738 692 632 750 646 631 738 0 426 0 729 0 927 0 783 0 0 715 568 0 747 717 1001 0 0 660 0 0 0 0 0 0 579 631 516 631 584 389 562 615 317 316 587 316 909 615 618 631 0 442 485 420 606 568 804 0 0 522 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 747 0 0 635 0 0 0 0 579 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 618 0 0 0 0 0 606]
+/Subtype /Type1
+/Type /Font
+/FirstChar 32
+/LastChar 252
+/FontDescriptor 161 0 R
+/BaseFont /UIRLSN+DBSans-Bold
+>>
+endobj 
+165 0 obj 
+<<
+/Descent -226
+/StemV 92
+/FontStretch /Normal
+/FontWeight 400
+/Ascent 981
+/FontName /UIRLSN+DBSans-Regular
+/ItalicAngle 0
+/CharSet (/space/percent/parenleft/parenright/asterisk/comma/hyphen/period/slash/zero/one/two/four/five/six/seven/colon/A/B/C/D/E/F/G/H/I/J/K/L/M/N/O/P/R/S/T/U/V/W/Z/a/b/c/d/e/f/g/h/i/k/l/m/n/o/p/r/s/t/u/v/w/y/z/endash/Udieresis/germandbls/adieresis/odieresis/udieresis)
+/Type /FontDescriptor
+/FontBBox [-237 -226 1118 981]
+/CapHeight 727
+/Flags 34
+/FontFile3 166 0 R
+/FontFamily (DB Sans)
+/XHeight 518
+>>
+endobj 
+167 0 obj 
+<<
+/Encoding /WinAnsiEncoding
+/ToUnicode 168 0 R
+/Widths [300 0 0 0 0 792 0 0 420 420 391 0 300 300 300 436 600 600 600 0 600 600 600 600 0 0 300 0 0 0 0 0 0 677 668 642 723 613 603 701 762 399 297 659 579 897 772 755 629 0 661 526 613 736 666 940 0 0 624 0 0 0 0 0 0 533 598 493 596 541 354 524 591 296 0 537 291 874 591 581 598 0 405 455 387 582 524 767 0 524 499 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 600 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 736 0 0 595 0 0 0 0 533 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 581 0 0 0 0 0 582]
+/Subtype /Type1
+/Type /Font
+/FirstChar 32
+/LastChar 252
+/FontDescriptor 165 0 R
+/BaseFont /UIRLSN+DBSans-Regular
+>>
+endobj 
+169 0 obj 
+<<
+/K false
+/Type /Group
+/S /Transparency
+>>
+endobj 
+170 0 obj 
+<<
+/OCGs 9 0 R
+/Type /OCMD
+>>
+endobj 
+171 0 obj 
+<<
+/K false
+/Type /Group
+/S /Transparency
+>>
+endobj 
+172 0 obj 
+<<
+/OCGs 10 0 R
+/Type /OCMD
+>>
+endobj 
+81 0 obj 
+<<
+/URI (https://www.fahrgastrechte.info/)
+/S /URI
+>>
+endobj 
+83 0 obj 
+<<
+/URI (https://www.bahn.de/fahrgastrechte)
+/S /URI
+>>
+endobj 
+86 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+84 0 obj 
+<<
+/JS (\nnextOnFull\("S1F2"\);\r)
+/S /JavaScript
+>>
+endobj 
+85 0 obj 
+<<
+/JS (\nisDayOfMonth\(\);\r)
+/S /JavaScript
+>>
+endobj 
+89 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+87 0 obj 
+<<
+/JS (\nnextOnFull\("S1F3"\);\r)
+/S /JavaScript
+>>
+endobj 
+88 0 obj 
+<<
+/JS (\nisMonthOfYear\(\);\r)
+/S /JavaScript
+>>
+endobj 
+92 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+90 0 obj 
+<<
+/JS (\nnextOnFull\("S1F4"\);\r)
+/S /JavaScript
+>>
+endobj 
+91 0 obj 
+<<
+/JS (\nisYearOfCentury\(\);\r)
+/S /JavaScript
+>>
+endobj 
+95 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+93 0 obj 
+<<
+/JS (\nnextOnFull\("S1F6"\);\r)
+/S /JavaScript
+>>
+endobj 
+94 0 obj 
+<<
+/JS (\nisHour\(\);\r)
+/S /JavaScript
+>>
+endobj 
+98 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+96 0 obj 
+<<
+/JS (\nnextOnFull\("S1F7"\);\r)
+/S /JavaScript
+>>
+endobj 
+97 0 obj 
+<<
+/JS (\nisMinute\(\);\r)
+/S /JavaScript
+>>
+endobj 
+101 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+99 0 obj 
+<<
+/JS (\nnextOnFull\("S1F9"\);\r)
+/S /JavaScript
+>>
+endobj 
+100 0 obj 
+<<
+/JS (\nisHour\(\);\r)
+/S /JavaScript
+>>
+endobj 
+104 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+102 0 obj 
+<<
+/JS (\nnextOnFull\("S1F10"\);\r)
+/S /JavaScript
+>>
+endobj 
+103 0 obj 
+<<
+/JS (\nisMinute\(\);\r)
+/S /JavaScript
+>>
+endobj 
+107 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+105 0 obj 
+<<
+/JS (\nnextOnFull\("S1F11"\);\r)
+/S /JavaScript
+>>
+endobj 
+106 0 obj 
+<<
+/JS (\nisDayOfMonth\(\);\r)
+/S /JavaScript
+>>
+endobj 
+110 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+108 0 obj 
+<<
+/JS (\nnextOnFull\("S1F12"\);\r)
+/S /JavaScript
+>>
+endobj 
+109 0 obj 
+<<
+/JS (\nisMonthOfYear\(\);\r)
+/S /JavaScript
+>>
+endobj 
+113 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+111 0 obj 
+<<
+/JS (\nnextOnFull\("S1F13"\);\r)
+/S /JavaScript
+>>
+endobj 
+112 0 obj 
+<<
+/JS (\nisYearOfCentury\(\);\r)
+/S /JavaScript
+>>
+endobj 
+114 0 obj 
+<<
+/JS (\nnextOnFull\("S1F14"\);\r)
+/S /JavaScript
+>>
+endobj 
+115 0 obj 
+<<
+/JS (\nnextOnFull\("S1F15"\);\r)
+/S /JavaScript
+>>
+endobj 
+118 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+116 0 obj 
+<<
+/JS (\nnextOnFull\("S1F16"\);\r)
+/S /JavaScript
+>>
+endobj 
+117 0 obj 
+<<
+/JS (\nisHour\(\);\r)
+/S /JavaScript
+>>
+endobj 
+121 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+119 0 obj 
+<<
+/JS (\nnextOnFull\("S1F17"\);\r)
+/S /JavaScript
+>>
+endobj 
+120 0 obj 
+<<
+/JS (\nisMinute\(\);\r)
+/S /JavaScript
+>>
+endobj 
+12 0 obj 
+<<
+/Subtype /XML
+/Type /Metadata
+/Length 3382
+>>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.6-c016 91.163616, 2018/10/29-16:58:49        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+            xmlns:adhocwf="http://ns.adobe.com/AcrobatAdhocWorkflow/1.0/">
+         <xmp:ModifyDate>2019-06-03T15:19:58+02:00</xmp:ModifyDate>
+         <xmp:CreateDate>2019-05-10T13:47:13+02:00</xmp:CreateDate>
+         <xmp:MetadataDate>2019-06-03T15:19:58+02:00</xmp:MetadataDate>
+         <dc:format>application/pdf</dc:format>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">Fahrgastrechteformular</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <dc:creator>
+            <rdf:Bag/>
+         </dc:creator>
+         <xmpMM:DocumentID>uuid:36045529-e504-4a13-8775-e1900889440b</xmpMM:DocumentID>
+         <xmpMM:InstanceID>uuid:bb27365a-a63e-4ab0-8426-06c195897045</xmpMM:InstanceID>
+         <adhocwf:state>1</adhocwf:state>
+         <adhocwf:version>1.1</adhocwf:version>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                           
+<?xpacket end="w"?>
+endstream 
+endobj 
+11 0 obj 
+<<
+/Name (Version)
+/Type /OCG
+>>
+endobj 
+6 0 obj 
+<<
+/D [82 0 R /Fit]
+/S /GoTo
+>>
+endobj 
+5 0 obj 
+<<
+/Type /Outlines
+/Count 0
+>>
+endobj 
+7 0 obj 
+<<
+/Kids [82 0 R 173 0 R]
+/Type /Pages
+/Count 2
+>>
+endobj 
+2 0 obj 
+<<
+/K 174 0 R
+/ParentTreeNextKey 177
+/Type /StructTreeRoot
+/ParentTree 175 0 R
+>>
+endobj 
+174 0 obj 
+<<
+/K [176 0 R 177 0 R 178 0 R 179 0 R 180 0 R 181 0 R 182 0 R]
+/T ()
+/S /Document
+/P 2 0 R
+>>
+endobj 
+175 0 obj 
+<<
+/Nums [57 183 0 R 80 184 0 R 81 184 0 R 88 185 0 R 116 186 0 R 117 186 0 R 118 186 0 R 119 187 0 R 120 188 0 R 121 188 0 R 122 189 0 R 123 190 0 R 124 190 0 R 125 191 0 R 126 191 0 R 127 191 0 R 130 192 0 R 131 193 0 R 132 194 0 R 133 194 0 R 134 195 0 R 135 196 0 R 136 197 0 R 137 197 0 R 138 198 0 R 139 198 0 R 140 199 0 R 141 199 0 R 142 200 0 R 143 200 0 R 144 201 0 R 145 201 0 R 146 202 0 R 147 203 0 R 148 204 0 R 149 205 0 R 150 206 0 R 151 207 0 R 152 208 0 R 153 209 0 R 154 210 0 R 155 211 0 R 156 212 0 R 157 213 0 R 158 214 0 R 159 215 0 R 160 216 0 R 161 217 0 R 162 218 0 R 163 219 0 R 164 220 0 R 165 221 0 R 166 222 0 R 167 223 0 R 170 223 0 R 171 223 0 R 174 224 0 R 175 225 0 R 176 226 0 R]
+>>
+endobj 
+183 0 obj [227 0 R 228 0 R 229 0 R 230 0 R 184 0 R 231 0 R 232 0 R 233 0 R 234 0 R 235 0 R null 236 0 R 236 0 R 237 0 R 238 0 R 238 0 R 239 0 R 240 0 R 241 0 R 242 0 R 242 0 R 243 0 R 244 0 R 245 0 R 246 0 R 246 0 R 247 0 R 248 0 R 249 0 R 250 0 R 251 0 R 252 0 R null null null 253 0 R 254 0 R 255 0 R null]
+endobj 
+184 0 obj 
+<<
+/K [4 
+<<
+/Type /OBJR
+/Obj 77 0 R
+>> 
+<<
+/Type /OBJR
+/Obj 78 0 R
+>>]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 176 0 R
+>>
+endobj 
+185 0 obj [256 0 R 257 0 R 258 0 R 259 0 R 260 0 R null 261 0 R 262 0 R 263 0 R 264 0 R 265 0 R 266 0 R 267 0 R 268 0 R 269 0 R 270 0 R 271 0 R 272 0 R 273 0 R 274 0 R 275 0 R 275 0 R 276 0 R 226 0 R 277 0 R 278 0 R 279 0 R 280 0 R 281 0 R 282 0 R]
+endobj 
+186 0 obj 
+<<
+/K [
+<<
+/Type /OBJR
+/Obj 17 0 R
+/Pg 82 0 R
+>> 
+<<
+/Type /OBJR
+/Obj 18 0 R
+/Pg 82 0 R
+>> 
+<<
+/Type /OBJR
+/Obj 19 0 R
+/Pg 82 0 R
+>>]
+/T ()
+/S /Form
+/P 234 0 R
+>>
+endobj 
+187 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 20 0 R
+/Pg 82 0 R
+>>
+/T ()
+/S /Form
+/P 235 0 R
+>>
+endobj 
+188 0 obj 
+<<
+/K [
+<<
+/Type /OBJR
+/Obj 21 0 R
+/Pg 82 0 R
+>> 
+<<
+/Type /OBJR
+/Obj 22 0 R
+/Pg 82 0 R
+>>]
+/T ()
+/S /Form
+/P 236 0 R
+>>
+endobj 
+189 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 23 0 R
+/Pg 82 0 R
+>>
+/T ()
+/S /Form
+/P 237 0 R
+>>
+endobj 
+190 0 obj 
+<<
+/K [
+<<
+/Type /OBJR
+/Obj 24 0 R
+/Pg 82 0 R
+>> 
+<<
+/Type /OBJR
+/Obj 25 0 R
+/Pg 82 0 R
+>>]
+/T ()
+/S /Form
+/P 238 0 R
+>>
+endobj 
+191 0 obj 
+<<
+/K [
+<<
+/Type /OBJR
+/Obj 26 0 R
+/Pg 82 0 R
+>> 
+<<
+/Type /OBJR
+/Obj 27 0 R
+/Pg 82 0 R
+>> 
+<<
+/Type /OBJR
+/Obj 28 0 R
+/Pg 82 0 R
+>>]
+/T ()
+/S /Form
+/P 239 0 R
+>>
+endobj 
+192 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 29 0 R
+/Pg 82 0 R
+>>
+/T ()
+/S /Form
+/P 240 0 R
+>>
+endobj 
+193 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 30 0 R
+/Pg 82 0 R
+>>
+/T ()
+/S /Form
+/P 241 0 R
+>>
+endobj 
+194 0 obj 
+<<
+/K [
+<<
+/Type /OBJR
+/Obj 31 0 R
+/Pg 82 0 R
+>> 
+<<
+/Type /OBJR
+/Obj 32 0 R
+/Pg 82 0 R
+>>]
+/T ()
+/S /Form
+/P 242 0 R
+>>
+endobj 
+195 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 33 0 R
+/Pg 82 0 R
+>>
+/T ()
+/S /Form
+/P 244 0 R
+>>
+endobj 
+196 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 34 0 R
+/Pg 82 0 R
+>>
+/T ()
+/S /Form
+/P 245 0 R
+>>
+endobj 
+197 0 obj 
+<<
+/K [
+<<
+/Type /OBJR
+/Obj 35 0 R
+/Pg 82 0 R
+>> 
+<<
+/Type /OBJR
+/Obj 36 0 R
+/Pg 82 0 R
+>>]
+/T ()
+/S /Form
+/P 246 0 R
+>>
+endobj 
+198 0 obj 
+<<
+/K [
+<<
+/Type /OBJR
+/Obj 37 0 R
+/Pg 82 0 R
+>> 
+<<
+/Type /OBJR
+/Obj 38 0 R
+/Pg 82 0 R
+>>]
+/T ()
+/S /Form
+/P 248 0 R
+>>
+endobj 
+199 0 obj 
+<<
+/K [
+<<
+/Type /OBJR
+/Obj 39 0 R
+/Pg 82 0 R
+>> 
+<<
+/Type /OBJR
+/Obj 40 0 R
+/Pg 82 0 R
+>>]
+/T ()
+/S /Form
+/P 249 0 R
+>>
+endobj 
+200 0 obj 
+<<
+/K [
+<<
+/Type /OBJR
+/Obj 41 0 R
+/Pg 82 0 R
+>> 
+<<
+/Type /OBJR
+/Obj 42 0 R
+/Pg 82 0 R
+>>]
+/T ()
+/S /Form
+/P 250 0 R
+>>
+endobj 
+201 0 obj 
+<<
+/K [
+<<
+/Type /OBJR
+/Obj 43 0 R
+/Pg 82 0 R
+>> 
+<<
+/Type /OBJR
+/Obj 44 0 R
+/Pg 82 0 R
+>>]
+/T ()
+/S /Form
+/P 251 0 R
+>>
+endobj 
+202 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 79 0 R
+/Pg 82 0 R
+>>
+/T ()
+/S /Form
+/P 254 0 R
+>>
+endobj 
+203 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 80 0 R
+/Pg 82 0 R
+>>
+/T ()
+/S /Form
+/P 255 0 R
+>>
+endobj 
+204 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 46 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 257 0 R
+>>
+endobj 
+205 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 47 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 258 0 R
+>>
+endobj 
+206 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 48 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 259 0 R
+>>
+endobj 
+207 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 283 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 262 0 R
+>>
+endobj 
+208 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 284 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 263 0 R
+>>
+endobj 
+209 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 50 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 264 0 R
+>>
+endobj 
+210 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 51 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 265 0 R
+>>
+endobj 
+211 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 52 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 266 0 R
+>>
+endobj 
+212 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 53 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 267 0 R
+>>
+endobj 
+213 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 54 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 268 0 R
+>>
+endobj 
+214 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 55 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 269 0 R
+>>
+endobj 
+215 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 56 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 270 0 R
+>>
+endobj 
+216 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 57 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 271 0 R
+>>
+endobj 
+217 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 58 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 272 0 R
+>>
+endobj 
+218 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 59 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 273 0 R
+>>
+endobj 
+219 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 60 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 274 0 R
+>>
+endobj 
+220 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 285 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 275 0 R
+>>
+endobj 
+221 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 286 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 275 0 R
+>>
+endobj 
+222 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 62 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 275 0 R
+>>
+endobj 
+223 0 obj 
+<<
+/K [
+<<
+/Type /OBJR
+/Obj 63 0 R
+/Pg 173 0 R
+>> 
+<<
+/Type /OBJR
+/Obj 64 0 R
+/Pg 173 0 R
+>> 
+<<
+/Type /OBJR
+/Obj 65 0 R
+/Pg 173 0 R
+>>]
+/T ()
+/S /Form
+/P 276 0 R
+>>
+endobj 
+224 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 67 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 277 0 R
+>>
+endobj 
+225 0 obj 
+<<
+/K 
+<<
+/Type /OBJR
+/Obj 66 0 R
+/Pg 173 0 R
+>>
+/T ()
+/S /Form
+/P 278 0 R
+>>
+endobj 
+226 0 obj 
+<<
+/K [23 
+<<
+/Type /OBJR
+/Obj 287 0 R
+>>]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 181 0 R
+>>
+endobj 
+181 0 obj 
+<<
+/K [226 0 R 277 0 R 278 0 R]
+/T ()
+/S /Sect
+/P 174 0 R
+>>
+endobj 
+277 0 obj 
+<<
+/K [24 224 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 181 0 R
+>>
+endobj 
+278 0 obj 
+<<
+/K [25 225 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 181 0 R
+>>
+endobj 
+276 0 obj 
+<<
+/K [22 223 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 180 0 R
+>>
+endobj 
+180 0 obj 
+<<
+/K [260 0 R 261 0 R 262 0 R 263 0 R 264 0 R 265 0 R 266 0 R 267 0 R 268 0 R 269 0 R 270 0 R 271 0 R 272 0 R 273 0 R 274 0 R 275 0 R 276 0 R]
+/T ()
+/S /Sect
+/P 174 0 R
+>>
+endobj 
+260 0 obj 
+<<
+/K 4
+/Pg 173 0 R
+/T ()
+/S /H2
+/P 180 0 R
+>>
+endobj 
+261 0 obj 
+<<
+/K 6
+/Pg 173 0 R
+/T ()
+/S /Note
+/P 180 0 R
+>>
+endobj 
+262 0 obj 
+<<
+/K [7 207 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 180 0 R
+>>
+endobj 
+263 0 obj 
+<<
+/K [8 208 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 180 0 R
+>>
+endobj 
+264 0 obj 
+<<
+/K [9 209 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 180 0 R
+>>
+endobj 
+265 0 obj 
+<<
+/K [10 210 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 180 0 R
+>>
+endobj 
+266 0 obj 
+<<
+/K [11 211 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 180 0 R
+>>
+endobj 
+267 0 obj 
+<<
+/K [12 212 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 180 0 R
+>>
+endobj 
+268 0 obj 
+<<
+/K [13 213 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 180 0 R
+>>
+endobj 
+269 0 obj 
+<<
+/K [14 214 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 180 0 R
+>>
+endobj 
+270 0 obj 
+<<
+/K [15 215 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 180 0 R
+>>
+endobj 
+271 0 obj 
+<<
+/K [16 216 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 180 0 R
+>>
+endobj 
+272 0 obj 
+<<
+/K [17 217 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 180 0 R
+>>
+endobj 
+273 0 obj 
+<<
+/K [18 218 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 180 0 R
+>>
+endobj 
+274 0 obj 
+<<
+/K [19 219 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 180 0 R
+>>
+endobj 
+275 0 obj 
+<<
+/K [20 220 0 R 21 221 0 R 222 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 180 0 R
+>>
+endobj 
+259 0 obj 
+<<
+/K [3 206 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 179 0 R
+>>
+endobj 
+179 0 obj 
+<<
+/K [256 0 R 281 0 R 257 0 R 258 0 R 259 0 R]
+/T ()
+/S /Sect
+/P 174 0 R
+>>
+endobj 
+256 0 obj 
+<<
+/K 0
+/Pg 173 0 R
+/T ()
+/S /H2
+/P 179 0 R
+>>
+endobj 
+281 0 obj 
+<<
+/K 28
+/Pg 173 0 R
+/T ()
+/S /Note
+/P 179 0 R
+>>
+endobj 
+257 0 obj 
+<<
+/K [1 204 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 179 0 R
+>>
+endobj 
+258 0 obj 
+<<
+/K [2 205 0 R]
+/Pg 173 0 R
+/T ()
+/S /P
+/P 179 0 R
+>>
+endobj 
+255 0 obj 
+<<
+/K [37 203 0 R]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 178 0 R
+>>
+endobj 
+178 0 obj 
+<<
+/K [252 0 R 253 0 R 254 0 R 255 0 R]
+/T ()
+/S /Sect
+/P 174 0 R
+>>
+endobj 
+252 0 obj 
+<<
+/K 31
+/Pg 82 0 R
+/T ()
+/S /H2
+/P 178 0 R
+>>
+endobj 
+253 0 obj 
+<<
+/K 35
+/Pg 82 0 R
+/T ()
+/S /Note
+/P 178 0 R
+>>
+endobj 
+254 0 obj 
+<<
+/K [36 202 0 R]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 178 0 R
+>>
+endobj 
+251 0 obj 
+<<
+/K [30 201 0 R]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+177 0 obj 
+<<
+/K [233 0 R 232 0 R 234 0 R 235 0 R 236 0 R 237 0 R 238 0 R 239 0 R 240 0 R 241 0 R 242 0 R 243 0 R 244 0 R 245 0 R 246 0 R 247 0 R 248 0 R 249 0 R 250 0 R 251 0 R]
+/T ()
+/S /Sect
+/P 174 0 R
+>>
+endobj 
+233 0 obj 
+<<
+/K 7
+/Pg 82 0 R
+/T ()
+/S /H2
+/P 177 0 R
+>>
+endobj 
+232 0 obj 
+<<
+/K 6
+/Pg 82 0 R
+/T ()
+/S /Note
+/P 177 0 R
+>>
+endobj 
+234 0 obj 
+<<
+/K [8 186 0 R]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+235 0 obj 
+<<
+/K [9 187 0 R]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+236 0 obj 
+<<
+/K [11 188 0 R 12]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+237 0 obj 
+<<
+/K [13 189 0 R]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+238 0 obj 
+<<
+/K [14 190 0 R 15]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+239 0 obj 
+<<
+/K [16 191 0 R]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+240 0 obj 
+<<
+/K [17 192 0 R]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+241 0 obj 
+<<
+/K [18 193 0 R]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+242 0 obj 
+<<
+/K [19 194 0 R 20]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+243 0 obj 
+<<
+/K 21
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+244 0 obj 
+<<
+/K [22 195 0 R]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+245 0 obj 
+<<
+/K [23 196 0 R]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+246 0 obj 
+<<
+/K [24 197 0 R 25]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+247 0 obj 
+<<
+/K 26
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+248 0 obj 
+<<
+/K [27 198 0 R]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+249 0 obj 
+<<
+/K [28 199 0 R]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+250 0 obj 
+<<
+/K [29 200 0 R]
+/Pg 82 0 R
+/T ()
+/S /P
+/P 177 0 R
+>>
+endobj 
+45 0 obj 
+<<
+/Ff 49152
+/FT /Btn
+/Kids [79 0 R 80 0 R]
+/V /null
+/T (S1F29)
+/TU (Gewünschte Art der Entschädigung … 1\) Auszahlung in der Verkaufsstelle oder Überweisung 2\) Gutschein)
+>>
+endobj 
+49 0 obj 
+<<
+/Ff 49154
+/FT /Btn
+/Kids [283 0 R 284 0 R]
+/V /null
+/T (S2F1)
+/TU (Anrede: 1\) Frau 2\) Herr)
+>>
+endobj 
+61 0 obj 
+<<
+/Ff 49152
+/FT /Btn
+/Kids [285 0 R 286 0 R]
+/V /null
+/T (S2F13)
+/TU (BahnCard oder Zeitkarten-Nr.)
+>>
+endobj 
+13 0 obj 
+<<
+/Encoding 16 0 R
+/Subtype /Type1
+/Name /Cour
+/Type /Font
+/BaseFont /Courier
+>>
+endobj 
+14 0 obj 
+<<
+/Encoding 16 0 R
+/Subtype /Type1
+/Name /Helv
+/Type /Font
+/BaseFont /Helvetica
+>>
+endobj 
+15 0 obj 
+<<
+/Subtype /Type1
+/Name /ZaDb
+/Type /Font
+/BaseFont /ZapfDingbats
+>>
+endobj 
+16 0 obj 
+<<
+/Type /Encoding
+/Differences [24 /breve /caron /circumflex /dotaccent /hungarumlaut /ogonek /ring /tilde 39 /quotesingle 96 /grave 128 /bullet /dagger /daggerdbl /ellipsis /emdash /endash /florin /fraction /guilsinglleft /guilsinglright /minus /perthousand /quotedblbase /quotedblleft /quotedblright /quoteleft /quoteright /quotesinglbase /trademark /fi /fl /Lslash /OE /Scaron /Ydieresis /Zcaron /dotlessi /lslash /oe /scaron /zcaron 160 /Euro 164 /currency 166 /brokenbar 168 /dieresis /copyright /ordfeminine 172 /logicalnot /.notdef /registered /macron /degree /plusminus /twosuperior /threesuperior /acute /mu 183 /periodcentered /cedilla /onesuperior /ordmasculine 188 /onequarter /onehalf /threequarters 192 /Agrave /Aacute /Acircumflex /Atilde /Adieresis /Aring /AE /Ccedilla /Egrave /Eacute /Ecircumflex /Edieresis /Igrave /Iacute /Icircumflex /Idieresis /Eth /Ntilde /Ograve /Oacute /Ocircumflex /Otilde /Odieresis /multiply /Oslash /Ugrave /Uacute /Ucircumflex /Udieresis /Yacute /Thorn /germandbls /agrave /aacute /acircumflex /atilde /adieresis /aring /ae /ccedilla /egrave /eacute /ecircumflex /edieresis /igrave /iacute /icircumflex /idieresis /eth /ntilde /ograve /oacute /ocircumflex /otilde /odieresis /divide /oslash /ugrave /uacute /ucircumflex /udieresis /yacute /thorn /ydieresis]
+>>
+endobj 
+51 0 obj 
+<<
+/Subtype /Widget
+/T (S2F3)
+/Rect [34.7072 574.75 506.795 590.641]
+/MaxLen 37
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 154
+/MK 
+<<
+>>
+/F 4
+/TU (Firma)
+/FT /Tx
+>>
+endobj 
+283 0 obj 
+<<
+/AA 
+<<
+/D 288 0 R
+>>
+/AP 
+<<
+/N 
+<<
+/Frau 289 0 R
+>>
+/D 
+<<
+/Frau 290 0 R
+/Off 291 0 R
+>>
+>>
+/MK 
+<<
+/CA (8)
+>>
+/Subtype /Widget
+/Type /Annot
+/Parent 49 0 R
+/F 4
+/Rect [34.7072 609.376 47.0195 625.607]
+/StructParent 151
+/A 292 0 R
+/P 173 0 R
+/AS /Off
+>>
+endobj 
+48 0 obj 
+<<
+/Subtype /Widget
+/T (S2F22)
+/Rect [34.41 673.77 176.432 689.661]
+/MaxLen 11
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 150
+/MK 
+<<
+>>
+/F 4
+/TU (BIC)
+/FT /Tx
+>>
+endobj 
+284 0 obj 
+<<
+/AA 
+<<
+/D 293 0 R
+>>
+/AP 
+<<
+/N 
+<<
+/Herr 294 0 R
+>>
+/D 
+<<
+/Herr 295 0 R
+/Off 296 0 R
+>>
+>>
+/MK 
+<<
+/CA (8)
+>>
+/Subtype /Widget
+/Type /Annot
+/Parent 49 0 R
+/F 4
+/Rect [98.6047 609.595 110.916 625.826]
+/StructParent 152
+/A 297 0 R
+/P 173 0 R
+/AS /Off
+>>
+endobj 
+292 0 obj 
+<<
+/JS (\n\(function\(doc, field\) {\r\n  if\( field.value==field._valueOnMousedown \) {\r\n    field.value=null;\r\n  }\r\n}\(event.target.doc, event.target\)\);\r)
+/S /JavaScript
+>>
+endobj 
+47 0 obj 
+<<
+/Subtype /Widget
+/T (S2F21)
+/Rect [34.41 707.631 468.126 723.522]
+/MaxLen 34
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 149
+/MK 
+<<
+>>
+/F 4
+/TU (IBAN)
+/FT /Tx
+>>
+endobj 
+287 0 obj 
+<<
+/Subtype /Link
+/Border [0 0 0]
+/Type /Annot
+/H /N
+/Rect [425.454 335.599 526.254 344.927]
+/StructParent 176
+/A 298 0 R
+/P 173 0 R
+/BS 
+<<
+/Type /Border
+/W 0
+/S /S
+>>
+>>
+endobj 
+46 0 obj 
+<<
+/Subtype /Widget
+/T (S2F20)
+/Rect [33.8817 741.574 506.425 757.465]
+/MaxLen 37
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 148
+/MK 
+<<
+>>
+/F 4
+/TU (Kontoinhaber \(Name, Vorname\))
+/FT /Tx
+>>
+endobj 
+50 0 obj 
+<<
+/Subtype /Widget
+/T (S2F2)
+/Rect [149.164 609.633 277.252 625.524]
+/MaxLen 10
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 153
+/MK 
+<<
+>>
+/F 4
+/TU (Titel)
+/FT /Tx
+>>
+endobj 
+52 0 obj 
+<<
+/Subtype /Widget
+/T (S2F4)
+/Rect [34.7072 541.085 264.182 556.976]
+/MaxLen 18
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 155
+/MK 
+<<
+>>
+/F 4
+/TU (Name \(Nachname\))
+/FT /Tx
+>>
+endobj 
+54 0 obj 
+<<
+/Subtype /Widget
+/T (S2F6)
+/Rect [34.7072 506.494 264.182 522.385]
+/MaxLen 18
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 157
+/MK 
+<<
+>>
+/F 4
+/TU (c/o \(wohnhaft bei\) oder Adresszusatz)
+/FT /Tx
+>>
+endobj 
+53 0 obj 
+<<
+/Subtype /Widget
+/T (S2F5)
+/Rect [277.605 541.085 506.03 556.976]
+/MaxLen 18
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 156
+/MK 
+<<
+>>
+/F 4
+/TU (Vorname)
+/FT /Tx
+>>
+endobj 
+56 0 obj 
+<<
+/Subtype /Widget
+/T (S2F8)
+/Rect [34.7072 472.957 442.803 488.849]
+/MaxLen 32
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 159
+/MK 
+<<
+>>
+/F 4
+/TU (Straße)
+/FT /Tx
+>>
+endobj 
+55 0 obj 
+<<
+/Subtype /Widget
+/T (S2F7)
+/Rect [277.605 506.494 506.03 522.385]
+/MaxLen 18
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 158
+/MK 
+<<
+>>
+/F 4
+/TU (Telefonnummer \(für Rückfragen\))
+/FT /Tx
+>>
+endobj 
+57 0 obj 
+<<
+/Subtype /Widget
+/T (S2F9)
+/Rect [454.735 472.957 506.047 488.849]
+/MaxLen 4
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 160
+/MK 
+<<
+>>
+/F 4
+/TU (Hausnummer)
+/FT /Tx
+>>
+endobj 
+58 0 obj 
+<<
+/Subtype /Widget
+/T (S2F10)
+/Rect [34.7072 438.828 73.5297 454.719]
+/MaxLen 3
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 161
+/MK 
+<<
+>>
+/F 4
+/TU (Staat \(wenn nicht D\))
+/FT /Tx
+>>
+endobj 
+59 0 obj 
+<<
+/Subtype /Widget
+/T (S2F11)
+/Rect [136.318 438.828 200.121 454.719]
+/MaxLen 5
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 162
+/MK 
+<<
+>>
+/F 4
+/TU (PLZ)
+/FT /Tx
+>>
+endobj 
+60 0 obj 
+<<
+/Subtype /Widget
+/T (S2F12)
+/Rect [213.172 438.828 505.856 454.719]
+/MaxLen 23
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360130
+/Type /Annot
+/StructParent 163
+/MK 
+<<
+>>
+/F 4
+/TU (Wohnort)
+/FT /Tx
+>>
+endobj 
+285 0 obj 
+<<
+/AA 
+<<
+/D 299 0 R
+>>
+/AP 
+<<
+/N 
+<<
+/BahnCard#20100-Nr. 300 0 R
+>>
+/D 
+<<
+/BahnCard#20100-Nr. 301 0 R
+/Off 302 0 R
+>>
+>>
+/MK 
+<<
+/CA (8)
+>>
+/Subtype /Widget
+/Type /Annot
+/Parent 61 0 R
+/F 4
+/Rect [34.4106 405.441 47.8303 421.065]
+/StructParent 164
+/A 303 0 R
+/P 173 0 R
+/AS /Off
+>>
+endobj 
+303 0 obj 
+<<
+/JS (\n\(function\(doc, field\) {\r\n  if\( field.value==field._valueOnMousedown \) {\r\n    field.value=null;\r\n  }\r\n}\(event.target.doc, event.target\)\);\r)
+/S /JavaScript
+>>
+endobj 
+304 0 obj 
+<<
+/Subtype /Type1
+/Name /ZaDb
+/Type /Font
+/BaseFont /ZapfDingbats
+>>
+endobj 
+305 0 obj 
+<<
+/JS (\n\(function\(doc, field\) {\r\n  if\( field.value==field._valueOnMousedown \) {\r\n    field.value=null;\r\n  }\r\n}\(event.target.doc, event.target\)\);\r)
+/S /JavaScript
+>>
+endobj 
+298 0 obj 
+<<
+/URI (https://www.bahn.de/datenschutz)
+/S /URI
+>>
+endobj 
+299 0 obj 
+<<
+/JS (\n\(function\(doc, field\) {\r\n  field._valueOnMousedown=field.value;\r\n}\(event.target.doc, event.target\)\);\r)
+/S /JavaScript
+>>
+endobj 
+306 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+307 0 obj 
+<<
+/JS (\n\(function\(doc, field\) {\r\n  field._valueOnMousedown=field.value;\r\n}\(event.target.doc, event.target\)\);\r)
+/S /JavaScript
+>>
+endobj 
+67 0 obj 
+<<
+/Subtype /Widget
+/T (S2F23)
+/Rect [34.9341 315.672 46.6892 331.835]
+/P 173 0 R
+/DA (/ZaDb 12 Tf 0 g)
+/Type /Annot
+/StructParent 174
+/MK 
+<<
+/CA (4)
+>>
+/AS /Off
+/F 4
+/TU (Ich bin einverstanden, dass meine Kontaktdaten für Marktforschungen im Zusammenhang mit den Fahrgastrechten verwendet anonymisiert genutzt werden \(bei Zustimmung bitte ankreuzen\))
+/AP 
+<<
+/N 
+<<
+/Ja 308 0 R
+>>
+/D 
+<<
+/Ja 309 0 R
+/Off 310 0 R
+>>
+>>
+/FT /Btn
+>>
+endobj 
+297 0 obj 
+<<
+/JS (\n\(function\(doc, field\) {\r\n  if\( field.value==field._valueOnMousedown \) {\r\n    field.value=null;\r\n  }\r\n}\(event.target.doc, event.target\)\);\r)
+/S /JavaScript
+>>
+endobj 
+311 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+312 0 obj 
+<<
+/JS (\nnextOnFull\("S2F17"\);\r)
+/S /JavaScript
+>>
+endobj 
+66 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/V 313 0 R
+>>
+/T (S2F19)
+/Rect [59.7919 262.732 531.88 278.623]
+/MaxLen 37
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 175
+/MK 
+<<
+>>
+/F 4
+/TU (E-Mail Adresse)
+/FT /Tx
+>>
+endobj 
+288 0 obj 
+<<
+/JS (\n\(function\(doc, field\) {\r\n  field._valueOnMousedown=field.value;\r\n}\(event.target.doc, event.target\)\);\r)
+/S /JavaScript
+>>
+endobj 
+293 0 obj 
+<<
+/JS (\n\(function\(doc, field\) {\r\n  field._valueOnMousedown=field.value;\r\n}\(event.target.doc, event.target\)\);\r)
+/S /JavaScript
+>>
+endobj 
+63 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 312 0 R
+/V 314 0 R
+/F 306 0 R
+>>
+/T (S2F16)
+/Rect [277.011 387.862 303.466 403.753]
+/MaxLen 2
+/Q 2
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 167
+/MK 
+<<
+>>
+/F 4
+/TU (Geburtsdatum Tag \(TT\))
+/FT /Tx
+>>
+endobj 
+286 0 obj 
+<<
+/AA 
+<<
+/D 307 0 R
+>>
+/AP 
+<<
+/N 
+<<
+/Zeitkarten-Nr. 315 0 R
+>>
+/D 
+<<
+/Zeitkarten-Nr. 316 0 R
+/Off 317 0 R
+>>
+>>
+/MK 
+<<
+/CA (8)
+>>
+/Subtype /Widget
+/Type /Annot
+/Parent 61 0 R
+/F 4
+/Rect [135.963 405.441 149.383 421.065]
+/StructParent 165
+/A 305 0 R
+/P 173 0 R
+/AS /Off
+>>
+endobj 
+62 0 obj 
+<<
+/Subtype /Widget
+/T (S2F15)
+/Rect [34.7072 387.862 264.549 403.753]
+/MaxLen 18
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 166
+/MK 
+<<
+>>
+/F 4
+/TU (BahnCard 100-/Zeitkarten-Nr.)
+/FT /Tx
+>>
+endobj 
+64 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 318 0 R
+/V 319 0 R
+/F 311 0 R
+>>
+/T (S2F17)
+/Rect [314.725 387.862 341.18 403.753]
+/MaxLen 2
+/Q 2
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 170
+/MK 
+<<
+>>
+/F 4
+/TU (Geburtsdatum Monat \(MM\))
+/FT /Tx
+>>
+endobj 
+65 0 obj 
+<<
+/Subtype /Widget
+/AA 
+<<
+/K 320 0 R
+/V 321 0 R
+>>
+/T (S2F18)
+/Rect [353.419 387.862 404.364 403.753]
+/MaxLen 4
+/Q 2
+/P 173 0 R
+/DA (/Cour 11 Tf 0 g)
+/Ff 29360128
+/Type /Annot
+/StructParent 171
+/MK 
+<<
+>>
+/F 4
+/TU (Geburtsdatum Jahr \(JJJJ\))
+/FT /Tx
+>>
+endobj 
+321 0 obj 
+<<
+/JS (\nisYearOfCenturyFourDigits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+313 0 obj 
+<<
+/JS (\nvar reEmail = /^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z0-9]{2,}$/i; \r\nif \(!reEmail.test\(event.value\)\) { \r\napp.alert\("Ungültige E-Mail-Adresse!"\); \r\nevent.rc = false; } \r)
+/S /JavaScript
+>>
+endobj 
+320 0 obj 
+<<
+/JS (\nnextOnFull\("S2F19"\);\r)
+/S /JavaScript
+>>
+endobj 
+314 0 obj 
+<<
+/JS (\nisDayOfMonth\(\);\r)
+/S /JavaScript
+>>
+endobj 
+318 0 obj 
+<<
+/JS (\nnextOnFull\("S2F18"\);\r)
+/S /JavaScript
+>>
+endobj 
+319 0 obj 
+<<
+/JS (\nisMonthOfYear\(\);\r)
+/S /JavaScript
+>>
+endobj 
+73 0 obj 
+<<
+/Filter /FlateDecode
+/Length 153
+>>
+stream
+xœAÂ E÷M¼Ã¤+HL£,5İö ê¦J4àÆpwi¤uUu53?ïO^õgio'’Ö÷H-ë£UÁ8Ë´S«
+€0D²ïÀc8à¡ŞÍ0áÀ'  W›†Îà]³ú(:±©yC¥Õæe¿ŒnÿGÅZŒÃÕø’¥õlß9ıGı§÷TaüÛÿq¤|$6¦<³/q˜e:
+endstream 
+endobj 
+74 0 obj 
+<<
+/Filter /FlateDecode
+/Length 207
+>>
+stream
+xœMÁŠÃ †ï¾ÃœŠH{ÊBOKö\Ù©BÃ–¥ï¾Ú„¦A¿ïÿgl=CÀ_ş
+×LÔár0ìcş@5l4Š'Ÿúú°ëêå:d}Ã-´Æœ*ÁnD¾Vü&õ»c.¸3“#¾Ú ë¹4T>ú›çMñN€Oƒ„y²hñÂâ,%H ¶íát‚4ÅLb ;|#X$¬ëÂŞÓ^ãàx,ã”X.š2¶Fv„aä©Ô¹.•?D““XW”ó!ëå²¼bb
+endstream 
+endobj 
+75 0 obj 
+<<
+/Filter /FlateDecode
+/Length 349
+>>
+stream
+xœµ’QkÂ0Çß~‡[¤…"­²§a°ÉØÃ‡m{<õ¢MKšİÜw_Ò_Ööp\Âı“ÿ/—¸‘K-r	¢|’:Â1|õ€
+T¬@U’«PER*ÜJ Kã‰Ó(ÒFI+cgeè÷§¬r¹š²Xéw/èg^3<ÌùK.õ&jíàìÆÂÇ+K`”Å·†µ7Å ·¤tŞ	­	Ö´ 	¯‚`eó®m.Áš .åUØ07&jÉ8nKrl“¸škÎ?UWºlèGWSÕ|Ï¸QäÇçÀæüŞÊŒ:t"L=±áú;ÕCnÔL¬….£	ìpßrÚ-}((çõš…F®ˆI«n!§)Ü¸JmkÏÔv}¡¥÷“_{pâø×6<Ú—wı“áÈÆÆ«v¯—vn¼oÔ'	í7ØBM]é®}&ÆFs»İebC
+endstream 
+endobj 
+173 0 obj 
+<<
+/ArtBox [0.0 0.0 595.276 841.89]
+/Rotate 0
+/Parent 7 0 R
+/StructParents 88
+/TrimBox [0.0 0.0 595.276 841.89]
+/Tabs /S
+/Contents 322 0 R
+/CropBox [0.0 0.0 595.276 841.89]
+/Annots 323 0 R
+/MediaBox [0.0 0.0 595.276 841.89]
+/Resources 
+<<
+/Font 
+<<
+/T1_1 167 0 R
+/T1_0 163 0 R
+>>
+/ProcSet [/PDF /Text]
+/XObject 
+<<
+/Fm2 324 0 R
+/Fm1 325 0 R
+/Fm0 326 0 R
+>>
+/ExtGState 
+<<
+/GS3 160 0 R
+/GS2 159 0 R
+/GS1 158 0 R
+/GS0 157 0 R
+>>
+/ColorSpace 
+<<
+/CS0 155 0 R
+>>
+>>
+/BleedBox [0.0 0.0 595.276 841.89]
+/Type /Page
+>>
+endobj 
+82 0 obj 
+<<
+/ArtBox [0.0 0.0 595.276 841.89]
+/Rotate 0
+/Parent 7 0 R
+/StructParents 57
+/TrimBox [0.0 0.0 595.276 841.89]
+/Tabs /S
+/Contents [327 0 R 328 0 R 329 0 R 330 0 R 331 0 R 332 0 R 333 0 R 334 0 R]
+/CropBox [0.0 0.0 595.276 841.89]
+/Annots 76 0 R
+/MediaBox [0.0 0.0 595.276 841.89]
+/Resources 
+<<
+/Font 
+<<
+/T1_1 167 0 R
+/T1_0 163 0 R
+>>
+/ProcSet [/PDF /Text]
+/XObject 
+<<
+/Fm1 335 0 R
+/Fm0 336 0 R
+>>
+/ExtGState 
+<<
+/GS3 160 0 R
+/GS2 159 0 R
+/GS1 158 0 R
+/GS0 157 0 R
+>>
+/ColorSpace 
+<<
+/CS0 155 0 R
+>>
+>>
+/BleedBox [0.0 0.0 595.276 841.89]
+/Type /Page
+>>
+endobj 
+122 0 obj 
+<<
+/JS (\nnextOnFull\("S1F18"\);\r)
+/S /JavaScript
+>>
+endobj 
+123 0 obj 
+<<
+/JS (\nnextOnFull\("S1F19"\);\r)
+/S /JavaScript
+>>
+endobj 
+126 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+124 0 obj 
+<<
+/JS (\nnextOnFull\("S1F20"\);\r)
+/S /JavaScript
+>>
+endobj 
+125 0 obj 
+<<
+/JS (\nisHour\(\);\r)
+/S /JavaScript
+>>
+endobj 
+128 0 obj 
+<<
+/JS (\nformat2digits\(\);\r)
+/S /JavaScript
+>>
+endobj 
+127 0 obj 
+<<
+/JS (\nisMinute\(\);\r)
+/S /JavaScript
+>>
+endobj 
+149 0 obj 
+<<
+/JS 337 0 R
+/S /JavaScript
+>>
+endobj 
+145 0 obj 
+<<
+/JS (\n\(function\(doc, field\) {\r\n  field._valueOnMousedown=field.value;\r\n}\(event.target.doc, event.target\)\);\r)
+/S /JavaScript
+>>
+endobj 
+154 0 obj 
+<<
+/JS 338 0 R
+/S /JavaScript
+>>
+endobj 
+150 0 obj 
+<<
+/JS (\n\(function\(doc, field\) {\r\n  field._valueOnMousedown=field.value;\r\n}\(event.target.doc, event.target\)\);\r)
+/S /JavaScript
+>>
+endobj 
+130 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/Font 
+<<
+/ZaDb 132 0 R
+>>
+/ProcSet [/PDF /Text]
+>>
+/Type /XObject
+/BBox [0.0 0.0 11.7551 16.163]
+/Filter /FlateDecode
+/Length 111
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰4Œ»
+ƒPDûùŠ)µÙìzzÛt6ÂB ]Ä(¤ÌÿŞ"éÎp˜£ÒÇ¢]à¥ÒLú”Œ–Årà÷êfù‰øìõ²áê¸<_·™ÖÑW¨j™QÔJ¦/¨É”*hbKÿàî˜p
+0 ½\†
+endstream 
+endobj 
+131 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 11.7551 16.163]
+/Filter /FlateDecode
+/Length 45
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰2Ğ37±402VHç2P0P04Ô3755T04Ó343V(JåJã0 xèë
+endstream 
+endobj 
+129 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/Font 
+<<
+/ZaDb 132 0 R
+>>
+/ProcSet [/PDF /Text]
+>>
+/Type /XObject
+/BBox [0.0 0.0 11.7551 16.163]
+/Filter /FlateDecode
+/Length 88
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰Æ±@0Ğı~ÅY>ÚÒUØ,’—HlƒAÂÿz¦óB©LÒ†ãEcÃïÄ‚½¡Z·a§Ö´N:§‘^œ¦H; *!äM(|I»1fü ·ïÛ
+endstream 
+endobj 
+134 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/Font 
+<<
+/ZaDb 136 0 R
+>>
+/ProcSet [/PDF /Text]
+>>
+/Type /XObject
+/BBox [0.0 0.0 11.7551 16.163]
+/Filter /FlateDecode
+/Length 111
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰4Œ»
+ƒPDûùŠ)µÙìzzÛt6ÂB ]Ä(¤ÌÿŞ"éÎp˜£ÒÇ¢]à¥ÒLú”Œ–Årà÷êfù‰øìõ²áê¸<_·™ÖÑW¨j™QÔJ¦/¨É”*hbKÿàî˜p
+0 ½\†
+endstream 
+endobj 
+135 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 11.7551 16.163]
+/Filter /FlateDecode
+/Length 45
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰2Ğ37±402VHç2P0P04Ô3755T04Ó343V(JåJã0 xèë
+endstream 
+endobj 
+133 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/Font 
+<<
+/ZaDb 136 0 R
+>>
+/ProcSet [/PDF /Text]
+>>
+/Type /XObject
+/BBox [0.0 0.0 11.7551 16.163]
+/Filter /FlateDecode
+/Length 88
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰Æ±@0Ğı~ÅY>ÚÒUØ,’—HlƒAÂÿz¦óB©LÒ†ãEcÃïÄ‚½¡Z·a§Ö´N:§‘^œ¦H; *!äM(|I»1fü ·ïÛ
+endstream 
+endobj 
+138 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/Font 
+<<
+/ZaDb 140 0 R
+>>
+/ProcSet [/PDF /Text]
+>>
+/Type /XObject
+/BBox [0.0 0.0 11.7551 16.163]
+/Filter /FlateDecode
+/Length 111
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰4Œ»
+ƒPDûùŠ)µÙìzzÛt6ÂB ]Ä(¤ÌÿŞ"éÎp˜£ÒÇ¢]à¥ÒLú”Œ–Årà÷êfù‰øìõ²áê¸<_·™ÖÑW¨j™QÔJ¦/¨É”*hbKÿàî˜p
+0 ½\†
+endstream 
+endobj 
+139 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 11.7551 16.163]
+/Filter /FlateDecode
+/Length 45
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰2Ğ37±402VHç2P0P04Ô3755T04Ó343V(JåJã0 xèë
+endstream 
+endobj 
+137 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/Font 
+<<
+/ZaDb 140 0 R
+>>
+/ProcSet [/PDF /Text]
+>>
+/Type /XObject
+/BBox [0.0 0.0 11.7551 16.163]
+/Filter /FlateDecode
+/Length 88
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰Æ±@0Ğı~ÅY>ÚÒUØ,’—HlƒAÂÿz¦óB©LÒ†ãEcÃïÄ‚½¡Z·a§Ö´N:§‘^œ¦H; *!äM(|I»1fü ·ïÛ
+endstream 
+endobj 
+142 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/Font 
+<<
+/ZaDb 144 0 R
+>>
+/ProcSet [/PDF /Text]
+>>
+/Type /XObject
+/BBox [0.0 0.0 11.7551 16.163]
+/Filter /FlateDecode
+/Length 111
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰4Œ»
+ƒPDûùŠ)µÙìzzÛt6ÂB ]Ä(¤ÌÿŞ"éÎp˜£ÒÇ¢]à¥ÒLú”Œ–Årà÷êfù‰øìõ²áê¸<_·™ÖÑW¨j™QÔJ¦/¨É”*hbKÿàî˜p
+0 ½\†
+endstream 
+endobj 
+143 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 11.7551 16.163]
+/Filter /FlateDecode
+/Length 45
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰2Ğ37±402VHç2P0P04Ô3755T04Ó343V(JåJã0 xèë
+endstream 
+endobj 
+141 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/Font 
+<<
+/ZaDb 144 0 R
+>>
+/ProcSet [/PDF /Text]
+>>
+/Type /XObject
+/BBox [0.0 0.0 11.7551 16.163]
+/Filter /FlateDecode
+/Length 88
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰Æ±@0Ğı~ÅY>ÚÒUØ,’—HlƒAÂÿz¦óB©LÒ†ãEcÃïÄ‚½¡Z·a§Ö´N:§‘^œ¦H; *!äM(|I»1fü ·ïÛ
+endstream 
+endobj 
+147 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 13.2026 15.7739]
+/Filter /FlateDecode
+/Length 90
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰DŒ»€0{Oá	¢÷IH2  ûK¤€ ww'KÈ±Š9W…êÁÄj
+9{å5cÁ	e›¾Ê»špÀ¨b)Î_ÒNJÊÜ:øûå  B	
+endstream 
+endobj 
+148 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 13.2026 15.7739]
+/Filter /FlateDecode
+/Length 46
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰2Ğ37±402VHç2P0P04Ö3202S04Õ377¶T(JåJã0 ¾$
+endstream 
+endobj 
+146 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 13.2026 15.7739]
+/Filter /FlateDecode
+/Length 70
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰*ä2T BC=##3Cc=sscK…¢T®p®<.#C#=c…\.˜c=#Ss…¸ B‰B²˜+ À 9%æ
+endstream 
+endobj 
+152 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 13.202 15.7739]
+/Filter /FlateDecode
+/Length 90
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰2Ğ37±402VHç2P0P04Ö320R04Õ377¶T(JåJã*ä2T BCˆŒ1\&œ+(`¤gban©ËU4ÁÂÔR!ÆG(@’+æ
+ä0 İè?
+endstream 
+endobj 
+153 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 13.202 15.7739]
+/Filter /FlateDecode
+/Length 45
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰2Ğ37±402VHç2P0P04Ö320R04Õ377¶T(JåJã0 x¥î
+endstream 
+endobj 
+151 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 13.202 15.7739]
+/Filter /FlateDecode
+/Length 67
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰*ä2T BC=##Cc=sscK…¢T®p®<. €‘‰…¹¥B.T…±‘…©¥BŒP€$WÌÈ` ­R
+endstream 
+endobj 
+156 0 obj 
+<<
+/N 3
+/Filter /FlateDecode
+/Length 2574
+>>
+stream
+H‰œ–yTSwÇoÉ•°Ãc[€°5la‘QIBHØADED„ª•2ÖmtFOE.®c­Ö}êÒõ0êè8´×8GNg¦Óïï÷9÷wïïİß½÷ó  '¥ªµÕ0 Ö ÏJŒÅb¤	 
+  2y­.-;!à’ÆK°ZÜ	ü‹^i½"LÊÀ0ğÿ‰-×é @8(”µrœ;q®ª7èLöœy¥•&†Qëñq¶4±j½ç|æ9ÚÄ
+V³)gB£0ñiœW×•8#©8wÕ©•õ8_ÅÙ¥Ê¨QãüÜ«QÊj@é&»A)/ÇÙgº>'K‚ó ÈtÕ;\ú”Ó¥$ÕºF½ZUnÀÜå˜(4TŒ%)ë«”ƒ0C&¯”é˜¤Z£“i˜¿óœ8¦Úbx‘ƒE¡ÁÁBÑ;…ú¯›¿P¦ŞÎÓ“Ì¹Aüom?çW=
+€x¯Íú·¶Ò- Œ¯Àòæ[›Ëû 0ñ¾¾øÎ}ø¦y)7ta¾¾õõõ>j¥ÜÇTĞ7úŸ¿@ï¼ÏÇtÜ›ò`qÊ2™±Ê€™ê&¯®ª6ê±ZL®Ä„?â_øóyxg)Ë”z¥ÈÃ§L­UáíÖ*ÔuµSkÿSeØO4?×¸¸c¯¯Ø°.ò ò· åÒ R´ßŞô-•’2ğ5ßáŞüÜÏ	ú÷Sá>Ó£V­š‹“då`r£¾n~ÏôY &à+`œ;ÂA4ˆÉ ä€°ÈA9Ğ =¨- t°lÃ`;»Á~pŒƒÁ	ğGp|	®[`Lƒ‡`<¯ "AˆYA+äùCb(Š‡R¡,¨ *T2B-Ğ
+¨ê‡†¡Ğnè÷ĞQètº}MA ï —0Óal»Á¾°Sàx	¬‚kà&¸^Á£ğ>ø0|>_ƒ'á‡ğ,ÂG!"F$H:Rˆ”!z¤éF‘Qd?r9‹\A&‘GÈ”ˆrQ¢áhš‹ÊÑ´íE‡Ñ]èaô4zBgĞ×Á–àE#H	‹*B=¡‹0HØIøˆp†p0MxJ$ùD1„˜D, V›‰½Ä­ÄÄãÄKÄ»ÄY‰dEò"EÒI2’ÔEÚBÚGúŒt™4MzN¦‘Èşär!YKî ’÷?%_&ß#¿¢°(®”0J:EAi¤ôQÆ(Ç()Ó”WT6U@ æP+¨íÔ!ê~êêmêæD¥eÒÔ´å´!ÚïhŸÓ¦h/èº']B/¢éëèÒÓ¿¢?a0nŒhF!ÃÀXÇØÍ8ÅøšñÜŒkæc&5S˜µ™˜6»lö˜Iaº2c˜K™MÌAæ!æEæ#…åÆ’°d¬VÖë(ëk–Íe‹Øél»—½‡}}ŸCâ¸qâ9
+N'çÎ)Î].ÂuæJ¸rî
+î÷wšGä	xR^¯‡÷[ŞoÆœchgŞ`>bş‰ù$á»ñ¥ü*~ÿ ÿ:ÿ¥…EŒ…ÒbÅ~‹ËÏ,m,£-•–İ–,¯Y¾´Â¬â­*­6X[İ±F­=­3­ë­·YŸ±~dÃ³	·‘ÛtÛ´¹iÛzÚfÙ6Û~`{ÁvÖÎŞ.ÑNg·Åî”İ#{¾}´}…ı€ı§ö¸‘j‡‡ÏşŠ™c1X6„Æfm“;'_9	œr:œ8İq¦:‹ËœœO:Ï¸8¸¤¹´¸ìu¹éJq»–»nv=ëúÌMà–ï¶ÊmÜí¾ÀR 4	ö
+n»3Ü£ÜkÜGİ¯z=Ä•[=¾ô„=ƒ<Ë=G</zÁ^Á^j¯­^—¼	Ş¡ŞZïQïBº0FX'Ü+œòáû¤útøŒû<öuñ-ôİà{Ö÷µ__•ß˜ß-G”,ê}çïé/÷ñ¿ÀHh8ğm W 2p[àŸƒ¸AiA«‚Nı#8$X¼?øAˆKHIÈ{!7Ä<q†¸Wüy(!46´-ôãĞaÁa†°ƒa†W†ï	¿¿@°@¹`lÁİ§YÄˆÉH,²$òıÈÉ(Ç(YÔhÔ7ÑÎÑŠèÑ÷b<b*böÅ<õ‹ÕÇ~ûL&Y&9‡Ä%ÆuÇMÄsâsã‡ã¿NpJP%ìM˜IJlN<DHJIÚtCj'•KwKg’C’—%ŸN¡§d§§|“ê™ªO=–§%§mL»½Ğu¡váx:H—¦oL¿“!È¨ÉøC&13#s$ó/Y¢¬–¬³ÙÜìâì=ÙOsbsúrnåºçsOæ1óŠòvç=ËËïÏŸ\ä»hÙ¢óÖê‚#…¤Â¼Â…³‹ãoZ<]TÔUt}‰`IÃ’sK­—V-ı¤˜Y,+>TB(É/ÙSòƒ,]6*›-•–¾W:#—È7Ë*¢ŠÊe¿ò^YDYÙ}U„j£êAyTù`ù#µD=¬ş¶"©b{Å³ÊôÊ+¬Ê¯: !kJ4Gµm¥ötµ}uCõ%—®K7YV³©fFŸ¢ßYÕ.©=bàá?SŒîÆ•Æ©ºÈº‘ºçõyõ‡ØÚ†kï5%4ı¦m–7Ÿlqlio™Z³lG+ÔZÚz²Í¹­³mzyâò]íÔöÊö?uøuôw|¿"Å±N»ÎåwW&®ÜÛeÖ¥ïº±*|ÕöÕèjõê‰5k¶¬yİ­èş¢Ç¯g°ç‡^yïkEk‡Öş¸®lİD_pß¶õÄõÚõ×7DmØÕÏîoê¿»1mãál {àûMÅ›ÎnßLİlÜ<9”úO ¤[ş˜¸™$™™üšhšÕ›B›¯œœ‰œ÷dÒ@®ŸŸ‹Ÿú i Ø¡G¡¶¢&¢–££v£æ¤V¤Ç¥8¥©¦¦‹¦ı§n§à¨R¨Ä©7©©ªª««u«é¬\¬Ğ­D­¸®-®¡¯¯‹° °u°ê±`±Ö²K²Â³8³®´%´œµµŠ¶¶y¶ğ·h·à¸Y¸Ñ¹J¹Âº;ºµ».»§¼!¼›½½¾
+¾„¾ÿ¿z¿õÀpÀìÁgÁãÂ_ÂÛÃXÃÔÄQÄÎÅKÅÈÆFÆÃÇAÇ¿È=È¼É:É¹Ê8Ê·Ë6Ë¶Ì5ÌµÍ5ÍµÎ6Î¶Ï7Ï¸Ğ9ĞºÑ<Ñ¾Ò?ÒÁÓDÓÆÔIÔËÕNÕÑÖUÖØ×\×àØdØèÙlÙñÚvÚûÛ€ÜÜŠİİ–ŞŞ¢ß)ß¯à6à½áDáÌâSâÛãcãëäsäüå„ææ–çç©è2è¼éFéĞê[êåëpëûì†ííœî(î´ï@ïÌğXğåñrñÿòŒóó§ô4ôÂõPõŞömöû÷Šøø¨ù8ùÇúWúçûwüü˜ı)ıºşKşÜÿmÿÿ ÷„óû
+endstream 
+endobj 
+162 0 obj 
+<<
+/Subtype /Type1C
+/Filter /FlateDecode
+/Length 3796
+>>
+stream
+H‰DUkPÙ¾ÍĞİ#BózĞiè5Bğ
+Š¸òØå
+Få!¸²0AŞ åŠFP£ã£Ep%¢¨ñ‰€!ˆ¥".+[ÑÚ¬‚1»šÓã«Ò¸UIõŸÛç~çïœó{)biA(ŠÒ¬ˆˆ]jˆhHÉ)œ˜».mÜì*”ìh);[ó¸×;[(¥]HÔ_WÛÀT[øÒş”³ıßˆE-6f¦çè=çÎ] ÿjƒ>¤ 3KoÈË4f²Srrô®ú Œ‚ÌÂ¢Ì”½!5£$¥ èë9¡†åòŒúùú4ãZB(å#6„Ø2Ä‰"S2ƒY„x2—/Šx[Å„ÚMVREÈ-Bz"d„EJ&Ä‚¨È4âG–‘zÒM	Ô>ªËbÅR‹2‹Tªíª¿¨Z†X®µ<dÙG{Ñ•ôOÌLf³‹igıØ*vX½@]¡¾;¡bB—••UŠÕ«‰S&¦N¼kíec=d3Õ&Åf»Í›ÎÈõÛî°s¶ÛÍqwqêêÇƒïtS:–Ä¥gÄÇ7ç÷ˆå‰¿MÛ¤æ6ÕP0üù¸Ô´¸­i­­i­+%—¯Bo\Ùùƒ.Z
+å
+˜H]€Å°«.ÀecŞ¢5x‚ç[°†lYˆqkôDOW´FÅò3êxtÈ‹‹ŒÌ»"LgÁ®áFooÃ
+´¹ĞÊQ
+6C°ª_+Œ¢‹üa
+ƒéÓi´baÊmÚ‡‹XZù+˜D]û3œ‚ Õ5å©-UÌğ£s-gÎ©ûŸÕß{®·Eƒ8×7bCZ”ˆNlÛãöêBÿ™¬Ğ€¢„ Ï¤äø¼|´E•š•_ƒ¼?œšÚ¶$tú«Õ©Áíâƒ!àtİEVÕ‹…‡7íIÚ§ÖtşĞÚÔö­,}ï¢»_ĞÆ¬íÙæÁk‡¯}§×'Dd• [®„,[u£qÏiASÛİX˜³.Ã?WŠ-‰/G‹­JÔÊPƒŠ‚·à¥’÷hÁy TÁ°’E¯BıÑ›…&y'3¼b>B{À3tfÇën[€¥äÉJîòÓí·úmIS£mh,Ò¨CÕ±Å­±bDû@Æ<FÇ`Haƒh·lÍ×)k¤½0ûIÄW«±ûùã§ë÷7]ÇòÎ+N_^ÔS¤½J¹ôÔwJ%Bh7Iô¿Í[Ù-¨§ÁÄpı
+u°ò’Ê´F‹gMëhœÄà¹ëhpen»™ÛèA»Ãq}™ç°‰æNT‚’€h† "ÁÖ¼ÒÂYbÿ5 ÂO	7Qu\ÒÈÿ8s¶mXÜÂ^ôñ<ÁæQ’ß³šwO›rÂ¾ÈÈö”< ›Ÿ1V#ß9Y`ˆÍË–¸µ¥0IŞª¨£¢ö¨äg¦Õ|íob,¦{ç®ˆ’üÃÓg¢¤C«zïëQbĞ½Q#Øı÷«OŞ”À‘ÍYU- cÜ„ˆkÀ©«sKá=‰ûv\ué ¥Æ™Ÿ€H•Bº™>ÙqGzÔİòOpÑAN [,±uœî¼œşF‘÷•%è‹¾‰áÈI\Q% ÊŒã')§È‡˜C Ğø³bß¸_Ù{‚yÃ•2QÀ‘ÿ+±[ VAÕ*ÆG
+j»ÒŒRâ¦Ô¶øSÖKá"ø¨L¦$şDÈ²2³r’odú,ÔëP}bÑÕÑ¿ç]*L^i~)Á{lAX¡»-7og–€n†>}}øö™V©­ùfÍĞßµ%o@¹vTÉcØ+tÀ~Œ_è¯Ç|ä†ïÆğµûs†ëª¬1ÕüŸí0{q˜†4¯Ë¼2¯¯hcğ Ğ0‚Á,ñ0ÍW\jù”3ÁÏ,Ò?2.ÿš6B°)“YŒ0{aˆìEc"ÃS
+öò>°W2‚aˆRÉ‚©”Ç\Ô¢‡–µ~W#%ï{£_'üçû¦ûİÒı¾Æ—`¯{_ü,©W‰q	m…]hÏÛñ9†axâç¨FõªÇ°‚:€Zâ.+õ?	,ÀñSÛ“•‰û”Õå³Ìå£›cZ$pÂ|zÀÂÖÂºÜÃ“ß5^ºñFÓ<û1RÄFE	øÃ+vèTaHhvn€Ä¹–‚“¼œ¨VX óÁOÕÒÈg=èŞ<$ÀÒ7OÁ¨Õ·P¸%yß¹«¤Zw¬ìO'uíßÔ=¼Û^¶n@‘­‹X^%àg3£8õJØ&H ]Q»1I·&Ï'teõy‘{Z
+“åïk¨>ƒ&ğPõ™²xs<‹	c`„Ô7¯ A”W¢‡y5;mMÒì_¥¶-Êq,wµ¢Æ¢´$Jq@w¿0— ¿\Bc'>fÓ0IiÀÈ/ 0Uğ ÊF°7i˜ÃÀjS6®Ú˜‹ÑQ.¦QÇ h.2¾Œ` RñçÊ•1“UŸÓÊLÕ¸ü?2 r.Ì—”kF áƒ²9ææm¬Ù\#Ï;‡f˜sa¦]¾_Q¾í[…¢òƒÄ³àÖ…‹Â—•‰hÇzqqÿu¡§®(ZÊaQõû¬	›Õ>ë×&/Ô¹ßí¿u¦ç‚¨‰®ı&ÿoBSÃŞƒõfƒ#Ÿ“µ)SHÙpìâÅÃGÏUIuûşñşn5gÜ‚†êU:–¨¼v½Z°fjïü—õjŠê¼âË½—ˆnã^/{gîUG#‰JY,†JĞ–¨ ¼6â.‹,¬! O+ë‚<,a½Ê.‘ 
+6Ë#F'D^
+˜l›L“Ncj”‚¶Ñ‰Ë|4Óo×Hâä;“Ù¹3;gîw¾ßùs~ç\b×àåã,¼ğé‚  »èùí±Y¡;x¸¤¡²³÷†uºË´ZOt°“M‰È-ÎHØªÑW›“q?­Ë)Ø@ŠËØNb¹JƒeLºR_Ï®ÉèÀm¶¸¹cÊj.Kÿ'˜:–Xµ‹Eªõ(EÜ^ª«}µÍğv|.X5;¦q,($â˜ûì‘y¨˜ê3…³ˆXT(hâeMöŸ¹Á›•D¼Àd$ekX¥ş".÷EÍV[ç™Òİ¼ÔÇoñ-<rœÄº³ñ"ä1½(7ßAÂs’¸ˆ˜Œß­£¨zÃîkƒµÍ,¤Ò·¼Q²“õØß:s˜?z‹ùGeó»Cì °ãqs{… ®	ş‘Nw0V³èËLÌù‚Bô$ˆh![š†OÖ-¯ãà¹Mrß€–ò•”tJ½ºN|Û§e'`õrX+`'¼H+ö‹‘ÌMäGÕ&§Y´ÊW‰„‰½Z>NkHJ'×:²9z6RŸ¦‰“oºõ:@ø!~Ò‹8ÑäŞœ?µÔ¯©©ãKÎ5ébé°ü‹	XĞväBo¬o8vŠ¥g‘n.Š9] 1”æó‡ŞÔ–Å°>ºú®ÆêÓ&ÿÃé†£-,ıÈ"Æ3—M†`eNæîèóQÁr‰—Fáğß•´G+I!ş‚lê5ŸhgßkÌRóè.¶¸Q¢GÖş>=8”ƒ«ó™”¢oñq9ƒ¿ì&ø#LıøÏV2qmÜîNíûïh;cxzêïÿ­dDk<•£×•½Ê¾†ˆks¤==;ø
+;ØŒLŞ=™¹ÔNCzT‡Hêã…Ún‹ë`×Ù«ŸËÅó±TNf2öğ:"HúK<l€‰}ú¶X^ê‹:ârÄkÈÆày´€m$Š€/1×ñú‰6£TBùQHñÉipqº‰B.\Œ8SWêÏª‘Ëõ¹ï°Ø”â7	¹‚ÌÎÚÇãCá NFš/©:Çv™ñ<š±[(sOãc&óø`2Fmİ§
+æÆ³4­alXdjèN˜±ÃH*T•»:ò2ÎıÙ“ÔX-85Ö3YØÿô÷©]¯KUEp´õŞvÛ»p
+Òƒ›9ü$0"ZôêšÕx¾„MyÀ6˜ş7/Û×şğÈÅ¥ËRŞÀ×*5ò‡µEN——›Èj2O¶äòo™Ë:>‘dì¬iäŞ}§¥¡‡}"DK¾‡‰¥ÃDjÿ/'ûû³WşÜĞu¿Ôßh'9(•÷T­ÃXıõ<Vú3,K¬C–:ÙIK"r.Óäëùı¹úü½¬6ó„E‹;5»â>apŸzKšÜaüşF0‘İõ×ë®Ç»1¥:ªMˆp½ÿC\CÃÁ¸ÆBa.¾ÂŞËÀVIzæÀĞ‡E7XXù—! nïé[ŞÌÿÖTşö[U®Ù5%µ&y‹åäàÀù’Ìëv‚’ª¢X´|krYÛó,Ğñã+*êJ]ë‹+‹òåº¬‚êšæ NŠÂ"Ã«ô´]ùğgS”’äM6:×„—ºb¼IĞüBRy„º +w{In #‰è£aiÏùÊº6N’'ˆÕ‚ÓæRaw¤p™ØN"E>1÷¥O2”èØ¸¼Óc<Ü¢ìFô…\®¨f&/5MsÒË±Xp¯ˆ­âIä†ÆŒÙKÒæÚ p!³ø¥R<5ƒğÔt%ÁÄ4AÀ"6‰mú%éƒF^ÂgV+Ñ˜Fô
+æru–¼Q_‡»ƒc©&¡şFLÏù#	¤}NHuÅàŒåÙY6
+ŞCÀàW+a-=5êŞbyûÜÅñ¾³Yod–äíUs´-"ğP–ZiÙ÷©šûHW]”&O6äÅ¤¤ët’P…m÷³àng›¾{K/Ô]X#Èªjº/pôÔø5SÛ€ü_ŞCˆóHWsÉ	q¾ò'+‡lğ'(›Àk<iÛ³n´Gè˜„””u»ÎÚ×ŞŞÛ›ÒÀÃ÷ŸØŞĞğê¯Üµ~®í òY·z!Rˆ§†­kWÿ¶İ6¯²E~]àe?Úö³Kí±şúŒ W¾lÈIñx%b"mÿgĞ(rö•g¼1[[Ø&°tºA ñÁå%³˜ÿ	0 ¢q¸€
+endstream 
+endobj 
+164 0 obj 
+<<
+/Filter /FlateDecode
+/Length 480
+>>
+stream
+H‰\“Í›0…÷<…—3‹	Ø÷ÎH(R&)‹ş¨i€€“"59d‘·¯g4•Š”ğ!ìó#sóİ¡>„a6ù÷8vG?›óúèoã=vŞœüeÙº0ıĞÍOËwm§,O›Ûì¯‡p³ª2ùôò6Ç‡yÚöãÉ?gù·Øû8„‹yúµ;>›üxŸ¦?şêÃlVf³1½?'¡/íôµ½z“/Û^}z?Ì—´çßŠŸÉ›by^3L7öş6µm¸ø¬Z¥kcª&]›Ì‡ş¿÷N¸ítî~·1«
+,^­Ò-ñ¼ïÉ{pCN‚UÉõ%Ö—kò\pI.Á–lÁB°’5±¥…¥…¥…¥…ud¦¦…¦¥¦]4ßÈoàwò;¸&×`ö²èåèëàëèëàëèåàåèåàåèåàå¶ämbaA¡¦@S¨)Ğvtêô…ú}¡¾@_^É¯`öôúÊâË‚Âsœ£°¯ ¯ğLg*ì.è®<SÅ™*3+2+3+2+3+2+3+2+3+2+3+2+³)²ÕÌS#OMß¾{jî¡ÙP§NÃõé†øãKÅ§œ&Î|ÎIw1È2–Ël`*†à?'w'“vá—ı` \‡ñ`
+endstream 
+endobj 
+166 0 obj 
+<<
+/Subtype /Type1C
+/Filter /FlateDecode
+/Length 4174
+>>
+stream
+H‰”TmTçawŞY¾ë.î,ŠA*©ˆ
+*¢D"
+*da!|%RDÓú…˜Ö&àgLUˆã¢¬Š„(1|D-‚U‹‰ ÈZê¹³ŞÍi4¿zú£gÎyçÜyßûÌó<÷¾—¦äVMÓ.«C#Â"WL[™ ÏñHNÉKOÈÙ™,ªhñ7rÑÕÇ0ÿÕğ«4fõNı:{pw€X§“®Îc(+š´(9'-E¯™éã3[³q“fqvšN™•–¬KÎÎHĞë5oi‚S³ÓrrÓôšÈÄÔ²s¦/‰|wSV²f–&)YKQ´ôP„¢¬­({Bñ2JEQ¨·j.E)¨0†Šd¨šÊ¤¨2Šú–¢š)êEõRÔIeEÉ¨¥oÿ¦ıèt½›>DZqV±VŸXÈ–É’edÍò9ò=ò¹™Ï1'˜ëŒ‰Œ'3‰–ü‰µbCÙ
+GÅEšb·âšbĞ:İúšÂf£M­ÍSÛ:Ûa»vZ»ívıöîö)öö"·;ÊıÓrğsˆq(tØãèèXàäåT1Æ™ã`vÑuØ}}ßÈBŸ½ï½YdaÖòÓ"B‘AëÆĞ§¦oÛ€6²ÍSèÀ5|`¾.::ÿt·º’í®8}åJ….P,WùN"Ö˜£˜`¢Góÿ—ÎaÊO&™h‹¾|H‡¶^×®Hî-ì¢r¨ËĞ«>İ~¶şf‡" NC7Wbx3º$Ã“¬Î¼İëÑ	£•½VzK¡º›€Lh7WBx¸¡JIÛÌkÊi˜.jøûä}˜ôÂ»¶ëÀéë„NwŸ aæ¨™ØŸNqè[Ô Ãí–’vóÛ£2ÒVoV$°ûš[TŞH;¿6)3K›r<¯V]J8¸ÔEŸ„bÙI¸ÄCqn‹”è	cøD½>ic¥şü¹ªªsçôU‰‡kâ$á½Dt}5‡ñ%\za‡8ĞA35Ã²oà"h^à5 6¡"¼Á½ĞËm0B-GGßø%ñ·ÀW*|/Üº°}Õ\zI'L².1¾ıÍª5µşÌrüKÆ°Ò‘.ñV7İ|:ŸÉš]ÄU¤´‹Á^c=zÄP£øWuû%L¸“.Î_­`/¶|¬MÕ[÷6:Åa:F©ºÜü­)$¼rp½)î*§E;©².à3tÓv±[ÜŒÅ,ôˆŸ1>[Î0Ñğ}$ ·aÃßiÑã©L,3Gñ(’µ†9Ğ`Ø{QÌßRıæå&¬Ô	‘Ë‹pìÅ\ìÿRÿiû_à|á»°W`D¥®°¸hº
+Ò¨±³š:hqõ°LÜfşÖ\øAP¼mEH-ê¯Äœ>äÀ&>–ºDº‡Äü>1J½–y
+úı
+ìC_ÓpşàÕ³j-RH’Ö{£<ÖK.İÌŞ¡AÇ¸k^ÌÜ°ä³ÛqŠTtPÃFPÿÊƒIşßİpQr.ºKô+§Í‚V›3™p‚†_2™Çä.d0p„ü3Ôñ¨%/ÁÀpgKŒpÊÆ1C&øìçÃÎ/†\`/¿>#(¯n>ŸyZÈ¨Ö/S8‹?ş²ö®¬ç7£F%ÄôËDNëüâùå8¯UÚä|a“.kÇR:Âs
+ÀuT§ÏóMN™%pû
+»Ä—]RwŠ3ËdâMóşØª¨ÒÕÔÀ¬ÈpaQÈ{ÓĞU‰öÇ}–«7=H™ª³é@å÷Â]6uáÚ-¡*œ¹` Õ8³[/oÕ·	Ü££Øc¤‡L¢|X6ÊıÑíÊÆF¡¹ù‹>§„±ıa7ÔQNú¨°t”³ØSXğº9c1zÑoqªÀm’|8l„â 	E|—”´Àa8hÄƒP÷Œ–@ÂeJ_7Bé›c&èƒP
+–PÂµK“Go„QœÔ¼ƒæõü±•+Ë«4¾º°0!$D7y%Zó¯[¡Ûô4U=?<Ó+@;~ãp[›¸=V…ó!şùcÍe¡ñë–Êª¶†­úNƒq‹[F¨/UıšÈCQMf'vXäĞáI8,,iZi˜f’Á´VŞ{Z½ÅV4,ö™b’˜Âw~zöÀ—•ŠsÕG/·+Í¹¿ä²³òßŸS æ*KÊÍÁå¿êí'pû°'(Š
+¸À¸¼OxâÉrkJŒfîÍa1pÔÃ~óD‰}c7É¸<$ûÄNĞYv1ß(?a,÷$êhËbe?æˆû´“rÜŞüºOtí“ ûÄ"Î¶´0­fİ‹XÜDÃÈÌÇÂN;G,Gº§œ¹ÇD´FnC®âwWB…ù×z“ÀJeê®jº&´üPõÆ+A‘w]«úö*ß´RËÛs7œ.D]€Œò­ÍKuÑêğäğôyª¥«?¿¨â®nê[¥4c~5W,•À`„ª‘F€SÃ£Ş´’çk‹/© à^;LîÉmˆùJ¨LZ·¾
+wS“ˆÉ4ujìF¤bã>şsŠÀ}!Á\3BÙ(Ìç¯aº/“–cE!uøáNd—BEöWyÙÆƒÍñ†& ”0naNQãbÂû<”’}væ=ïÛs>Ì²óµE1*î?¬WkPTGu2Ü{GC¦”Ë˜¹:MV1."Ñ*qƒˆ^
+‚
+ò^Ê‚ÈK#¨
+ÊdPEy‚øÄ0&¨ã#ºj÷T[Û€»šÚª-+µU÷GWW÷ô÷õ9ßéšÒ_vóZÁ¿óO¨™à[­)],0|·ÆÔËj¸Ğò´½3›Óš7U^ß¨­úéÒ™TùÉ ¥tuÏuaÑdk{$XS°NÈ)£~Œ¾Ôç³o{q¢àØæ¼ˆ ±İj¿™Kİ^(ÁêQè…]<°3¾]Ê”äv;D¼™ú«~*ˆ …/“{õ¼pÂşÀğ
+…\†ÌÁjàüè	ğ”À5VO
+Msv@"4Éí
+0—@l-êL…~9f)±ÄÆcèE°—ø	ÊßlÂä‚+£+ÀùL|Ïy†sÄm¬Óo"¬Hô¥¡Í‡m„#‰âát<4'fŒöÓ"XDfwKZÀ'D³a;•aG@SÒ`axBg$İpVÀ•]&gt \G×ÂZ&+5cg*™v@Å
+0Î­Hää–î$±¥T·êg;+Bpë)dš‘µ6E`'_¿P<«iÍÃ«š²ÖóÚÓó`Et=[¨Ü“SÂÑÑ\ d¼|½£dìšXekûñ0~W³;o!”'İ„\ï¾ñï‹.‘…Í„ìJKìE¶¡¶@­æ”/ÄÀfÙSD9®KpúV®%QI)áia;:ô˜Ñåœc*W#34%Pú•WÈµ¾9H’º Ù-æ7p
+7ãÕÏÿ¿lÉôd/¸Ì3Ug_×—e„uqT‘«î½ó-Ñäxw6˜ÓT›[q‰îMóêø0G¤ÏJÆÈaÃÈ¨€ªqõ*tc¥Ñ¾A\ OâR1²iŸÆ¶5_í’(—¡@Àø,Nöf_“Áêæ‡ªÔ œĞ*©8Ü –×yP^Â‡i ©¡À\ÛŸÑdd¾`&²GËîY‚yër^•ôPÖß¹³è#¿ğ)wÃh÷©ŠsŠçŠ+›ÙŞ
+DíÅ	c±ÁÅZ°°ƒø:¾
+z0½ô &ZdrìWŸ¼™»gV¾ä–…Æ._ŒL¹)¡
+Ñ«Ûı×AÂ5i£‰rĞS7÷.Ó…Ü£Ç¹0ˆiDöıbÌŞè˜İ‘,2]ä€ÈŠõµ!ı|ŒHBh°8</öè	ıÒV*ğ[÷û`Ó×øzÈùš&±&éç©>Ñùå‡³ó+¸ô²#;Ô, ;ÚÀØšï*rt›mNaÑ2-3¬ezË=#2¶$lå6û¦9²Ÿû×Wå•W–s;S²ôW©ÕĞ“é®obÿ×pÕ@JÃWÀn„Ké:Ì%“õw¨c›„9sÈ ƒ|jÈã¢•£,nÕïx$D¿àĞ¯o>B“! œ¢£‡À×úp&xsTp`iTUUiiUUTiGëêŞ„3ğH•±İ…õ·ï5¬ …8:J‡QÁŸÉ;ÁlÜÜ“H®ƒ¥`ñ9‰BP!w½‡©Ãmå³ŞKÈ0·â©äØğíÎ¬ÿ’Ş7Xú;F²Ù¢0ÁùÈ‡?ÓItßpVy¶[¹ï,[W´É‘COPµİeûÏ²µÅ‘®œ7œæóµ­óW­^ùär¬¼TÊJ7$¬ZÄÑõïğıßûºîy¿`Í¥ázıŸ‚yÅJm%tíOï¢½’®CL_¬£Ïøà4T2h6=rºƒæÜ}Àr›‡hç`ô¬Ú™£®Ó¦\Àê›V}á7î­ôG7P8„7€|ØIúµhÎc~ô¾¶#Â'WŸ£ç½Ã§{tˆb4÷9ulŸÊ}†¦I­ş­ı¸ïµº¹÷Í±:şqÈÓÎwÈšâÖülÁÊ=Ó=Rê!øåıS¤lğ•Á~['doñ.õûŸùÍJ&ê¼&µ•cÛ[×%©‚Ê¹øCqûW•f©“òÎˆOU]®U§G\Å–Rì”íÍ"ÂÉÃÒï`È‘Í\Ily²6JĞVä'–…Æ-rõßLŠWY©p’–>ÂÇ:™´Ğ¤¬VUv…ÀT-š
+Œ\¨/Â{kBÊZ6ay:C"Æ+Ù“{L"”%uB©‚×§‰¸+-]†‡ÈYÛ	ÃdJæœ,cİb*:9ğO
+Ï¡×”[vha„$@YßÄ¶kJ¯i9¡Y¦Æã×Ç0Ÿ1ü\‚ãˆé$ØlP-˜z“ğŠd\½U™L;	>…"ğ‰ADtãk3TÖ$âŒ‘N ìHdb˜€Æ@cì;B3˜©àıâ#´é7Ôô
+Y€WÃÿŞ`Ø@ÑÄïÛáøv^­~ÙjHpN!4†ñKÁa
+2˜ø¥ÓØÉÃ—?Ê:2R´­C/¼f208xWû`Ó=ˆa9	>ªi|tåd¨,(5ÁÙA²bñ¶˜uâÈ}Qñ’C‰E[¢tWßÆüd±<Úi]pN¡v¯ä'2YÀ×^xÜ^eq†[¬JÌWŠ‹shZ$´®·¿°²A|Q"l¥Ñ>~’@¿dïÅâ·ön2ğâ`tŸôà‡»<=ñW°’‘ÇÄÈå%1•?–”¨T1%r|+ú¯¹÷íxÖÖ]ıÿñd×ßyröÿğdÚ-‰¸ãÑ>`¢y6}d¿ŸÑƒ¨Ğ­Á¡ÄU€IßÛUëèÁ? z"Ú ç>2^óÀEAv{úqçcã§{Œ?M¦ú™	0 Û³¶’
+endstream 
+endobj 
+168 0 obj 
+<<
+/Filter /FlateDecode
+/Length 536
+>>
+stream
+H‰\”Íjã0…÷~
+-ÛEñßÕU&Æ	d1?LfÀ±•ÔĞØFqyûÑñ)Câc,}|pnõaèg“şc{ô³9÷Cüm¼‡Ö›“¿ôC’¦ëÛùóiùo¯Í”¤qóñq›ıõ0œÇ¤ªLú+¾¼Íáa6İxòÏIú#t>ôÃÅ<ıÙŸMz¼OÓ‡¿úa6™Y¯MçÏ±è[3}o®Ş¤Ë¶—Cß÷óã%îù·â÷cò¦XsÂ´cçoSÓúĞŸTY¼Ö¦ÚÇkø¡ûï½®¸ítnß›TgY¼Ål™-ò+ó+òŠy…¼aŞ o™·È5s¼cŞ!ï™#LUò¬g•9s\0ÈÂ,Èä)ÁS*³";f‡L<ÂNA§°SĞ)%s‰Ì~A¿°_Ğ/ìôûıBBÂse9÷ù™NN„NN„NN„NN,X8±d¶`¶d¶`¶d¶`¶d¶`¶d¶`¶d¶`¶d³`S:Q8Qö+ú•ıŠ~e¿¢_Ù¯èWö+ú•ıŠ~¥…¥…¥…¥…¥…¥…¥…G989898989898ÙØ88Ya}‘åè¬ÉYƒ³&OÏÚá¬=û÷èßs}¼a¸>§c¿æk†Û{q|—OÆ2·˜Ø~ğ__•iœLÜ…_òW€ h–
+endstream 
+endobj 
+279 0 obj 
+<<
+/K 26
+/Pg 173 0 R
+/T ()
+/S /P
+/P 182 0 R
+>>
+endobj 
+280 0 obj 
+<<
+/K 27
+/Pg 173 0 R
+/T ()
+/S /P
+/P 182 0 R
+>>
+endobj 
+282 0 obj 
+<<
+/K 29
+/Pg 173 0 R
+/T ()
+/S /P
+/P 182 0 R
+>>
+endobj 
+182 0 obj 
+<<
+/K [282 0 R 279 0 R 280 0 R]
+/T ()
+/S /Sect
+/P 174 0 R
+>>
+endobj 
+176 0 obj 
+<<
+/K [227 0 R 228 0 R 229 0 R 230 0 R 184 0 R 231 0 R]
+/T ()
+/S /Sect
+/P 174 0 R
+>>
+endobj 
+227 0 obj 
+<<
+/K 0
+/Pg 82 0 R
+/T ()
+/S /H1
+/P 176 0 R
+>>
+endobj 
+228 0 obj 
+<<
+/K 1
+/Pg 82 0 R
+/T ()
+/S /P
+/P 176 0 R
+>>
+endobj 
+229 0 obj 
+<<
+/K 2
+/Pg 82 0 R
+/T ()
+/S /P
+/P 176 0 R
+>>
+endobj 
+230 0 obj 
+<<
+/K 3
+/Pg 82 0 R
+/T ()
+/S /P
+/P 176 0 R
+>>
+endobj 
+231 0 obj 
+<<
+/K 5
+/Pg 82 0 R
+/T ()
+/S /P
+/P 176 0 R
+>>
+endobj 
+290 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 12.3123 16.231]
+/Filter /FlateDecode
+/Length 88
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰D‹»€0C{Oá	N÷	DƒŠ	€€ı%‚D@®ì÷¬’SQ.P*Í%¬6ëÅÃxN˜qÀX£/IŒØáÏÃ³enhFHéJâú¿â?¼0à` Fy
+endstream 
+endobj 
+291 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 12.3123 16.231]
+/Filter /FlateDecode
+/Length 44
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰2Ğ37±402VHç2P0P04Ò36òÍôŒŒŠR¹Ò¸  xIß
+endstream 
+endobj 
+289 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 12.3123 16.231]
+/Filter /FlateDecode
+/Length 69
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰*ä2T B=cC#cC=#cC…¢T®p®<.#C#=#sCs…\.˜
+c=KSK…¸ B‰B²˜+ À  Ä›
+endstream 
+endobj 
+295 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 12.3113 16.231]
+/Filter /FlateDecode
+/Length 88
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰D‹Ë	€0ï[ÅVğxŸhH¬@½¨ ö*ÃŞffUr*êÁJ¥¹„YĞzñ0f0>ÓÏ¤jFìğ÷áÙœjRºR¸ş %Şä…·  ¹u
+endstream 
+endobj 
+296 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 12.3113 16.231]
+/Filter /FlateDecode
+/Length 45
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰2Ğ37±402VHç2P0P04Ò3644V04Ó326T(JåJã0 x:Ş
+endstream 
+endobj 
+294 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 12.3113 16.231]
+/Filter /FlateDecode
+/Length 69
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰*ä2T B=cCCcC=#cC…¢T®p®<.#C#=#sC#…\.˜
+c=KSKK…¸ B‰B²˜+ À  ˜
+endstream 
+endobj 
+301 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 13.4197 15.624]
+/Filter /FlateDecode
+/Length 88
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰DÊ»€0CÑŞSx‚§÷Iˆ2  ûKP"w>W¥¤ª\¡TZH²ZhYO¼f,8a|gŸD“	œæ’İ*w´"ÄÔÛôÄ;Şñ0 w‹
+endstream 
+endobj 
+302 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 13.4197 15.624]
+/Filter /FlateDecode
+/Length 45
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰2Ğ37±402VHç2P0P04Ö31´4W04Õ332Q(JåJã0 y4ñ
+endstream 
+endobj 
+300 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 13.4197 15.624]
+/Filter /FlateDecode
+/Length 69
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰*ä2T BC=CKsCc=3#…¢T®p®<.#C#=S#CK…\.˜
+c=C##…¸ B‰B²˜+ À %¶›
+endstream 
+endobj 
+309 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/Font 
+<<
+/ZaDb 304 0 R
+>>
+/ProcSet [/PDF /Text]
+>>
+/Type /XObject
+/BBox [0.0 0.0 11.7551 16.163]
+/Filter /FlateDecode
+/Length 111
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰4Œ»
+ƒPDûùŠ)µÙìzzÛt6ÂB ]Ä(¤ÌÿŞ"éÎp˜£ÒÇ¢]à¥ÒLú”Œ–Årà÷êfù‰øìõ²áê¸<_·™ÖÑW¨j™QÔJ¦/¨É”*hbKÿàî˜p
+0 ½\†
+endstream 
+endobj 
+310 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 11.7551 16.163]
+/Filter /FlateDecode
+/Length 45
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰2Ğ37±402VHç2P0P04Ô3755T04Ó343V(JåJã0 xèë
+endstream 
+endobj 
+308 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/Font 
+<<
+/ZaDb 304 0 R
+>>
+/ProcSet [/PDF /Text]
+>>
+/Type /XObject
+/BBox [0.0 0.0 11.7551 16.163]
+/Filter /FlateDecode
+/Length 88
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰Æ±@0Ğı~ÅY>ÚÒUØ,’—HlƒAÂÿz¦óB©LÒ†ãEcÃïÄ‚½¡Z·a§Ö´N:§‘^œ¦H; *!äM(|I»1fü ·ïÛ
+endstream 
+endobj 
+317 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 13.42 15.624]
+/Filter /FlateDecode
+/Length 43
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰2Ğ37±402VHç2P0P04Ö31R04Õ332Q(JåJã0 ki‚
+endstream 
+endobj 
+316 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 13.42 15.624]
+/Filter /FlateDecode
+/Length 84
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰D‰É€0ÄşSÅT°Ú#Q/* | 	è_"â”_¶UÚÔ©'(•’œ–¥ñÄ}DÁcÅ®o°¢ºKvç‚{‡˜:çÇ¾ù=N ê¶û
+endstream 
+endobj 
+315 0 obj 
+<<
+/FormType 1
+/Subtype /Form
+/Resources 
+<<
+/ProcSet [/PDF]
+>>
+/Type /XObject
+/BBox [0.0 0.0 13.42 15.624]
+/Filter /FlateDecode
+/Length 63
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰*ä2T BC=#Cc=3#…¢T®p®<. ßHÏÔÈH!—"m¬gh`¤åÁ%Å\\  vßz
+endstream 
+endobj 
+323 0 obj [287 0 R 46 0 R 47 0 R 48 0 R 283 0 R 284 0 R 50 0 R 51 0 R 52 0 R 53 0 R 54 0 R 55 0 R 56 0 R 57 0 R 58 0 R 59 0 R 60 0 R 285 0 R 286 0 R 62 0 R 63 0 R 64 0 R 65 0 R 67 0 R 66 0 R]
+endobj 
+339 0 obj 
+<<
+/K false
+/Type /Group
+/S /Transparency
+>>
+endobj 
+340 0 obj 
+<<
+/OCGs 9 0 R
+/Type /OCMD
+>>
+endobj 
+341 0 obj 
+<<
+/K false
+/Type /Group
+/S /Transparency
+>>
+endobj 
+342 0 obj 
+<<
+/OCGs 10 0 R
+/Type /OCMD
+>>
+endobj 
+322 0 obj 
+<<
+/Filter /FlateDecode
+/Length 46094
+>>
+stream
+H‰ÔWË·İ÷WôÅG‘E.cÎÊÈ2.,;ÀLIòû9§ŠìÛwe @ÃsY,Ö‹U§¿nşú9î¿}ß>üô÷ÿ³}Ú¾ò·d¿ı’ş‘ö´ÿò…Ûé´½dÿíÃ_¾ıñ¯/ÿ¼ü±ÿğóÇ}ûğ—ï{´û÷Ë¿y&óÌ×-ÙP;B—Üö^jÈûåiãÏü?…˜÷Çí!•j¹B	I_ÀxZóDoétöå/”ÿ}ûb~,KZh}(J±Ö«)v—ßÀÕCÊADN¸i8Ö0¦ê+x§õsKjï¡ö:^Úr˜òÌ’;†œƒğü—?eŒÖ ¥X‚’y%G·)ºÍĞ)A/òó"=/²c%ôñóÃjTü_zŞ÷Ïÿ·ëşß]öŸwVV¹­¬^Ck£ìšjĞÇÙğ±+®ù|ãk*(‚‘Ç»ÎtšØwœÉ¥•˜Şu¦ ­ô÷œ)ƒv•w)ôô.ÓDrèEÚŸ9ÃŸëÀ[W¼yÁUcÿöëö÷ıµŞPb¥f…M‚\^e¹±R°*ü“F:!İ/Û#E»ü3bó³\\6W¶~?¹êÃ
+.[&ğßåÙ«A4Ğ×4ÿß˜ş	È~±v^'w¬àoO!×qJpÍx¼Ù›3<›=Ã¼Î×òÚöŒ§®µZ[o!K=ôœ¥†Rt¹é†µ„¨é8Ã!•|Ğ¼tmcZc}¢F´‡Şw¼ÜPFEBÃÂë²f„.…¢tÙ“@$ö×D¤³‚!RÑŠ…)q9ŒÜïê¨Í:ÚqÖÑ4HÒg:Æ)¡aŠ¾­£
+ºaº«£ hzGEê!%¹#1®dÜ½!-ÈÈK¼–;:
+D"ª÷MO®Vl”„ü¥W-{´;(Š(wök¹ß3³.¦ñv]ä˜ì	¾)È¢ŞPöÚtG ¡ôPÙo™*Ú@wŒÔjÉ¨l/“ÁÇ)÷"‘~¤qWG– ùNå%´må®ü44İÑ>£>Óqóıe*(/4ry{~¦ŞßŞ÷z»N×[fÊ¨,TfF–½"Cè’{ë(·J©ÏwGè]¦n“@âĞñ4ŒO}¬=Œ]´àòL%œØÑÒr‹àEÍF×ê÷MÁë9P
+mrˆ4_P+L¥N!ˆ•¯/›Ñ…ØŠÂ\k$6QÊ¬Á™62uiYëËÖœcj¡[#”`!6 éée[H• å¨ÍK´?œGÂÚ|UisM+GN¡™&ÌÏĞÁq}íŞ_ÇH#nz"â¸Í%•;Ú¨A×#WÓİ‡y­¼55FC`ã”æÚ|km"ÎŒ²“/ÓfÁˆñiÈ%X4òƒ{0Xz²”Ú+gë˜èœ#%ØàƒF„¡Ã5ùú²Pú<Ñ†ÉÛŠzLÂÖÔïÂëŞ«AJ)[áù
+‰W~yt@=!5;
+-¤q§'êJ$"¶f"ûÄÇBbwFşi‘PVK©“F ¦ĞåX'˜8@£9|¥2—´8Ö×Òˆæ
+V‘À'-.è° ÷ì¡¡I&ÀèVøÔX	‡Ú^LcÄsK”gJMŒ­'	iB4¾•QzÃ¢1!\FU±Ã4Jb×™kÈÑ€¾¶2Ş
+£VR%¨ƒ‚q¨èP3Eí\'-‚ÄE]ÿfH;¶0e"ÛÈø^¨SÎ!£€X"6,cÕ6Ò¡Q*¶~—ÌÏ”œ+à‰Í°[b‹&¾Vr?@´Ò2A‡-šå#ˆX¾‹ô	<ğymAÜZc–ı¨5/PP•ßYÜEÏ'15gq°qbXË ’<d\&ÀxøqÁÄÎAÁÆ¨9H!Å)Hè{ä­ç—yy¼
+ß@Ù	“=ğFTµÀqK1’f™ë>¼Ê‘nô^'¸P®H¹Ş±à4¨„‘Ÿ!¸2ÆæÃÁµÖ»£q£]èyñu·úL¬†<à±ÌÎMû*¨Vµ—>—‡‘ìIDeˆåÔ‰Ğcrµbäô9…Ì]Å^:¬áÑzİ+¦„M~ø©ÕK<%ó/Öëí”+â@Âí 6ƒÌ|G2XÉ‚Ş˜›gĞ5ÏA€ÎºF yz_~©]6ÅÒ,h9Ù‹aÔ°Ôè$`.}6=’‘3<#m ÕÒ±F‘øú²_•xlN§¹D¬SJ†ß"fåi‰®i„bB4ŒÄÓ:tr Ğ¸ƒ6à~öÔ¹GŞDA–Åô Øwãe; OÀÚo øt±ƒ™;lß38ÔØ=ZN˜]ğóé
+=¿Ù¿RO0Ùî@™gæM–¥Y–«ÃëØ«¬bŸğ¾væ`b†ø†µé°Ê¾Š´¨‹‰A¶½\-sğCÀ.èÊ¢ÊO¬[á_€É¥N™Kp Ÿ”hhWĞ
+»ôÂü°ITS;):H7ŸaßDFg\7Q¢Ã63&ôB|`ìÃ8©ÜL•Ö4,®Í5äÀ‚ÊDD±Ë¬hñÚä
+†—­Cï³Õ¢Gg]&B«®Ÿ´{°†—q®ÀUwNêæ[ºöĞI8©PÚ² RZ²{æp côÌ¦µ½„n_¨ƒ4}OH{0jÌ"dl¬v¬DI·ÙØ1ŸÕ:	!cŞúj W$¥ÎŒ8ns7Ynü“jœTwVµ„Ål»Y€A2m®c³Úƒ…QÒ	ÕV\vâŒ¡>ëz6ê±vŸŒŠã|xÒ/ÏE>|fbêOÇÎ"R¢®Pªõ|ÿØ˜ Û¬t’ÓE›`ÚòtÑ×nJ?¶¼~ÈCÆÌl;,dÈ4Ù’Yq¶r Å¥/n
+T=(ìE@£äÉ@„w}c§…­kñÖâöø`±Ó’–ÉK½“â7ÑÉN©Ñj—ì´MÖÉN‹S§IOiıµ' ì"FOàôtB§§Ğó˜¡øÇ×â§…<¶®=Ül<“ü ÖqğÓ:?Lyq*ñï‰bËXÀ,i¢2âZ'A`ÔBÖ,4'¨ béªÎ*@·&bTœI:jñ®ã•Æ¦Ù©}½øéBŒ1½ĞIA‹ó€ÅNyÑ±ÇBqŠÇxÔĞâ§…ÓÑ¸µ}ªv{<Uğí×­T¦Ñğ´|Ş¥:áã¹$-I7Ë%„Ò–öŠ}GÂÏ`µwz\ğÂfÛBğ\,#,eXÒiàæÈ¥Dk7Ñ¾MYàFÍ¬H;É8
+GvAÛW„¶±€³:dIå}KEÊ§F™Ïƒ—A,DøiBÉÓš†ß\–ÑËEx¶]›ñ0¹CxÍgS»BhîQ'¤	Få328_ûbÈ"´GmşñŠ©ÑËáËöiûº1—qG	‚VJCa%%ÉÃ`¾<mÑ‚üàÅ…fÔ¬µXl­Ù‹‘åÌr}`Ğ¹ƒ‡ÓX/$_>_”Öwïçƒœİ&HÓ+"Ÿ£è„ÅxÙ)Ô”!¨`# µüí2Iª-‡èœU°~¸oÖó¢"j “Úÿ 2S’}?âìëFV“Z¶*;¹®z€'™¥yHV©x–/<_ŒšÚÕfg×Ô´XaÙÄŞ€+!V~qU/÷)+±Êıd´Xm/¼x5	¤ì¤ÊØzw)'®YÊäy läHÿäŠÅß_§\K†ß­Û’½‹{Õhšz†ZÌDVOjq1!Æ¨µ³¼:ƒˆ¥ßğe™ñà%M¡Ñg]î,ıL©wS 7‰,õ¼­„vÒï-…4ŠÿFÃk”3’dºIõã¿³,b»²’ÕØÕ¡©½|`Ìôd?¦]+upz?Ş+«ğ™ï¨ÒÕÀwïU:ÀRAŸ×uç652U¸Ì…a¡°P¦¹TS;
+¹±vÀëm¨gt’´n‚¥ÚÄaO¥ñ‰fA3Ñ™üñÆÙ°äõÄœ¥ ÷%s¾ÊÌ½ÌÒ\¢ÿ,ùzƒáæº;´ãt3Ûä#]ÂKd\ÒMÚ`;ÜÕ^¸SËóuéM©Ùæ˜Ï.8–A“ñ
+—ï[™‹klü³ÀØ ÕàL´ıXM¦:W>ÜJ^oJ^,¶hUDC¿äUs›îf£‹‰8XV¢ ØÒ<V§˜f|½Õˆºa·zYmkæŞ[I%Á 5´
+ãMsÅHÒ¬[™%î¼4FğC(‘T^0®?-v_šÈvÕÁ´"':"]¢
+ÊF	Ö[È–`Û]æK¼ã… óvc(7N{$î%[î*«·¬ğKıIÖÏ]¸¯3—'Ş­<9îÈĞğÿyH9òˆ÷™ÿ×‡>ôEÎcF„ƒ˜BÆ¨Áà}á4%b\£Å¬&çÂı‹Mâ™àMüĞ*ò¦Ç²ea.,áÏÏQœG%‡º%óâëİ‹÷ë-¯-İFÚã"…ñì‚ŠôÍMjÒ(b”ò²G¡	²·Sˆ±ÌÍ/ëI«qøÈ«Ü´œÄÊóE"œ;,`îİ¹[iÁ0ìÛCÓX¢ ÆJhyªÖXC²ËnjÄùÇÜ~«°ä…¸^gpı)i¸1Ñï;ÂmÇ_ØZ£Ë´WÒ£º'Ô^}Xx*Îïh²ğêL4çbI‰Î‘]íÚu<‰=bRHÔÇ0‡¿›Y³TÕ/FYg…¿\˜U¢÷øFû¬ÇÉRİ<œ·”<­‡bD¿–:Ó7Şùá>_²Â[rÙÏ¬3Šp9‚‘;åR?FMuı“Ÿ5‹G„×è5B;´ÀdÚKƒIÊÏegGæ:ÿaòú[ZóéCFK¶¶+üPÚî‡È²Ø¶XV]K¤bdä·>ƒ¼‹ÊF½Ô8ÎÔ$¸ñ¦…MFiRÎ†…«y÷·IÀƒé¦çÒ7.à§ŠXé&c}”u¶ùwçw­6Ñ1iŒ_cÜ#jbIó†ppVÆş$'Ï3ÆÌ«&h`Ğqh ]ÜIn°/†Õ¥ØyÕü#raLÕ~2d?²Kpdğ4fv)È x‹ ºnz²0ŞÁmºïï¡¦ÄñlI¥2~s¤—`¥@Y'½`¥‘Ë#HDÁa½k.‹Ï½™¥—àóHFóÉÅÚ:D\|üq–4lÈu-ËÔ$A$µÃÆuU:CGü÷Ï[…³Óm¦3¦À‹m€1z‡.@Qâ˜[;ˆY®ûd—,Ûsæ#É£u:åÚöµfe¦ßxuÉ™5J -Ìå­–æá2˜1ªä`Öña'Ó-ràêr‰¤ïq^JÅv{*Ôj÷A5U¡¥1»™™Ÿ}UcK²£«=¼Ô²OoÕàv–Ù8VGô—¬Á
+>GÀÙë>GpŠ&ë2»,Ò.ç@ÈrVö­Ï·Ü¼Ñâ6iDjo,õ&~Ş¥ä3Št—st[š°=Û­ÆŒÑBí~‘GÙ·çWk¨–eüæ3™ÕºŸì&9ó2/qÙüÔ—z¬LB`ñfF/­óc´,}ÉèÕ­/Ùh.9IøëX)=ÍkWÆ§ˆçkŠù×Ã@~c@ãß:#¦FÛ¶	S¸ ¹j4ª ‘oÛ(ÜÏrÙ¬ÇÓY|ZC”ºşÆ~Ê3ÿ;Gó
+î^Ô‚%;½›Vsl¤€ç7®K*Ì££ı´ÏawJÀñ›½«TÿcDï
+óôtº\™KrüŒîm<ÁmmñŸQóÍu½˜g…Ãø•:¨ã|å/\´¾æ—V£7 W¸E‡öK5Ëë-ØŠ‡¾f!Ä6 Nk*`Û»Å}pÔğt)Ü·½3ê|ç9j8®¼Û©÷/™àòçá(é9'ÿæc7a0ŒŠ€¬-şóENİfŒ÷2·-ÃBÛ‘Ü¹¬vF}é‰B~©WŸ;ì`SOåHÁ[89¯ÓZuä¹ÜnİîX±éªÅ|éÏ²L,M¥ˆ`vÜ¥"YYGåçB×pcl“MW‘ği×wt[—ò—¦$j0ÊœºH¬¼§•½iûô!‚¶3Ô?ÕØ­ËÅĞ°òºâw“Whâ¯'¤,¬‘ÒéAcí[-x“QÎh—ò`µvònÍ@µg cp‚¤ÇnX)7²ç]ù1ºí@{…×08­…Iš^é‹Ü·6¼ 6¬"³ÈÛAïÛf¾cÕ|Š±p VŸ)†³<¡/v4]TeÕq.3ÊªÖ½è…Î‹õf?P¬°S}=Ø’^ßØå;Ïï€f:\>	İÙÇÃc‘ ÷…Òl%š vMòXç*)Z»Ä1¹N‘¸ZJİ¦jgª'a=ÙOÂIlYCE£/k&^ÖÒÀµ¦Ÿ`Sıvz&¯}aûL!…«$¾Ü÷ h,£×Û@íŸ%¦Ms‡¨B¼I!ãp8İ`†ÒÁ‡Y¶·$Ëîœƒ?É}Œ3›=‡¨Ïş ¨ÃtÅÎêhJ®h®ÖAÃ4}î´hLØ»åÈÄğŞªNºk¶ó“AÓÂh^;¹]œS¼kå.êÉÒSñ¹ÃTÉÂó€èî®ƒE})şàÙƒÁæ{ôåSw=¸‘Puë‰³&–®æ¤äe3S×;BH`ÃYôÄìEh”vHl#ŸQv%¶Ğ<€Í«ZÏ›"Ğ2v‹ìsG6¶w™÷Î|¥zÈm¢—2~‘§Õ·¨’*µ÷“fñW#m³ãËy²K\öäjœ;ê…/ëp€ËYƒìÎü<ßO«¸ğ»¢èâA©'¼sÂqK4ÖÅÊ>EE)óŒÂã[s=ÀTª×w†çÃF³·`—¶ŞGv°I¬sY/e´“”,TèThR–5‚2=\õå¤¢(ä/™¼œ!\A=Ÿî´Ç‘:BMóŒVõ]fšÁhÕ:|]-™p”{˜<ìS&t.TPÁ¸Í<¤#eï8ŠºF'oê„ã/Ï_ÎÈ€i&KM©n[µ/í±*ì™tÑj~Òó´'4-`ïb
+ïRõİxêO²ÌvyÂåx³n]¨<cnoHüY¬ôÚXrÈ:«ÜUÕJú „hWoƒCHoÓY!ò»q¢‡R>X“€EC›A8ÈD-ØÑÙ,÷Æê6U|¶Eycğ©şçƒ™ß<VŠ±TûjœqíÃ<ÑÜŞñå¹]Rš
+Ùö¦éğta:ùqÛÿ³]&É‘å8İÇ)t–qÑg³²ZH‹¾ÿ¦İá ù•JËEÆ?'ƒÃ®Û\aÈlÊŒ¦x‡ìÁËM™~éNSóÙ„ıÁø³êÏJëT%Òá“íÃvx¿€]‘ÆjÑœ^Êö>Áq„Áò²ãAløöf8‚f.q ĞR’V;4ÙÖêêÙ¶-#¤+h*ÅIØâ.¥å3š­@0¿£ÎÎ}ËÜr×Ù¬W;î:)Ãía0›5úÉìê$Ô€¢úÂ “;®»NT®tÜw² ªn#^mêÛzÃû £z†Mğ9ôWñ&·œ!;m§eïqÏ"à£¦ÜÔ¤\æ°ÁgßsÕßq¬”òéº°Vİ…‹SîzÔ«Íìhqÿİ]Ísªgå)dwæö;ëB<F»¢3á¡ş|¸º£ËŠ?ğ¨?¹»~Ÿœ\v‹xO¹ñ¸ µò¼¾³E[Ç›ï¤;.ü×·€Úõ¤÷<GyŒî¼Ãw.Éw‚Ï¾ìÇo>çhÒòPÇ[@ózÖîÖ6Ä(Â¨”ğKòà³/’_^¿9|'X¾ê·;Zì:ò}cpÛí1šÖ
+ßÁıÚ×w«tßYÔw&[Ûc]\å1JµÜwâùÂw.ËWÀyÿdO¸xø†‰+ùNxÊõ•\¼Õd2¿\˜ÌY?¥|ÁÎ¸ş¸ÁŒd£ˆ£|ôidİA0ƒSRL‰ËÎ9o]ŞœùèV¹ÀSÎMEoïœ“sp³×øâTj4¦rš%Ë¹Öã6ŞTæªÓï1Ïè<%Q$YÄ¿P(}/óÀ©ï§â¢O[kÊË)4´S5Ë0Œq¢,±–ÑpmêÌ._Îè6EL›:Í#Öü-×ÍÕxK¨²§ßÃu‰sÿ«¿3nÓŸÒ´Ó’ĞmOYkÜ¶wÖë‘“
+ÎÍĞ4ÕÈ÷QQŞT-q²˜KsPê)ªà™ ìù¹TùÀºüu¸˜’²µš£|là6ş÷õÏë¿¯ÿ½òGÂ¿üQ:¦æÉÖúëııâĞ÷ë?hEj	¹)Ä~* h‚$íÆÔŞŸ&u[‹sÚ¤1Á‹5–tó2§ó“.?u„ù¹+wñoÌ_¡Aİ‰mÕ,é™å--ÅU	Û:½y—µË…ĞY;º7İ>M¦pÙ#Ò`\i”ßk™Áí’û7#´%^JnÙÙi‡‹vÀºİc0a¶1åƒ°‘#“ªõxòµl§\Ë¿-†²İ¸WMÓ¡™¨– 3‘Å±rÊ¶'D’Iü1ŠR,£¬£–Q?ø(.–B¨¢òrr!”2İ­†.EtU—ÂEIÙU²ÚÇI3$rü–@Å®°Å¬±«CˆãƒÔÆòd?‚jŞQÆÙŞOÂØª…gl¸Y}¤s$‘Şñ.­‡&¦Ï¯’ØÊ1w£†/(ÃäR|xè¬Ï²v :îÁ4]ÂJÕ‡CÏ&Š9{ş½ƒˆ «©°äõÄÌúÿ°öRÔ™Â\–æ2ĞgÉ÷‹mİê8]fûùH—ğ—t“²òMi
+D'*Ğ¼cİCší”LH.)át¶ôÊÛg¸,Òï§79¨DĞ³À’õÎ2dl?V 4^2oq®x˜¸-y¼`Xòj¦v¸¨é‘Šò0wd,l¿³MËVğ–‡Vç)ÓVRêå‚Ìp0c6Ú†z­ß>V¶­³j™{ï®ªÕHKı
+ãÍ¾5F’féz9äsr!5'~ˆ–R]5>–»/ûâÄç–DºD'µ¢ôCÉ¬âŠí,ó%ŞÎ0‚ÌÛYG…´¢'@â^fË]ÍêMÚ õ'±Û·Î·âuæòÄ»-ÏENÆ†;24¼ÆgÒ
+yd)º3ÿ.±6)¡2sÓŠ]­–áıh3œ¦DŒÛ(e–Òù‚¨4õ©!	ŞÄ‰ªÈ£\Vbkë[XÂŸŸ£8úÈıÜLØyñ~¿‚ñÚÉ’fû”ĞoHa<ûé¸IíW%ã­a°jB¤·³ 1¦J^<|«'uÆá#¯rÓrGùpÕerXÁì¢?w•–ŠyÀµÚŠÁ’¬àiµŞº ¬7ı²ìÄ ã´e8ÆB\¯3q«HCÀˆË|ì¸$¿ÿähÑ‚i®dê6„Nõaá)ÕF“Â«3Ñœ‹%KtÎˆìªk×ñ¤ÒL·›ˆ	ğ{ü”ñğ»Éš¥Zı:-Ôek¡­(Dïñ÷Y“—dCœémôè ‚¢ƒ
+¶Š÷yüB¹Ü%^;ÖÅ¸ÁDäÎÛ?‰¢{*TÿÑ<q^#ä¸C»ñLÒ^6˜Lù¹ìº½Óı‹z'rÖ‰0V´N şÑ:
+âM¶-ÊªlhÌÙoëd·>ƒ¼ËŠÎ	ÔÕãFçTš	n¼)ŒûM¤r$ìÒ¸¿%ÚH—VœËæ¸€ŸVÄJ—ŒõQÖÙæóÎïZõ¡c²1Î:Ç¸G´Kš7„ƒ£g'Ï3bæU	4N“ ‹Ÿª°‰8üu8Z&^5ÿÂˆ\AµŸGƒÙìÙ<ÅÌ.Ä/bT×M/@Æ;¸õ¨ûşÖ”8-©TæoôléPÖI/XiäòÒQp˜gïö-‹Ï½™ÒKğy$£ùäb­Ÿ®Â[ûr]e™Ú”º´ï÷«²©9\>QFôÃ›"R	©ÒM¡¾[d}å‰ÚÃH6Šô7Ç™éäe5Ğúˆ˜ç'ùqÎ÷ãÜÄoîRê‰ÓJl'GI	ˆM•H8Ï;Ø.V½iYƒ¬ÈúL§(«ÁÚ[>ÇùqØ÷«A÷ì}{7¡PECy©ŒéåjS½¨Ò{Q/ê‘ìo¿ÈUyTá¶û¨ƒÊ:·¦„ë•;
+×«FÌ×•=‘ÂF—¤ëYÕÁq*‹ ä03Ì¢O“äÕÔ·}¯À–­—‡à€uŸQœ=«Ûº¨·e–Gh„VN«ûï¹z£»ËŞ!A©Jä»ú˜‡l_ïlıJ2ßl«Â}L¶ã}>S)4{¹	»ærôK¼…2Q—~2-ZÛ­ô—­ÒZ¥XÙ×cµjbâ<eCÒº²°åˆ–ú (õÁVê9±Ÿ Å²u=T xÕ3(k…¾1á—[êƒ£ØƒS-Qí¹Ì-èSn¹oGpÛhù¼Aêp‹ıùƒj=Q^9õu­Që	û–znÒf”úV$i—4¦š6ÒªöÕGÕ:¨ÔV–úÖÍíOujÓºÕS‚ù–f¤åñæq‹¾O’”l@=o5—ğø^kq	ÔY¯ns‡÷L¬y*;†»uıûìµ<rşÁMé ÑM eÖğÖMwœ
+O\ş:%³“KÖ|là6ş÷ÕáXu_«v7SÒûzuÚ}1EV‘Í{ÆÀşÁSjfûIº=º«µ§æÀ½™æÎô³Îx¶ıfdóñ=R«krGòéõ¤ª@Ø²Û|¨¯òBöAå Ï“÷ kA}{¦"”šŞ¯>W€QM'O´/—²%¦às„n]iÁ©™İÜá#¤İÎÆ®*G×<ì®Ù¶M§7ÀqS7ğ.¥=Fw6bbƒZVVÚÕ"kày½Ï°)°û>dĞö¥]^ÛrĞû5Š\ßG™ìÛ”àÉ­°C”"¢A#è=Pmª&»‡:Oj!Ô=Pª¦˜ƒp„¾²¹Ÿç[Ë’ÑêvÚ9Ô”üŸírIÎ$·ğ^§Ğ<Á7ÈcøŠpx!-æşg& V©=Ñ‹®OäO‚ IÄéC£ÅÜàŠğÂBÅßŸ‡¿Ä…­š„¹eïèõJ ¤¤éı¢I$£ 0J9ÙÊX|Õ9a7msI&­Vïhñ|ªRËI0‡ùÁ€6n……Tjãµª+'º¨‹fÕA»÷>ó{Á	ı§§ë&Šë³2ßÔWÜa°ueWEFÛ'À¯eÕCDT™£pã[-0„]¡Eı*É.PÀ°§­cÜõ–K³‡=±şjÿÈÇtaÂåÍW†ÑUveËóÂùCÓO´>êr;lQ]I_œÚÊzV/,†öö›°æŠuÃß«ÚäÂ[g_¹ ˆêK®ƒ›ëa¢´EX!ÉA=ÂJ‚(ñË. <EiA)Á…Ìa²¨çV~
+íW/ƒ†'B…üzÈ<^ƒ‘©EnGåáK	l¾ÏôRš6 ãÃÀy•!¨E¨í7$ƒQs–N:ŸBˆ-êŞOYäaV½£l¢¶Üøé×ÔİvJ!B+Ì4•ÚA×²“ü†÷{tø&}‰8 Á^ñ¤Çßk<ÀÎªI§ a­ £«9v¥´Ùz™¡¬wU¨”-ß®¡ƒ–êZØ¶Ÿ´·ãÚO·tom×F™SŸô4ÖÏı¤g²K@±9Sƒ˜E¡Ô\Æ£ãe¨¾FOh@”ÿ‡rªğn)ü'Q®Ø¥Ê»Äg«71°ÈìëIp™—aëÚjŞzÎUŠîÙ9ŞğÊ9oÚ¶ã	X3^‘á¼|EÂ›èÜ§¿¼éœë,lı¦î«"oÕWEö”a­0!}ñ;ñ_XfÆØŸüè°8½BêçcCØÕ+«‚²|nV¸‘’&)U•¨"´<­˜({_Ue[%1Æ›g¦ªzÈUUrš`Ho±oJUõ0U~[¢VÓ Ôw¿«*p·ªŠÛ D€¹¬)·|€ç®¯Ñã5ªŠ^°ñVUéP^Y³iç•5É™5Û¥Pdè´›51¼û“5àuÖktïÈš¬=}ªøn;qˆÿÃÌ›@%¾ë¹‰ƒuf}%ÎæÃó2LÑs2Ï›ä|ñÀ3Ç~óö]yğæ“)8>Ó‰\ØÓçÜ¦[hğêÅM–Ï_8}´~î­\Jƒk¿Á_Ñ¥‡i,ÛgrW²ƒ¶w.ÖK¬ãÅuûÑ18ªË)ÓB—í¼		â«:RäªªõX´4]Z±0€µ›—è¨K@ÄÔœ˜)ÄÚ:"ü‡cĞÔN˜‰6ğEp{BÀ”¦ÖÌx'ñØ å^³'É«ThÁßäaÏløÜuÓ´ù"oì7DE ošªe#S—i›‚"ËMMss{³v’õåÔ;Šò„ìãåíy	]Â'Álì<êÕ)ÕS²ÅÜéd/ùÏ|t‡7ËNRq@`.à6Æ˜QC‹LÍïë
+Š‡ÌO{ù ÔŠn¸jjå²Cşß^£ô„2â®¤_æ%ùPu0Fqô7²ØĞƒúòê-#~êÅU¶«¦˜éM¥ù½DqÕMb=(|¢›rş(—=÷åQ¥J³Öò&ÓË.êñÆ“î•'Oš‚‡FÙ¼£X7¾ïõ'VÍ³_Æ¼Lıú8hø–ÙŸ©l¿,°`Sbû ’$xsİÂc Oìğò!ù@Qz$»68¬š
+ãSÛ™Ë´†Ë÷<ÊlI—ON,PX~\ìÀÃ’Ãæ~¸$e0õ˜´™$«k_w”Ù¢_Î`u‹©Ámèô½gá§+¼ğ/$Wº~Ó`ñt’1Vvæ¡NXwÏ*ÃŸP»_ò¤¹Á¼)
+ü¥OU‹ËÒİ,dzÌ«ÇÂù:eºÏöîZÛ_MVj]'‘‡o¸½~)Âº5N¬]ã—aÑ/{¿>şóñï¿? ığ¯~âĞ0pˆ.)òóÁ¡ŸeÎşÄş›îš±"#føÙYŞã‹-·M_±7bË‹Rgjâ9ÆôÀ›ZGO¼¨½Øzar3Mç»nË*l†êÁEü«K­XÁ@R)Nğ¶.IO‰<Ñ¿ ĞR„ª¥}0	’_<kÅwÕƒ•³H¹iQÏÍM*EUBÑ3ßpï_òP‡–«Ê<ın ‘à$Ü¨—	ÿş‚ù}Ï ¦šÎ4ìÛ¤õçXª‡ˆã–•%­À´DÑš¯‡‡/*4Š²C¢şUv máãÎ¿Ÿ]b:¨¼¸zü^(Ğ”@üŞJ+,…;B{ƒ!
+>]—¢=š­ª; ÑšbÍ ñ›9˜ß§šf‘\,Mx‚ßŒ+4%¬âßx†R@æ ¥/¾ù|RÌ1}M69™îóVÜµ>)]+yUãñíõ„{ã“ªÓç”Ìîğ[ÑUï"ğDçŸ×Ñ…6z¥z>È«l•·^ä®Á¶óab>Éij…ßcğk~Ê­­y[EPÀ…–“&2‰ª×fQ~B¬3Õ ˜ÖA¤÷‡ÚR’Ç>”Ûù(1O›K¾)îÁ3¹ÂÀÃGéÄ¹„U¶’>œGĞM¹1$Ã€Œù£–Ô)!«/¸‚Ôı|'u0ñZ»šº~…TZñ-DØ8 1–"8	-ğ›`L¬Ğù£Kâêİd…xŒÅ¦¯´Ö|¢cë²*ƒ‰Q—o€C +¾5s,­R&2î˜‚Ÿ| øÎ`J¢_ñ“~k–.ãÜ‚Cë[{Æn¨˜ÌíUñ¡êŠÃÚä]Ê;“Wt’tu<£S¹LBæŞ˜(¡vÃE·ñC{ÎÔ®&7DB«¨¬'@~Ø½ånQ3×T´t˜#Ï	8(KÈK)¥ VD“ú)ÌÃ.àiÍK9«œBªš÷ÁøtÅ¤~dz4VÈØ¢˜á.[Aà€Í(òÛ3f£Ûpé> ğ¨XõıÙôèºÈÀÿÄ7ß.Ü[¹xßTuc–*‘ğSôm¨gÒ{À=¡uâ\úå¬®Îg¸Èk"/·U¥-}Ÿ¹Hc5ü…Í×ÄåŠÖœì‚…€ÉNüND êÙŠêöè2¤ñ7aËÔÓ‡Ï,n•hŞ6xÅÅ@K>©.†
+MèÄÎ8W`4¸µ%øús‰#ğn ^Ïî¢.2Z‹<•Hhú8d°uO0mÖVÊ	Ü;ÅUCİ:ÆF$ë.İû|‰†æ¿<ò%¤G~|fä·­*ä‘`yt74š1näyÉwÌ†"ÿ~7)ZÍ#Jş±ßÕ÷g†~ B¿{½ñğÆ¯»=¡ƒöÍšªÊnèqŒı‹,£:$ïâ…”¬ü!+Y—ÒqÉ-Ÿuêu†{øy0,Û/=šŞ•
+njçÃğÜct4uÇªÚõr œ§Îx±rÊSU¥ŒKŠ‘©óv>˜ZèşŠWF~¼¯·¢	Çr^y;#½­Øwt"¸3©õ
+µç{õêóšŞl…k @âĞ›ÚxĞ]×^£ˆTùµº.1ÑºÏ%Ã4"¼HÚ»#™räÚ‰ßÄŞïT>	jø	GÁX]A°Ó•‡õ% ›VLœ>o;„«mÅùNÀï^åØÇ`²q¢ÑÏM­Vgs<T\ìÆ¬”pô)jNT™ÿÛU’[÷>Å¿€š‡cô(ôÂ^ôı7¥—.×&ñ"5Q6(B€®1Æ!ÀTø(J1©¨)Y¥Éõir‰ºİßQ«=^Åxx4»£™ºÜ¦Ho¬W$»àÍÓ®*oˆ(Ñàù"ùôuF[¶k~C}TQà²ë	ìÏ°û2$W´mİ„ÉÏAZ¼g:@>ñûØ}ßJUe¶¼É'ÇÕßx52%zŞ„uE\ğˆìŞ
+s Ñğı€xnÃ*ŠEı˜ôÃ¾×ÇßÿùøßÉ1ıÁêI;xÕÑ¾¾?’¨ûÓMC’¡G™´òt+İß¯Ovo3FXqHÀŸ$GµÖçŸVËÜ¤ñ‰×FbŸ1„kh¿€°–§’ábAg¯‹ ­Ë»æN€x¬Ú q´DWè°ôâ]9"FME@µÙvMM‹¯ÌÎàù_~î¤âO·'¿02§-ã…'^ ¬Î¶Œì=€\9ÉqsÇ
+çÇG3<½°ø]³¬\Kgg¨-{îU£ì4xûbY’×.bc{F¹D	JÕ•”·ÅÉºì<D	¸ƒ"ôu/šTy#? © 2	yÛÄIúVs6F‰o”W¼F¹#I®›T*ñå£s*|1ë95€åÖ”ğW$‡	,XºV*ÒÛz?Ş+»“RìP¾´:àÉ»÷«ÊÈg—ÄdÌëºs›' Ënƒ˜v*°¡˜©&Õa°ö¯!=p¨Ş„.(Õ‡ŸíĞ×…ÇühİÉ? Ş8–¼ŞaÎ*Å{%_¥â^ö4·\¾[¾>à¸¹.´9İnûä#=/‘qÉpiƒï&B½ğÂX¶îX”Şr5@rÌ.¶Aü:!;ÿl1÷Øø³€ |©ç,)e³@Ë›-«/³9%x3€!òjkÆ¦UÍ39-‚7$Ÿ–©*Ã°,bG²U‡>­b/°.ÌX½%KÃ±[R3€ÎµÌ³·H%Á@khæ›æ
+ƒ¤Õ1²Œß—æFÃq¸‘>å€œOK¿/M¤’P¢Û»t	-%x­€	¶=ÛÁ}‰·c¾³dŞnqãô€¸—|¹«¼Ş²Ò/õwd±õà‰[ñ:sñnñÜád¸C³#ğw¦‘
+(ğH¨€Ìÿµ°#†¾‰óX'ÃH!õ8ÑçA°¦œ×(8{j”Áwu—§
+â™M\èŠ¼1ÊmË<sá‰x~6¶…ĞR™_¢x¿>Æk'‘f#íñAa´] ‚¾yHíÉ Š„3Š’Tû)4ùí”$Â8îæÊz©óx•‡–g”§LDpO#™»³;w—–.Eß„V;øëbœ(BËSµfRvÍ¸ìfÏ3ÿrØo–¼×ë.v&Ì4$Üg¢Í¶ã_0oÍ7Lp'=jøeªoÊóg49½:‰æ^,‰è#³«¯]Ç;*Mº­ha¢n‡;Âyønöf©ª_Ì²Î
+ÿà¢–6 ŠbAöŞØ(ŸõfyÕÍ‹3èmÈéÅú ÷°<0cãîûøØv=¡€m‹ZŸ3Š9‚…àN†ÔQS]ÿâ²få…´â½”ã	íÉGÀdí¥Á$å²ó ;Gîºÿ¼¾…Mk1}(Ñè	 UÖ‰C9hG‚e[:¹k-!#£¸õä]´Q6ê¥dS“àv3óMHål`a‡&æ~[^¨‘n­8—Ö„€Ÿ*b¥[ÆÆ(ël‹u÷»VO˜4ÆU×ŒÇDM,i>)|pc§àcòªÛ¨†Z ¤€JSˆRì]¯K±óªù<™g"©ö»i!û]>ì<É.Ä‹\ªë¡@ÆgpûQ÷ó=Ô”¼GR©ÌßøĞËÁ¢€².½`§‘Ë[’.ˆ‚‹i{×\Ÿçf¦—ƒï#€Œæ;(ÖîqññW¨ğÖşr_³ÌÏ6‚jL?@,B·…RÂÿICS«ÙïˆØû…˜´^k?rc<ó~"äyrƒÂÛıDn1ó~±jx4Ú†€^¶Í_E‘E4Ûª:êe_‘ÍC¿ş¦bgöœ‘­‘|>av÷$¢$	?fyû²<ˆšH½?wç¹#Íøæ6¹Ôµ°êtÛ]¥_íiNM{üÒˆ6¥º´3ÜÛ©ƒÓPÜ>~ÎJØ†DæÈ$””; •Ö^QQrÚ¨3¾3Š†gÁÜU­Jòş\‹Ÿ¹ïˆ–Q~?¨€A~j)2y»-5˜J‰=•?)K{™wóƒl6HıØû".7oÛÜ¸$Bk½È}9íÎ`í.d'½Ú©¬X0A¦ì-3E''é¬ºŒöUŒ’ˆ3•3ŞÌ;l€JX›å˜aµzL›`Xu.ÎGYÑ‰z¦†zaœJe1ç˜”%tlÅíÜ
+d6İšÖ`çé‰„Õª¥¨‰²gvkt°c_cUò [{gåü­k8³”¦®óÄ™+”@U–ì~€,É©1\¾*éÚîÔ$sÙ)e’ î°õ½õ~vã_ºWÍìZùD°›4ß«aÛ){”m£® )?5ÑiÏ‹ˆ)Î±ã$sØ÷­=cI ³	<a4{ÄÉ˜6• ”ò<É<M~"eèÉ•f€ù~ÆÀ7.Ö
+pïâyDx8š‹¦¥Î9HçvÇ¦Ê %ğÄËqbÎÅgmVúŠ…ã¸GßÁÜ_eÁôˆ³û¾cM²¬Šø¡=[RªYÜ—²)—c±-wl‚gõÏuj^áå¥˜bAæ³“äãó”hÅR[Ô€¦«°tPUæ¤^K>e 1L©íıXğ¤æZñ˜óxÿ<u% 
+æÏ[?¨{¹¾“Ì?f*K(â
+§ºìĞjÛìù¬*¸}heÆ¿¨¹£ğOY¼¬ÈúdxuäÄ·¬áOG7K$; àÅ‰¹çg,M®¢¿`¥˜H¨ş:ˆØõt[èÎRÒÏy3¸55&esÕ°Ğ>ªX‚t©´Ö$]\äuH"í¯úC`Ù=¤´^|Úq¾inhi¡RC)7
+JLôî(ƒERœ«FN6URŒŒª6“rmpˆæÂ2u1Ê"‡9ï_ÛMZŸæ3¶7"MÙÛÔv•!Â½Oc NpoÁ £ïb©ÇË”2ŞF[2¢ğ?aqÊ¢‘ôßn!tè”#Æ"`mdß“[ 7L	á3}\€ø?.3T™C]Q!xYŞ–j!P¢»™tç”\°]YÚÿËíZÂ>ğB¥x–ÔŒğ=*GJŸHÙ‡5kĞºè6¤t}ë
+|{Fù±Äàìvò[ğf›C«¶k)#ŞÏ¼­lÎŞDq¬×ØìVÆµ”lšïÈìoKÎné ¯±o¶½>ª[„?ÑTV¾ükÉÁ;•rëğ'VôÃ;ğ»»ÇjE‚8i*»ÇÈüõFî°n©‰æ°ª"°ì²Âw·W¥Y¨¨õÊG€Ô3Ú°ÌØğ*À(û$„¨ó!ÇÉ{Ÿ|,Ô¼Ê¦ş–¾J¢49‹â(9}OŠiµ»X×Bà=·¤„OmNË¥1Ôa1ïêí S‹ì'DeÚ$—Ó¬4R†*`M7ÿOv¹cI–ƒ@ÔïUÔæ}‘´tÆÈÚ¿;èeö8İyKzú  @Gv{K ó-JsIèM™ oıY/8öªÖ…1x(~sG8Î€:»‚‰;txqA[öŒmë÷#şç¼¤­ü›8Äç5‘êPü¬.Şgñ«r>qtÉ3SŞU!ö%ÌÎ›Œ‹ïÛ¾Œ7s_èŞáw¨R¡o…Q}Ñ{›²l~áÒèác ˆÔc©PFüzİ¾#£ô;Æ¾Q±3wï©‰‰îÜ™EWäF@g1€^rùŠE¨BŸ'`L0§ Ä\ÇWtdØÇŠÍMÙ¼Yn-*è óHÊXé\`’ÕL16‡ërÆëå­‹c£ Ì5×½…9k×—Ôõ F‰üÊ¹¨–í…º¹9M%‰¹9©^‰oÚb•šSá–-ËôG1ˆş³øD<2b	ôt÷aeŞ	¸›Z¼f~?…/A×ónEc(ü]Ëhj‡¦şG³šéqºª^ZHNí™ãz–¡Ú³ğF˜§Ê‰Šs¸Ÿ:‹²å«8Ë€™µÂ'yv}Øb´ë}ôƒËl%Ñ½âŠõèEl‡=™lH0­±,É|.ËÁ6W:½~Ğ´îsƒÛéîŞòÕÒˆ"HS—Ò.3ßæŞšoc	a¾›ïWëªâÖ¬ê ÛU¼gŒD¦B~U²b‰;fùÂ³œ;æ>„¯Êy ^Ü»éî»å©¾øú3Šß§°…>?3Ó`£ØÏƒx"àHŸ`YÚEQÀìxpÙ€3ASêÎ1H³G]Ì¡á‘âxİ’2äö˜üAL8•ë¯f» ªÿ`ŒhÑ.Q¤3cƒšêŒS–úÔÊ@~}Ç<hî=´Â¦çé¦¹ñ €c»ñüg¶‹@;Ôr0Ã¦Æ¤k,ĞÆzÆ¶Æêı§1oGg:¦Îúñ3[Æ@µŒø]Gæ|=Ì®6à@ç6J<jåÄ…Ì×È–ñ¢‹áàõ¾pK*ùaSx³ñœ?a".¹e³	[–Ì#¿†§áaöNW5HÜàî<*·îçÈNó™|Ú%. %î"%ÀÈv‰ÃåÔ+qRâø•\w‘+ºÄº —8àl'$n0uŸ¸\â’]â¸Lï)b¸x…®Ä£Z;Gá¯£¦Ä%¥Ä»Ä¼Õ37çPÊ³4'K‹”8àh;§²6Ş!q\â]â ]ªF‰‹%RâkåØÍBÆt¿s%§,#0ÍBâ2á]¤ÄT½Râh!ëWâî À”Ùèƒ¥ìş8ºŸÚO—8ŒW)=‘«Ö–÷KÜÃæ£m”8.ãÉÇ%»œVSâ¸ç)btó2‰£M[¿£¦à‰{È%îaJ\¸wH×QÃàÇ×Ù5$osoMO8ö!qñ>)qØ™rØ^Úö–w‘Ç¯zªZÜ1%n°»cîC.qâÅ%qüHÙ)ññÅã—C¾PÂÙn•RöÏ„c-§CXµà;æ±“cğ¥2:í¡SY.vT*øŠV¯H
+°*a+¬¸¢ü÷,"ƒÀa±õ™¼šš(jRËÙîj'Ì½82j L ©tI~ÇS¶ò×»a³ª—ÑX‹~ #0y^*¢^—Ô•Sõó19ê‡úòdäã-ÇØÍrlM•›&:BËğ›†[«ìñ,«t]¬)‘ì&s¬ÂÌanû¦T‰«¸Ig¶%E
+¥‰l&»7Âzv›;À¯ĞĞ˜‡Îá¿´thÙ@üxë8Yo™”?W”9Lê»™K’îd›Ö£¸˜¦F"àhõ[3Åb.¥j…LÇ?Ù€ æšª†>à(Ë2B–¹Âå›$ÒåÇZ­ç»Gµ™ô{ÖrªÎ\ˆ[Ø‰«–/œô/xùà—7˜°™–¡¥¦<:LÇ…¼Húå†*>¹¤É¡É¦×n‘„ƒO5(C[#_‚ëÆo\=lI‚K™.;%{|¬·%m®Üøìg¬‘7^Ûà'FÏ[›GljÏŞ‰8ØUé„[Óğ„ëÃÒHö–èºóe .Pc"‘Éüp,RyÕŠ­>ncôƒ“cÈI^Ic%¾Ã¸ÈÎöÍï¶É*È+\Dµòh‚ˆ ‰ÃD¡à%=PT5lÆÛ‰Ş”Ñ«úĞƒ¯
+¥k5j/ÂäØ2-ÓüåÚô-Øåt98Àf–o4Ÿ¼–—­Ï˜ËM:ô©#¶Ös1§zÃçBİ»ˆæ7ú¦ IàJÀÈ}=Ñ˜Ã¦º”•àÕ&=§¾¹Õÿ‘×±wêâ€-°Bw>°ÀŞ8âc5µƒ¬ÓÏÑ|ÙF/NlëcÏÄ8ğ8cUF¿èòftÈ¥nRÖ¥oÖëÇàØ=« kòÒ#d¦Ò¤¡B÷ü¿PeÉœßà%œ`W­Ò±QYÎ:cu:Ã[^.«@/÷èXãphı‘a^¼{ôÑ?±º!‘<ŒùGÙ9àÂ¶%¿¼ŞÅ÷ƒmOÇ­û…÷ªašÀÿ,
+[Úå—hJ?é0—"¡{¼8±­ıŒµÒ£¹°KN,İ•÷Äqı¬¢j+2ÖA<?¢±”ÍŒe¨â\ğD€Ñø•©j¹ˆ[¼IG!İ¡·\c(¤Q'q}y"ÇB¶Ù‰‹×_|s»À/ŸèØºì‰:~°x¨æ4æ“Š¸Š­YYå±èé{ëüÿÁœHEY!\¤[¨3‘U±›qq¶\ÂÅùeù‰ÕâMU@CÎô*°ÇğPñ‡ŠZsÆãôÙ?Fgw‚\ÏÈ°
+K=É/‘Åş¸d	ê¶w €áß>~ğ2²;åSÊo(0P´™ãlº}•02ëbÜ¯[¬YxQ9q0à	§*©½¥ú}ĞSÔB*9_Ø4z`C@é;ÜnaJÛ×%W‹Ä¯±şIIpÅÑDÇŠWSî÷Ãq	Õ”S6Nİƒ•#¿šô˜2.P5O¬(T€ùŠnO€m4‹­[ÏPš¼‰pÁzõ™â*'ã2CŞD]‚‹¯S“^4 _0G§Ô_"£&±–é>—ŒÓ!&ÓÍ‰š¶­*ÍÍ	ÛíÄ7±öS‘U/Õb®‡øªT´ñ¾¾|Zuèbù¨º…`ª÷k÷;/zÀš-Ç¦z3¼Mí½ßEJ¡2ÕÔ-ğzËë;­è]côÆ5åùŠ*¸Ÿ¢•ÂöKÜµrU„BèÜC£Ïxgãè@‰§÷]è¸V1¢tE^oÆ’{½gAEO7¯—d7v˜9ŠËÕ}lIšÖı1‚t¸w¨4×Q¨*èø:*‹?Goös'Î’ ›øû¸ùd“.5G”â¬^p)ãÅBua)“9#îx?·gŒ>„¯àªâÅÙËp¨Í<Õ×_¶÷”ÿ¸#ş’k‘]Œ<J$ ıÒÑ¦Ø]-y’#Ai1€€Ş>¯*iÕ®¡.5šÒÄm{,È½ğşö§`Ñ~âˆSe‹NÌLçˆğƒzu–‹®½•a¸~şÎcìÈ=[³ø		ûÇza¾â®*€X†m¸*ü…u~VïmUnm$³ÿ#ò"sÂÆ¥°ô7Qé?¦ş…ˆ‚2}ò>ûoDÛåKùÑqÖq=~VZÚkÆøùÙUœÉÃrŸÂğ”ş%cÏàª­	<ÁŞ?Y $Õıæ•ÁêO¢(
+²Sà£¡;?İX´²`qi…0Ôa˜?#èaşHægIÛÅÜÒ{%+¯ 6¿"‡wû…2íRK?ˆ£rÚW†²@ZjÍuø¢ClŠâ3¢¬ã\¹¸Vú=M¶¹˜ŞŒÆÒE¾©<kR$L^Cjªºş¦êÜ=D·5é0WİF‚¹¢;‘knkÒ ®¹±ÂY)ºcõ”İºÒló¼a‘òä´tw×FªWxóœş<Ğ•6à~éğ€÷¼‘£+¼¥¹S\ qXµ$4R¥V^TdŠ÷¬9Šf¿¤X1/ĞÜOÄnzç4ÆzñÕŞÊï§¥Qïğ¾ŸhY;ˆ´Ñ, ~Ç¦Â®‘ãgq"·üŠ’Í0Ös å[KˆCÙH Šİú^Cš<‚xˆï¶|¬³â=’|h‚ğe [ıxCàz[û˜@l+^~¶v•ëO6šÎ’åò&û‡úŠ¯nc©dæßÿıøÏÇÿ>8ü!±U²¥OJn<º?EÏíO¥ˆÖ«êK.ë"ğ-~!m–£~˜ÏÕHZ¿#%¢hÍŸïï{ØóYw¨½úVÛi[Ÿ{ê•?H.â£$0vÑsùËQ²gCAõ`,êÛ GpˆµËœs'ªA¾K}|HÎ9mÖdimÊ»ìwSGÁ™œ213ö‡Ô±s	“ËnçK¬¼Ò‘nö}lH^½£¦{t®ìb¨‡*Y¥Ü²òQj‰¢;Ü¾D»´£ç‚lÜc¡ëôq•VãG:İD	Ç‹FKq|\sƒÆ)iD’Y…yƒ]cØŸ Á÷À‚”oO”QMTèÈ)z"³®Bk1†¡C¹ÖzòVÍu	AÆähëNğ]6Ü\ßaï1äŞŒÍt…|Şˆ!èôoôøBp8ãXÕUï"N+8ŒéBi;QzÊêú¥vL³‰ÀÆ«æã¢şÁ­Â@wáxŞbÍ¡ÒÚZ ì­ñD
+³ ¶ÂşıQi<Òüy seCútEJëZ©ŸwÒ7¨g_ö>º5G µÕƒ'}œ¶5MZ¼jœ¦õü:Ã®geó4@ÿ”†ÕÇéWÑ®úRîV©²ö5««ìğªŞ»À&wìN5 Õ£»
+jÂ)ÇãR+Ëõ°@Ë,]j¢t©İ¥VêÖi¬«]—
+Æî‰@ò2{Ààe‡EÍ±;TGnP1şÔö^HwJ	?Â€òPûzS„s ÌŞF8Ó éS.¤œâyô"µâĞ“tgª¹¾¥VU¢S¢*IgÊêr"“3e$iÒ˜ê¾ô·¥®˜«'])—Øóq¥•ö(Miåe´´&5v=)Òx.<¢¨p¤¸!½~Ô+7ì(—°ëFÚÁÂŒšdG~Åš}¬¨ßF:Q¾¿šÉ+jšnD¤½F”§°‡û¹Ò‡"Š3î+Å]hırÉƒÒøe8ïĞ°%X¬¬˜I/ˆ`¨Çğ>@W"ô»ºí™«îaXb	NÉËpRıI„já	¡4V‚©]²#¹§2î‘sè¶*ñÍb©ñ\ˆSü9ƒñ¼\cğgäÊõ‡ÀÏÆ¯šã¡ôĞ?`¼Û¿sHÍøÃ°Æ ¬Ë×oÌw%øÎlÿ9Š¾èÉÒşÈ&p!
+ ÓB¡‹PR)0ü>rn ôõÄ¶,	¤®4Ûz­#ËºL¿¥ZéfÚ|Ïß  ãŞ²(=Œç¡„ï`2[iP•°<0ækt ãÙ9×Dó|ràef¾Î¦£—)%Bƒıyécã^ô¼•yXŞq('ëÒ«¡Äğ”š˜l©3eáÅm\\&ºÉ·›uöœ¢öÎ¾Ğ,®Ÿ
+yd'0mK±ø&òÈÚŞœë2"*ñ£—tËÚŞîÓØñN® É¤÷ãâº–ÅAw{C*8<j„°Ú–Î·ÏÈ“ë]°/„k´>€[ïÊ+RÀzCÿ•ˆë.›Oğ‰æLb‹ì‡§TœÇ’ßÆu´ :mÌíƒ…à>š§u19K¤ôçÑ"®ÏÆà"—­©@3Ï­Š‡cô;ƒš |Wê½xù«yu;Eï|$=3˜
+;S«|É l>©j¬øD{7¶òf¯iO€&0c¨h×NØ¨vğl Ï…’ãÿ €L%~H¶Vı÷J4ßX›±ÃP
+¶æÌ5 D§j%ˆcæƒâfN‹	.˜-…Qø0«°Ô§vªÌ²XÖ´(V€•«;ÄæFNn¨ywnxm…ÅĞ…Òç²§4PÌ¡ŸIíğ ŠŒk‘6PŸ[Vãã¥óL~çÀMœ¾[bï…§‚5ª%Y`ç²_>oéPwÎ\D Ó<‹ŞÅ”à±y©â²8'ßŒ1{4C# Ï¹òÙ óµ)æŒ9òºÕ‘Àû’>z2¶ôá²|×\qïûÈ÷lÏœç»á¶î]”æ<Ò)fA8{
+ŠÎ§’‚ Û#( ëÕİí„Š\PAÈEçûÈ×Üq-ö
+Àöx¸¤ häáGP\(AÁ/Ï
+AÁ5f
+
+®?AÑ«®?æğªj*Š ©(.tEeÆLEÁz*ŠØ:…Â²¸:€b))¤¤¸POØô€¼ğ°zİõ%0²(UÑ=QR0Äq%Ewç’¢»ÑÀì·—¤ në=;Æ•·0RRD"RR0—[‰ØÕB8 ô™
+C´™¢`ŸRT\HQEÊZ!* ÌQ­{}DEöˆŠw¢ fçClUeL™Ñ–ÛÊ u[ ¬u²ì™k*şE®tàfO¢Êà~¸Aëßğxxùñ? ¤^ô¢~ÁÍ¡š†9\ Æ¼v=R_¨“¾cüÍïŠ$qì‘0ÂÏüú¸÷Ó´Ë2ÌT'±^ôÍ“œ,g™WKx“~ëå8ÿñğ˜KîæÃ)ÛÑËîö@p‡‡N2“Ò`«S“&€oÉÛhi	;o-İÜJ€ÃŠŞíÑq–=Û;dfÄ_¹}K„²TKEâS‹.=@¨nĞW¾Òxä) å]ÌA—IH‰Z¬ô2y£ˆ™¼Aip”¼zÍ„ËMvÁ9€,•ı ĞdÌñŠQ?Ø  Şºd_@í…ÒÛõ=¼Û¢‚»:Ï'†ƒUã£ˆ÷£4ıK6!€¶“a@Ñ¨Tj§‰ıû{ØÔÉ.ôÆ°Zæ àÅîQLGÍÁ6T8Æœ™®oª«Ul\åè* øÒqìY±‰åc®ªª]½Ä}`!ÿ0!s¨ëiIÂª\A?àzMmCÅ]œ£ËŸ$´óù…ßWJåÉ¯ëfáÙM¶H\ã.6k’ƒ€U6ª}€w¦v`. NÂ-ñÌó3~ÔÕ~cÁ!ñ¨¹h`}FSe!B¡íøîŒğ‡ëodŒvvsëÆ§5‹ñFsI¬¯ø¾d!Ö‹('KÔ3å‘’&èğGppC+ÜvÑÈ_U5Q°µ¾‡÷#ß áïÅ~ÛŸ—ŞÈİ‘o~?¿Æk>ío¨mĞßËyó£Øàµ£³ò<h“C»ƒŒÀŒNş¹°úÜY*h¬èà›Œ{kÏ_%pçráö¹ñÄñ¢ÓĞ	1\fÙS»ø¨x2¶i@4D™§¹ö‚[Ï£.Ô2çC3ûøˆo÷BjáCåpHÜküŸìjI’ìbû:…/`ÿÏ1|†Š˜èE÷Â÷ßXRfÂ›šM*x@")á`½ÈóÄ9#×L˜&6ì—Ãæ>!O°iª'ÆI7ø€`À¹NÈ5É¨?›±,å\/,z—2VŸıö"Âõ€_¯9 X'3€z ´«*^Õ–fëcMd—oóE^LÈg ´ëûx€¥ÅÓúò#ˆ†m¦7Wîk†„MäÖßFLsÓ/Ÿ‡h‚¹»X@t<¼‹’Š9Çç<1kïŸĞG?ñT}k¿‹ŞhS³šhOS½ñÏV#ş…%Â …øû˜¾€™vlà"Û€ãˆ‹ìU?áÙÀÅØ À*=6pÃ=€jî`gÄO‰l›…\¥»ÇqÌ NÇ¬p³oHÇŸïîÒDİñ7¿lsyí¶Ö½}WØRDHcá†œ|½~½ş}ı÷"¤¿ä·òBˆìCşóJzÀ¨¯¶ùJ™$2RÓÛ¬ºä¾í¦â‘eÊCV€“Í&	q“1iì ­€s‚cÁó×ï®>ª˜Úş9~wóv‹"ÁÑ–aK‘ªYĞÚoìâ¾q{Vú#8‘JÏ¯ÆEEÚcˆÌĞªJ¶±a‹Ò@îôwk™Ğê³$¾s.Î}5µ¾>ø¿G,ï›m9báBlé¢¢ıÂAJï†NØÚiM-K„#Rr4|šo"–á²0Ì*»æb¢ò‹2…èBÁJÅí,û.Ç¹![V ØÂÉK-5ÚHÙrCV’Âİ¤î&¿öcŞ‡ÏĞÄ,j'.N—ŒŠAÌg€n“&i46<äÈŒF1m?ŒJ#*™§??kÛÆe„‘°›üÏÓï‘ÒªŒRÇÊö63ˆ4Ğ†¥›Ë²²#R1È¶mËÁÔİ°®¹ãİ_ëgº’#ÑfÖ+w†ƒY ¬¹¼_€cìÛ×·ª¤ä+ù@Bê,SÊ¹ıÌkÌ8êyİ>”\>šnÒJI
+
+=óÂQ`s¿ñIUÈ*€¦Sï—Î™eó	İöíZ;ªŒtÚ8ƒ¥vÍ¾uyhöÌôÎ¸p[•6Õãa®/dç’*g•³ÖN*8Ê/páˆ·gßÆÛ,'/v‰€J‹Äœ
+tëiKãqŠ)‡®ÓÙÔu/#å@Êjôön[ AN"¤jÌàûOº‚Â®<AĞmóò+H¦oóŞèP¢§(Eøş¬PuN(»;x	y‘“´a?‚¹‹^-(ëÏoK^æ‘ô‚ªc¥@4•Ò€HœüÄcjÓ[ñF•èƒiÃª+Ãæ©Xä5!–€[¬I~Ì¶É Š¾cÎúÈCIêV,’€°YncÃ VP->¢s5ğÖVü¾O^Óä<?áÙ²“Ã/îe—bç'9­ A³ÛÛ—SÜzğ	Yi#OV{$*,|è]‰JZ
+7Ån¤S…iP'%€°G·„Uór’qXnïÃ€=ïÛ—uCïÑõÔJ6tØEZÚ[Û¿Á:	yû TVp.&ó“ê²¤z6‘qñ(²¼l?$³< SäVå|°‹*™RßÂ$²3Ú|‹6lè+ğM~!˜Ï	7ûÎËn·/Uõí;O2‚¹Pö[‡¡¶)·¥8ò4K6±ƒ.˜nDOrÚ¦â:Éuho­È“Be¹ISh'úí[¹»îfñ<Ê{ i/†š¡úr’æ"ËùË­h~I¡Ì…ÄÑ]’\	ö?BƒÍw¸)‚Ş]†KvKf:˜%¾Ìn€âË£¡Ê¶ÕZÌøGw1˜ù!ÆS•zƒN±4mÚ`i¢^ødêIäà–›]s°(`]ëxsşš}mgÿÈÚœÏ†ÒRöñĞæc2Vk¯–:0 9D¸ZĞ@Ë—æ s¾4w ñZa©3?a§‚•f¥W:Y@î÷uËŸ à­˜x5Uï´èr<ƒZo »íwˆ‡²dÕñRËø.IÕüÄY‡Y>ûÀTh^kÓ‹Òeœ`Êêr"€&±"xs`ÑõEzDô¦ífmş@5&D ¥›ÀXl%íƒŞÜZÅÖno3%H]ÈN=\Ceñ²Ù8²qH²A3¿WYâ^Z/[™ÓÄ º1pèÆ Ó¾Á0Õ„%èpÔvû¶oPq0™ƒn4ºÁĞUƒn8‰˜•œRI0—o*-OğM¥Oìàòÿ|C¸ƒo*½js¾©Tğ—èÁ7 C©@RÑñ]ÂaœeŞ¾Õš“ê0N…iö‚+ó/ë5yÓÜMrÌµ—ÙlÊ$³ÀÂİïM}CIÎ…£MîÖ8ƒZ
+y÷ùhéæ,ø}«Q`•Ùo²Tã)ïc}*'Æû²mT©èûu q`)¿Áœôbñ!¹­ÉBËˆS.YÃÍª3óføˆÆ‚&?aªÙmE£—İn+3v[á¶yŞ-
+™ºÅç¾=ä{kwë°F»FœóY™P¬ ª:pØ&¹NN÷VX²q@Áš6¹EËJû+—<î{²úÌ`cB‡SlIÉ—d9µµ…êÌ8Ú÷IwCæwâ NºC‘²€ÖØ>k>–Oì[½°ŠK»•Dà_y6¢ÌÈLÅj;;<çÍü>w‘Š9¾†ûÛ—Ñ£9$£µ.´Ûh¥ÎMÒFk°{Ib4ÁhÑZ‘ûôSn²Vq€}·Û·{0âhå2ÚÆh:w0'™Áh\`\FkØSFH5ÍÁe4ÿ#°£ì`´Vå­ƒÑ¸DFè+MÇwq®yûV
+F#hOFk^Ğ `(ÏiÚ•ğåwm‚„3€% ksGß‚BWGY{Ô@ƒô; d
+.
+`$‚ew;áê+[®Ö§±€’ñÓ8DÕÈ{$ƒF/@Àı°í-´ò€Ôcò0Kx­œÌÓ³ò%
+ÀcPr4ĞàÌJfíá/8‰¼uÚŞ<Öµrôœ•ê½€tï>Ğ xíãáU	Luä;NªjciëI³ÜÔ[ñw˜TGJ2¯’Ø\h4@Nªš®½·åÀ¿äè£äd'¤“HQGuÛ†x¿ãÕ§.Vcs’›¸ûoZBìŸo¯#Y? nb<~@ªY·EdãŸÏÚæ±°~½BFòÛ?„©¬;œYY™Í›²×±åùè…2çúœıùÔix”Æb†{ÜÅZš4¯2xóUŒ…%’®å@ï×èÒÎèíx!~}Ö6»¨qën~˜ù€;IC´ÛÜªV_0)è©¨‰€ÉíÀ6¤„÷°½ş}ı÷¢mJ!i7rx ×2\	¼¸ëç•”2ØØô”ñæßÆÁß/¤s-Ÿ1Îm’µP+á®bÄ'Ú£ßÉÿ€66®N¹†,Ìh¼0–š	ÔÂÚ¿‰r¨ÅÚMÕ$†ªÔŸoéíÖÌ*dpâ²„µyÓ)Om0hæk¨“¢3 Ä¸Ùæ¼¥Ñá8$âË¬}ß\h˜ò¼_®CìÓ€!Ì–bEÑL"Bä²(ÖÊLa’P41“†A6pX´+D«wl;ôm«÷2;5©¯’/Oo+T]F7[8u‰ÈÃ¸Š¢Q_¯ùO=ùñóÊ)"òIÿ“]-I’¥0lŸ§ètó;Æœ!#&zQµ˜ûoF’¼ªÚd „ÆÈ²­¤Æê	2ı€­µúBÏËß`›¥ còô…Íì'tJÉ¸şr–Åão”‰ó,ãk^‘*S›±¬â{<™"$“K!1¼7ª¤¿c-íêNÃ¾ètÃãˆ0Ó¨*	èÆ
+P9ÁRpıº#¤°b¸á’—J‡ )g˜<½¾‹ˆL'd`ç˜;hÉyà ¬9Ø¡>BpØÁÁÖó’T*è	û÷lV-ñ4xG`>!Ä}Ò¬ylÈ7ŠtıFöy ñ«IÜòJq^ÌÁ’Lç±v4•¬†ã0´€ôi\†È¹]JSãuZ:”hİx^Ö/CúaV Ùp¬1¾àÄ…5áàs"GâFlQa^qáö =æY#¼Šöå«
+GRèÆ}¾ °^”³¦ï[Muâ`¨Øì v (ùŒ…„ÎJ€ÌNUñQ¦:<ïí«á(ÿºşÙò¡;ç§ÔÌ!€ªc<_Ş æø)"Íp\ØR°•À*Æˆe]Smj¿ªv€?8wf“•$÷«©8¹şF^Iu+)V¯h+ie>Ê?¡´ô¬}¢}{RGş	İ“aâul\·©‹²¢R7uÑã–‘WëP¡|©‹>7™=îŒ'NŞ\5ãóÂ®DM@·;u-«lŞÔE£Zï1lì¢nÌj~êëùÔ°aA]c5ßu±¯ˆ!ê´>ƒº6u:uRŞù
+f¯d‡ºá‡‡İAİ@ûyÌ3í,gw^4š?‚º6ud…„q+N]^\]S—W×©K—sCŒâÖ/uÑå2ôÏ3ŠàõxFv1ùøŸÍÚœNİ£ÜwÃ6dg
+ ş3ºZHÓñ)U_XH,fK&³+=6N56Û_Xû*¾‰º˜4/è96µ4ÆGïWámÚ}¢¸ì}"³¨Î³o ïz>äŠ¾.ìB‡´;“vL†ä}AB0¼ëNbÁUØÕ-–Z½7­0-­ËJ\ô,+üåã÷µÒqÌ<ÔiJ*v¸ï0©‡"fP? ¼æ‡äõµ|fÅ¶§[Ğ¶+3£;emÎÇ,°óóÂqÑU²»MËÖY´ÌÜÌmÀ[R5º²Át êš×Ç¾øª&I+6lÙêAov¨k¬3[!B-Í\n‰p6·;O6CÜ£{Ñu@+d3»£˜ƒyEÀ"/í?Xƒ~
+0Çâ!ÊO[UQùØ—¨XŠ”Eå…ûæW-{®*…R°Jµ8Y¦°íQ=Á<õ’d&h$PwMÖˆHèÍµühÏ2¸Q~Œ=æâÙƒß-VK_!ŞcQDbñ7È2* ©|>µ¶÷e‚¥,u>…F¤¹7jˆƒj`’îzœéğXÔ_ë;„;‰şæMOiĞ&òâ.u$uïbvºùªáyªeèkOŠ°n(x–Z½®³òò¦Ši?Õ©ÇºëÌM	$¨·‡`”D$`‘rò)æB‰Ëı¤oLœ¹åÎÁ‰=#»Â/ »ê	`Vçiè/i°ƒ.`µßøFÁĞÎË…®tÔ7Èª¡ß¯€¸R¿r)‚İæß8¯œYšâ‘ÊøÏ²qO#ÁtúÈ°3ùlĞÕ*ãßï×Å°C_ùãB‚bË@oQ/îÌ®}x€^/ è_…%O+ß¯_ÿ¼ş{±ßL¿à;D®›'o3ŞŸ¯ä,RKñNT#'¬±ÿõ¯©šº£¦ìÏYà+*êÒ´U2æÒı}±yhºJÊ8|á…Ö†‘IqÎÇkªPEPßæÈwşx¡"¨ÜªCÆ4šeAá)T/!–
+…Œ[ï±©—t´E~Ìóê‡®;Ç‡{0ÊÕÜ{Ø¿aZi+èhEt´_óYÒ"ó!J@;= ¼Öãb¢È,¼~À¢ÊLp	NE.Ò&„`˜Kz>=qC•]€–Ù{±LfÍ7†@ª; ©Õy,®0u.^h[3œÌ!\’“ÄÖÁ›÷„'}ÄğÄ ªÎû÷uÃCş¾òòÇ¥Ë|ˆ÷è2åq¢Ç„lLÌdi‰˜…/U‹é|’Š¦‚4×.*Ò/]}œ|ÖpÛsí„ŠÜÔ-ÁğUR"ªKörÏ9İ¦—½¢Oª›= ,<EÂ¼¢b¯¥°–OœÜn:`² é‚OĞ–)-]D›`“®=æn2û¡Ä¿ÁTÊê@›ÃdTh©äš@ö÷Zîœ·imgƒ…¥‰ò…	¢Üà/ÈÃ­ßè¼#Ë{;‘èh‡?z+ÿRÔ~z˜—¬ÿ¶ 6•¾1g–CpxÎNjŞÎá·t! èu¿-¶©'øµ+™sEÂàb 0ümC
+jŠÒÄîo—Ü=Œ  ,ùÜ‚ Ø)e¨tA h^‘KnAàÒ²B¸I·„8`BÀ­ e×Zö±B ,oÀİfkGxU1Æ5á@W|™¾£sápÒÑ„šÕÚd™şùªx‹¦×g•á‰‹Ù)à	”`dn§6ÁòÖj¾ƒ‰ñ¨¹Ê&¢xóh“«b®-Œab•óà@U
+ò!ƒ‡¤GWfûşÄYkl ;¦ú»˜r]•(j?õ¶ –ÆWÁ?ßqs3v0†‡&Z‡ğ*K"Üê¢FrÖªB‰äŒ!øfÅaS˜(ÿÕ)°Vp2Êñ¾!€‰¦ùÛôUç€XhåÃ¢vëÀªÆÀóe_·~%»:¹cëUöO™–E÷:ôŠw&©8¥ÖÚ#± °õÄÚ‰åïË39
+ŸÏ—!ö‹:È¨\L³hßÚæ[KA÷û—Åez‘$12äáñÀ8Œ±ÎíX}nF†w@°¹¼#Åî¶¦ü²)f¨ïúN÷ ùf£«è¤Şù~€æU<«ŠªtÏøB8cú:¢¤ğæk³Ïš˜¾©8Û¦)L,óPÑØ`–CÅ€,=>\›UáásìâÌgLŒ;ŞqÚsà†i,|§—ï”¶ê¢¤Äb²šk‡Ñ2ŠòÚ@wèŠÉ˜c8Uì¼œÊ´º‚C'2˜l©KRqÃ6À¼~À­ô€&H¥76\5”¾!ªç<Jp+}cª¡ôø®Y¥¶ÒÜÒn¨¨¬?ao‡^–¸šãn³ÚQz^5_¥?ĞµpI%¿ÀsåpÓÑú–]ÂÙêÂ›9Ëo1tY‰°K 8[c¡A«¡TêemùÄ,ªûæŠÉÖ/ôıñ;.Ú‚ ÈÒé@ô´Ğ‡ÆÒc…>„íWĞ}²^s3;JÀ4ÔÄ€*¥YÑÄ®^‘ÇÊwnh¡Ê]YOíYÑšwÈæÊ’w.i¨mG?" h(‚Ï\òÖˆ—„ñJ~Ó´¿Cî~—!a•{`<9Ò×LEh¬uGÌÊ(ĞZ_æ¨ú›¢ÕQl¹¹ñ^eè$v¼, [Ø¤ìØ}">á07HV|!!òmÒÂ¶z¨v¬ğÓV&š¹İYvĞ´ó¬L…“‹"yÚM]ˆÁè¶Ë%G–İ¢óZE­à9%ê»/¡ ûºoÿ€#‚¤2û^OyZ*}CdĞo¦Gëlï£Š«{0Š“ğPõM¬;Càê”mg`~ëÑfMâ²š =öæ%ägë‡#ÆázÂIìŒ“İ# »×ö¨²IÇçD•ºnŸœ^İK­Çk¦ÓL’%¬>`´v`*sÜê–1–mè_,¬ş·ú9=Î|^óL˜V?Ğ­şàÕ§Ï³¥p5-íÔà1•°úÜĞÚ«?[äğq<L8‰_‰ŒSe¯ççé—.ãózÌ:`‹-*`+#0b“¡'|8jv·õ.À1Fx7İÿôµ\å0ğ¶co]7€eU*ñC,:É§FÍQÅ˜ÿ›ÔæHZş„µŞ[-iîJœ|Z#®3 vJÉêàFÅ‹_ÍÆ°_>1âV\Áˆñ‹"+ÂÑ`öcÜ€ºØo(Œ‹ñÍ ïÆõÀV(äej®:<k×èc— måRŞUŠ‘–Å`Ñ¸+˜ª£ã¾tèj#ªbğ9•ıq}ffˆGÊ˜=ë·îu‘Œê
+ÛÏ ÑÉÏbo³27?Ÿ°”¸ùlÔqWBóGP¸®×¼¡¨À	¼”‡8¢ŞÖlÚŒ• 5²<6ì¬êW˜$VèP§^$®~ÜÚšE÷ÚšŒ©­‰ÜòĞÖÄéßÚÂIİÚr8ÚJ¤¶¦×®-ŒØomqü£­É"4µ5‹J‘ÔÖ,*E¤­É—Ú:àÚ
+tmqŒ£­É|zkkÖğtÑ¶¶&íş­­ƒ®-v=Úâ G[œà¡-L^³ˆwm¤¶R[€}´Åõ?´…	ìÈéWhmñŒ¶G[\[®-x´Å»xh‹¢8ÚâÎ¶bõm13¯H`ßDpÌÀ|Ûó‡¬{V f@ÙpÆD9!¸©,ìmVï7u§	8[ı?èQôtşãpÈ*òm!,÷æÈXÔ”—½”h2„'|Øñ²rO’+ja¯ ncÌñ†øòš¬)_×2î{OKú¼t^§§ŠR(ŠÆsäi£]qx—ï ¼4%('ˆº¾ª¥şæÆøù2vi3Ğ·(€&êÛ²ÖR¥×-&§°‹O}zGSm²—÷#Á˜úí‘f3·‡³ î’ÎK´0Ø(hé¸ÊàË	Ä†T2ë”†pe° Æù,*°eYT Æ5Ârü}ğä¤fş£D5ûıŠÎFóÊQ.E”<½ =Œ5î¶eúÑĞ÷1®
+Ê(¦*/>³ºZ<ÅòÄ>ÙÚñĞë2[ØÖ*z–^pSÍFüJ„š­;îküŠ—,ÇbkñÏ39,Œ=Öâµe¬cá!ÇZø^k1¼©ÇZÏä6~E_Ë¦Ğo¦ˆ]Å[Şß•º¨Ô}T¼P¦X*|ÍÈ Tñò8©b ?pª`èï*¹Š9Æ8J…M²}T¼˜ß³ÊÂ­·£â­ñ¨Øñ¨xËT¹Š9ÊNáú*GÅØÎ²mEL/ÚšñPñòâ-U¥bRR©<½1ŠíX»Û–r$äÂïÙ*Ş,CŠ”³«jTŞb|"ÑµêØâñÌ÷fÎgh¾¶€e§ÃçµñæÎ6“ïCÚ-è:º@ÍÕ”gÎ—»ƒ$\3,¾‹<ıµ4T›%àÃÅ1"E&¸¸¸…ßÆ.0ÕìŞ‘è’ÂøLÕå‰£¹ÆŞ»È÷`h6NÈ¢zûó#õGmJ€ØØ·¸‘šuÅå’t¦qóåB¯İO+³¦~‰y’Jì+;ê|9É¾:[ÉÍl8åGØÛ<mKëankï9éõ-y®@¿¡/ş®êÈqş1†qg›F6¾ñ#¼Z[-•Pé¸¸^ïædV}ì©©*¶ÏÁ›`j&Ú-¸(¿%¬©ówUƒ‡?ù8;&\­zÇªÔ`—:Î+3Ñf]µÎƒŞ^EÛVåˆo‡¡!új¾dÏ.¥úu”Ëóöp—%Æõô»™íqâ}$Óz†?òo¢íLq€¢Ô8–nkÇ§ßãêw‹;0«ñ¡õæİDbõ“Åù9¸şP–\ºÎj4g³›Œ‡™Z¾y+5L`–ÿø:ÿ€®Ê#È(ïÒ\äÂÈ¦°êî’4;"©Éù#[ÖKÛàL75E°ä{EÕÚ½Õ[ÙÏv/~`¦Q¦6HÛúÖÕí´šÜ N€*äş6wĞw†ø<¯ÍˆcXgåšò^‘FˆËw±”Š³™¤ÙY£SVh7³Dã/·¢k4¯5Š4M5¿©&/ÒHM¯Î«4²Uó2Pqò‰oòB-Ù+5Ô£#,E£"¢(W{+Äé[ëAĞªıTk7{¹¦ŞÕ¢^ÓH5‹2Ís¢ßGg=Çiô{ğ’-)k¶›‹t÷àÊßq(<Ó(ÛÈ[v¼Å‘ıBzM^¹éä¥3–n"¯®ù /Ş’½¶ÒH3K4]Óe§~“nºVl´d!–{¹K8âT‡ ‹É§0³o…2#Ô“ÑŞxfU.íf/8®üÄ/è¥G}İœ«@Lnò„¥Å¥;5ü'ñóË›:ï8øÄ“Ò£LP<­râ	¨÷G<’»•^4âÉ¡ˆ'Á÷:èñ$øÄ“àx«…N8#iïG<áºÊ‰'\ó>ñû³ş#¨¤eú-‚4ÙïwkoÏïÓ¯âÊïWyzÿävö—<˜+WKZxŒ$¹2ÂG#³Óİ8‹ˆá¯Ò‰¢'	U‰Ë\æƒ1i½,87ÚıÉaU–êKn ÍYy™íwïíÅ?ÎWd§¶î;>Ú7åwi¯šî<ÔÂ#?Ò«õÙoC(n)¼„Ğã½³Çœì‚Cv•I=‡jˆ™Gvà}‹4=ÉÄ*â!»Êâ€G¿”Æ€"…³&Ú*m>èÚ>‘sCnïïü%l¼¾mU}û‚¦İ-{QD4"I÷ˆÉ>~W×YËc¡]Ê®ó±pC¾³Ó»¶~JÊiœsáşK_G=ënr¬Ş€¿õ,[pèsáG£?Öq¯’]‘L#^û'Z†ßğÈ‡qaˆ z‡şLÛÑ%"–ÄA»Ì»ó×a¼aë1Ô5í7¾â¹ÀöX’>ï%àYîùƒ‘òrIKEW.i)\ßKB’kÏ%9ßK€‰möÇ’¬¹ƒuı>\ª¿ãYBà†ÌßÒãcè·U0ø¦Ó†×§¼µiáï[¾Á¾!œ¹™¡7 µÉ)§ú:a¬]›B@·êÉŒë‘°¼kŸ$ êñ~¹å~æêÏ+•…ÎÌÜ²îhúeÉ‚“Ìö¨3Á×uêL,h®¨>²<K½xşÇ¸5Clù~EwÓÜ<®%c@õò0-É§QöF:qşløw‹}<º!•[“øÆ8­÷Y59Y¾F€ºV'‡e•õÌV•,eô8G¡Ï·”•ßnso† ˜±@&?²|Àa+ÈG„DO+¬>GıçQ¦Oîì’ûÒIì>0s!Eø&tíq1ñÅ¡Y$“?_ÿzıã…ëG‰¨âr½ß}şóúÛßÿiïÿõúï‹›¼Ş¸„>xóXÍ‚&[ƒ&¾_—N¿*HqÿPN‚ñi†vı»ğ7˜Ğ	·¨SY»z} +Æ©mî©Z¬ÚCçwûÛÕ’%IÂöuŠ9A?±}ÜÌ¢úşÛ‘8¢«g“¥ş`b´°]½s–££·íbôÉåàÉ°?8 [JylzXa§^H]Í7n éô€åfŸ -ìŒğDTM¼ëËÂ¼¿ìÏİÁlçnIªç&eÎkÿÛ—˜ÖÂvqCGÃ˜c·X´EƒC›Nq	~áƒß@£$‚Ô‘‹ìšUM’ jNÏÂbÜµÒş|ÔO„"~öùncÍq›ëûüÜö9gõ]3neÄ¢X´s¢· P¯Ø´©*hzVĞúNô}QYSÔ5 §ıÒ„_ıšv¢g:ò­wAçW/öçk£G;Î¼€BÏm<êjšE”’İÊø¹|Ì™o+´T äwÌ!´ä18aQ$û
+`ì¢>_lìîÊüøbıDU¹˜º9Àt¨x€¢qóS|¾XªOBøn¬2éÖ’q±ÇÏ€«¦£¬¦§+KéãêÊ´H_£<= ½ğé@'ÿS¿Çä?`:Ğ»³€%¸Ô^©³Ãë°mÇ2°Û¹~'zµ²¿^­RQªü€éù€îz¤ë{Ü¡—óé©q^£«_÷_w_ÿC÷aò7¯¶qèÒuFÉ-õB²|tÍÇĞ†®"GÖ Vµ«j [®¦¡}Aè™ñëiZ¡ı)c*1‚Â]ç½ä×]%ãğ*–—Í+U@>£=:æşSHÂ1ÔKÁğG¿ø\×/,9+
+<Öpqì3	&W/°¯âúlWÇ¹L8vB€V[éN×€õU23WŒÀåQĞ8µ–ŞØüÊóöÚË¿¹§xNèI<¬›I×"·=°H0y¤ ˜µ i€zù»‚şNäŒÍKÎ¿ 38;Ñæ½ë.ÂÂLÍÇ–ÈNH>tKÕW;£Œ«øÚPpÜ±SV¾\ğÔ^ˆ.Øc¦ÜèjÒªz ôqÅº¹„ Å,´^\$¥^Àë[ü?Ç¶â•ò¶µ²)óÂIÊ£ªî]^3;.À9íG!œ.®ì¼ë„l75£1„²1â6	µ
+ë”RjëâàF(´cdƒ·Ë·°«èó"~ø
+G‰ã´€»ó¤(ƒ›YÍ1F0“½PÆ³-å”81‹«‡Q¿ˆ³vÁµuÓÚX¡$C™@»õnÏ9ºêm/ØŠ¬€p69ÀŒ*€6IŞ©t¬ªÑ˜Ÿƒñ˜Ç»¶éˆ¨9v9ƒjOmÕ]{_àœÑS*«á+i-ò€•GèuR[Í±‰*‘R/€sÆÚË¿‰S¼Oè«ë½03r1qÏó†f)ù:Sô5àìÉİ;Œ¤(ØÜzr¿a<8fß’0Kb@•DØu%Ÿ¡+;ëÜš8Z& Ú°³³&²aëOMd‹V²&²?;'Šb€¨Š¼,ryÃ|ã÷<a¾Á*YqÄ2nùšsÜÊ0+#>d½òÊÈUöˆ
+ĞÖSÙÒ¶“cxDuğ.«#ÿ˜ç–Ç˜¬òÈUJVDzo>åö=rlãÎÃË#mu6Yfñ, ÒßDÛ]Q€G•|!:lU +hºfŒá9Ñùb©yó&&<HÏÁ|ãö,3X¢è1ë[Áy´óšÌiÃÓXç<Sî ½½›¥İv”…ÎX1¯m	Â¥5*©¿±lzTºÊ¨í³Ã‰õè¸UR”Ş²@}ó;Û"_¿Lß¾ƒ17n,ÊsË1w8•ÜLÀB1}¢Ã
+×Š`c,İm.rŞT¾ó‹A3èŸ AñLm1 ÚÖXÇÂ e= –æ»øœ$ÀE\É]ÆÔ¼-_Ÿ×„Œµil#âôˆä¶<¶ĞHÍ‡	&À®3™`Ì`ÑğŞ”ˆ1 % X}˜ °îd¼ÕYÉ‚	9pÉ?L›$ Î“L0(ƒ/Œ¥œJ&˜L€™Î fÉ m>L€»Í’L Ğv2Áx3ÿèÄd1=´3ùé½ş06ì–LÀÕ`Úã&ØrkÈ Iã’äó0¡F¦Ÿl}´Êş,
+×t“ê#Á‡U§rlƒÿ¼À^0Õ`ä^“¡±ßæİ–Ùe¹-…Ôİ/|^ÛvEWŒuIøØ6ÁÜ1‘P{¡"=_fÊÌ€]Ò ¨SJâónçÊÌI)[sŒ¤d&pRfIf*F'Y´J<rÈ{…â€ú.ˆè\w3²sİ‚•²¼«oØkuÙ
+»Ô²5Şú‘­s)„øøz°„;ÜT¾‚á©ê_°‹}îä$2²Fÿ¦:İïÜ<á¿_6Á$v‰#`G@‡A5Yr…A¤ğrA€¥%©X“C8 š*¢‡Õˆ! “Ş‰#@G 'ó"æä€­V[—8pªVS8NÄÃW€GÀ$Ìkqp•\a|«s‰°ºŒæ;’ÄaÌ™ñ"ş1×%˜,âà*%ÉŞ›ã k.Á‰Š¼(mk/â°åÕŸ‹»™=`yµ<fº8G0ø°";WVY¿’©§/CÅ÷ºø\Îåg	37_T õ©0¼ıİ¢ıZ¨Ö«İö+`¶_«HÈ{ûĞn‹e_oûe-N¶f ph¿ÂÎö+ ·_üèv\XĞ t2¨¸Üï`šEû…ã—SoûØVM‡øñ³ıâñ9¦ö`xLÑEâ&Û/m`HŠ°ıºÀÛ¯€Ş~Å‘½Åâ»İö‹G.öŒ™x°œtøÓ~­)£GDùŠ»„‰Fs¸ÊVã&ˆ,©6Òş‚˜¼ó’°È.õ³ÁÓúS¹P{¼f›Y"À cZ°4>§@N_”ò	y>İA0,më09°œş@”s¶«¤pØ¦‹‘ÂÃI…o–Œ}›ÖíÅÙá:X%É¼ièí§¾ÊÆ”+n»M+à™=Ç¨ï{~åÀ›Ö¸W|ã§øã„šXO×3‡™—Ş”¡õMõøŠİE8¸gg¿’M+à8	¿è]*/ê"â=M6äT£T-ƒi²‡âÇ@•˜¸s-@õoT¡™CàÊ¡5Øœ3}!â4êy‹ÁõÆğáÆcÛ3f& ÎU³äÛ:ÂE+	’Ç•¿´3–èéK€2ú-‰»)íb¬ŠººŸ ¨±j2 p1ÿÊ™'VLVŠß±íbš¥.|š¥N6Ih=8²ÃóË­Ìj ©ÚÎ¬Şì2«÷ÆÑúÍjÀŞÇ36Kfõsû¼jfC+Õş63©zRoŠ&âÆçÖÇ%uÀúŒ­h·ÚúMiGYj¶E\¸KÊÀfÖ+Oø'+Ï¿_‡±ÊÈc<ÿş:8o›Ñ£ˆ×ÙyRXğá<ºüñ1Šzª è¥½2À6NxÎÿ@FÂ÷3ùˆwˆŞı‹ØoLèÁöF¿U<Ğaõ±Xè0|8±{6I'bBÖŸ|cëø¯ˆ´©˜-8Ëô¤‹OØ3ºogw}^¦óêÁÃ.‹Uñx£X—»àù$ûN°Ï± Øñº†O6Ó&I6Ÿ&tP=aóè.,2¡±Üù>ÜölòÇ<Úõ,F¯!WEmq4j$†aÚŒOûŒå“LüÃmğ¹^µáûÃše0o)øïØ©ITÿ±]&Ér®:{g×¢_Ï‰x#{ÿÓ—©Êö¬¾‚ŸF(Õà¤]S4…$¢±¢²{Ì!‡hS`á›3øù˜Ù"„†pú¦'	¬0à:ñ:z³uhÀ¡9…'¦ùš–-­›ÈÜPµÄ¦­;K2)ëBÕHèè¢Ã"ú«ëƒkˆ\İï¢Ó|¤–Ğ£Ÿ‚¥U›À+kòH]“z› ²kÁ¯”6i¥¶ƒBÜÁ¡®5Ï¿Ø´vçrJ¹öU8bælWáGs•+üxS…£ñ||è’>xÈú'¦Â]áÈßWá<íy%®¦»W#§Èï„Êk¡°GöœÁÑtk×Ybt¶-vº^§GiZs”ú‰Î>m´l=É}mï=I¢îò¹$ï>­ıÔ…Z$^¡gsÀ¹x¦ÓrtülRïå‡JKÌÁÑ„’eDÊ¥ÎŒŠ‡4úÎú‡·ce£è!wõNT©·§ÕÚÌ^4æk3ªfÛÑ€ªQ[Ëv”<g}Fw­Ö*ôút¤|¬-ÖÖ‚@Œ Rôfö[TDÆoÊ.Š0êğ’‚t‹îGm-GŒ·½g¹4\yÆºe-Z¼¿s{ğÜ-ö¯EÛß¡V—ï_©ëöŒ’û'sÉ¶'ë„öñ;Êà¦½'©a5ëX¸†	ºäšRv2ĞñKY Ñ"¶™SƒËÜVÑëÄw€¦Å©¯
++ï5syD×¡â±°êñ©Äh
+Ğ¼àöOmò­lo•Ân¯TkÓ–â¿ªO/©]û:ÿãWş³DQ5bTZ|hÓèúª,ÜnMLî²ŸÑ5( ¢V^æá×à^)(¶v$†r$Y	@ª>QÃH6ô<ÒÍÇS!ãì4*¾õòºf÷şµ7ÛŞ8­k|p—áVT±ŠaÄmH«6·ª-ÿ2›²KQÚ1˜:ÙÙgñˆ-È,VGÍÑ	/¡?oIˆNê²æoœ(§t™½3×êÃhìÚEtÓ=«æ±í`FÓ˜cÕZ¾±¾®+œŞí¢Â˜ü$çLÎ–,„ÊG­§ØO²¨Hœ-“¨îÉ¢BıIà^2Y€¤d²pŠdáèÉ‚ÍL8BkO²–™,äVÎ43pÍ'Y8g²+ü=Yp©“ÉÄä–É·[-“hÔL ¾>’ÿ™O²ğù–,j´lšhÔù$ğ8õ]=’a}$PP´h²ğßÑ«Á	ğk|0o×ƒ‘D½¾x[áA<„h#iü+y¬ç­•ñ'3RóT'™~ª©î­1Ü³egKSB¨Ñ ªIB¬#É"KƒoŒ²ÖR_şÌÆ¶%Ra¿3…8ÃL‹ vãÖ˜òÄ%p­—„]H{¿VÓù×Ì8sœ>>xˆK€~fD{·Üíå0t"¶×Ns¶òÓb?qm5‚wÇq)#Q£'¾\ÚzàZ‡oİd·ãS+s5udS…âä‡º…>!W=ÃéûGìòŸˆs‚ïqø› ÷lÈ;X÷fµ¶´›ºYÍÿÈ¿±}úÀ©ëg8«% 65„ÏªõÁ2’ãÀcvÕZ¢”Ó2gv@d2×r¦5 ~Ø#ö`ÑºÇLm¨übtj	†²ËâÙ¢¯Êx›ßvz–^n°ÖÑÖiU;ş<A¶c€¢äeêA]&ñ›vù´üîĞo++]ĞÒlI²UÏ9
+ŸV­”-y~+áôüİ¨zbAÊÇ:*~\Îÿø•0Hé{uz'í|ìy«vad\H¼Ñ$XéN]˜8‹«¤6xV“QàU7ºÔÏñ¹ä<FÛ(½æ=†3Ë˜w.<lµRóM™îƒw«$}4õ½^y·Íãã²îô[Üø­<%˜Ô:CwŸ/¡4ÔŒ»¾—~©®İ‡Ñ9œÚqî•ƒˆ×úö¡–õ™F¶¥}wsksÇñ¬ã¿3¸ujb|pQ`!|ú¨ÍÛ$Ò·zÈ)Á¿.Ë<„åtı‹=étÖØá0<ØÒ–¬X™ß<IºÒqúÖ¹HŸ9:5ôa%>¹!;¥1tûK¿=ã_ìq)ç2ê²d*ìeFm>™¦Ş>Te]uAZ=‚ © o+ó	‘Éq¶a!óõ×Ex:Ó!!VIáåy))+Ğ,6jÇ×9Yxå[”áş>Xj=¯3ğ«åëZ>_4×ó:`YıÅvñ:Nù:ÎyEî[şÅn¡œÿÉ÷5†š—ëz_ç¨7Æë V=÷u6ZÙ÷uP×÷u‚ã96ê„?ñ¾b¼zÑ™ÖEÕz_‡œı?ı¾N¾Å}”ó#`†"ü.V'Î—<9{D™±4Úè¢ëÆ¢Ñ´h‰Qˆ·ôüÒÈcQ’íißİóäQmªú†Û~gè¢Şöò’±Ä¢İcl¢¡ÅCPë;Dxxëù7{ KëÛl°œ³Ár¶ -ÂeĞ~–Ç€	v¶_ Ò3–˜î¶W Sº¶W 2[´WNÑ^9z{Åen…Ôóä4ğÌ”†³Ö²¯!¤Ö}»+çì®À¥Gs5¬º÷zÔZT7vÏ¡	İFÕææŠôÑ[ñi··òéÖ[q¥ÍÍ)·³ví0bpœíï)ûí¬Ææ¶êWjb&á¥â7,Û‹üÍ°üç¦¼a$ÒFÙ¿¤&¢VåØ±ó9[aßî¦ñêJ“Á{-#îc•Àwî{}ıh}¹ïë;Ç;óıMI]ßçÍ_çoGÓBñ“Ón9G˜r-¾RÎ)gÄD¨=!:qİ+‡Éb4Å2ad+x%PSº &kŞ‚ -	=„Œ\\%ı}²¿»ZÀÉÚ3İXy¯bÀDëuƒsŠÓçÙ¡P/YİOÖlíª,ï`‘b˜t–ıªAÿ¹bğé&.$éğ ¹ö•Ã¤G"€h)A9Lëˆ9L”+ô°9ëÁ~‹†4ã]—îOK£°®áÉ'`³	¼ƒkpËS_nNcÛÕ>êü÷·hMÙJb¿7Aq½›“­ÙT"6º´à“¯¸äµlã”Ód=$\ôj‡Ö›ª~,µÖWX®y³[.D^2ôàœzp6=¬ÁÄä.¿àtu_A€ñ¬9ÚèÉ®‡egO=,±âBå Xm‡œB®®sÒë±áÎ„À¹V€Æ(Ò²7\÷°6Í5áœšàô:B .™@h´R‹é-ÓÇêš&]¤2^M,
+ê…Ï7Q,kPÜíu9®(°oµ°¡£Ãß¢à]K{E±YÔ‚»5,IAí–­ ©ëµkk*ˆQ„à#QÔ:eQëœ•!Öšã_ì…eÎÿä,bDÚÖ¯ºnQ5- ÷(i×úùV´xÑ3Ÿ}ãXËsÎ'gEëì%-è”‘5+Î| °[ÓÒ€åÜqØúôëkñYÓnè‡úÓì‰ÇÙ¢Â`NÅE@KÃ¾:¨Ëõ¶]a¯“ƒ;éB¨,.3|.‹S-ş%®ŒQ.Û¬Uô¹TÖxF—ÿ_zÚN—õ4/UNÕá\†;JàÁ‡$GnLØtÇDë¤¹»S)N4E|ª˜Òwÿò]Ê¾j
+İ£MƒfßMB§ñ»Åq-È+	&‰éfËCãØVÁ•qY¿Ô}©q_×‘“‡zOŸ³Üoƒx?›llûÚ§÷L÷Äß?ş÷ãÿÔ—;’lÇDı^Eo`¨úlòÁxĞ!iŒFP4´}e&€ºwŞ# cîéú¡P(Tâ—GzòïùÇë·Çßşñ­<ÿıÇã÷GÖÈÈ•ª³å:¤§_Ÿğùx³€N4ª7¥C¾ÂõJÓ/^V»U$‘7D™¤¦¼6Yü~rÍ×ª:Şøg›¹YÎw¢ó"şX~âÛßfßçŸr¥"ä7VÚ8VŞ«kWˆÎdzáÛG\Cøí¯‡ğç¾ùŒçjõùŸ>~}şv’kfT¯èŠZi#3—’¿¸x˜tz+ªØŞ *;Ó!Öô"?Ô£SGfzc¸Ó¾ñû£J+¼Ù;ÿyaUıáXcŠ—8ıÆÓ'ı¿ *8ƒÌîEO¿1CİêDâ“QôÀÑ†>­¬ï×ææz5­é¶¯T ¥S86–—F! Úƒ¢	=)d1ıê¸ÂğYËª)Îw¨÷ÇùoÏ'b[&¥+¿‡Á0=i~QfJø©'¹eóPn´om3õ@oƒŠõ‘­KCZ]haàQÍØ8K)şúq­&œ¨Ò€ç%•ì `6äfaõëáÈãä,)	xğ!%9
+J©|ú\¹sÇ¬LÎÕ¸›f»ã}ñÚ¶ûQ)®ÛŒïw{èÃ	+è½o’ğß£oÖİäôş˜H*
+‚2é¶)q'·íç2cº®jˆ>^¨‚ÚQt9›ı`oêèÈ'uCÚÊOÖú6]à1Ş*”–[÷¬Ht¢ÎÁûüF‰±Ÿ2S° sôÊÃ9Èƒ[ºg¼Óƒ»spå”{ –¶6”NÓ¨Ú›:
+Mş~ =ëöÁ®©à7,°Z -¡t„»‡tj0y›ÉÔclæ·A&b‡lÎŒ–sà‘6äÆÊ3¢‰U¥!-Î–øE0—_yÆã]«±G²+Ÿ4QjòúœBSfóğ1q/EÂ Ã‡D 	buş8l±fâ·U$ì=¯Ö• ‘4ªmÜ[±K•´'ˆ¤ãŒ @<d
+¼â)¹*='c>¶·°³¾+B·Á¥jœãª‚{ûÊÜ‚î®F—¤(”’î•¬ƒ”ŸÎìLˆŸ´£Xd3ôè‹=:~H‡ä‡f^­LÆŠ>UAÇÎPwj¬Û²|ã¬3o9¢¶vµéT˜&æñÄí”ãL’J#”R~D¨Zz¥fµ4/z—¹8ÚòĞ°E¥ÈªXG»‡qux ˆÂ:”gã@‡”¥µt•¼t{Õ¥1«HÁ;³xĞ
+HÛÕò;yjÒú‰E&Öğ#hrëD’:¼¬:²î´¬Æp®ªK?h`OÆKË”¥;[©qİ«#ÜDµv5æfÙ“E«SÜä`ü›Ú+åD\,Ròí"œä¹X0Ğßş:Í|; åy`_ºsµ°xD$Ú@F	dæ ™ÁÓÚl‘&İoÊCîD&Chş”-M;QKiÈzŠD'YŸ<;ùaYDQ1]Ôš{EŒû_9QÎòîìÚ(™sÛF«¿G–¨Î±Ál¾”Í©P‹>•œzç`nS²šóPk~ÎXë¸lw¹– í®ZÉç­}Ä¸øö9µà%c¾˜j!XòÍô)	½§êÔ˜éP‹ p¦	g ŒÃ´¹İLŸ–'N+ü5ĞáÌêìkú@·çf-D ¢å“LëÅ©ç—ùå¦ DŸ’$0ULŞW[µ´´IOšøàu™Ï½„´÷ÿÒ’¢g+§İyš°Í–Í¶r)º
+Z¨—˜t¾_ìÏ•V
+Ë8Sí?2
+£^nln¡SíŠ"‹–$éä$O§=N+ı¼ã:Ç)t9/paºo—ä.ø¨7Í||„—ºšÍåÆH (!Äñ6ÀPÜX×µ’FÚA0ºhí[kÊãœì!‘ê+>f ß—›†è=¾à€D%Ì±æÒvMÈƒ=‰¶¢Ö½Æ©ÈÎïÊ…»±¦V,fÅ%;ÑÛ$y²ÌX†=nÇ±¼gûæXgÓ`è3ãŒGTZu ©]Ú¡Pïí *ÖZaŞEÔÜê[R»­»­®ùéˆ}ã¬·ÔCsÁŠÁœïD(0ìe¯lÊHä;3Í,•tã<æ‚ßv?š+¼xi®ŠË>İ¾¿^l‘Q©ïŒ'ÜÛ1Qå6—Y])¶Vì§²ƒkÈšìRXÉ„‰ÔÑÑo`X.Í_˜ÊL ıº³Ï™‡B/ã‚tÂxÖÒ†¢ëbæœ˜ÖGPm¦·×6Ö¶X¢	HÎvèª ¼¯«X_ç™m&FŸÍ-ĞWF/únŞZáÙœ9’iPW¶y=.ÎĞ<¹L].Î:§)Bö3%&úà.ç~¼½Ë®é¼‘I¡‹¹uÒT¦/ætŸ%-ïËƒ¢Ÿ:\q+wäÕl;H{T•ê­5´ÚØóNºXWGæNnqŠÊÍjW²ºëÖÔu`É
+ç¤Ú"HAÅBkËÍï
+JdCA£f	U"g_´l³ÎH5¤¢ã-HyÕ*2,P9jhv,ª›ÉÑtJ”tNæï}µ"N(L†ÔõE)âZŒˆÃÑFÔÛƒÃ³±üRK³¾«wµz†ÕFqRã;F§en”c’İ¹µÚã‚#ÈwZzşƒáƒ*Ç¤Ê06ë2‘6ímZUª&(Bà`±Æu_mE_ä±¤‰º2~Kºè«<ÌÀæUğî­|á$
+†úhÃ¢fŞÚU0µl³…ÎÓ(òn™=˜/<G4×¨?2ä[1¬&«İ±¤÷ıbè‰Ü­{ª&qS½ñ™İ­~§={äËŞ©˜‹Ã^pµztñ!jËî[ ÜQ…	ï%ˆN÷2ª'İI'Î¡ÓƒËòõ|r•Rõ:â‚ñxfÁĞ˜6Ï¨.Z+×è}½hAJõ´¢2š+Ä/(M›'ó’S*úf¨èMÊ™ò²U·Ö1N’ı¹ç`P*v¹ˆo¥÷›Š ¥-¯¤Ù…M!›Ši*ªXZØ,ĞõM*&_:üµåÒÒYÚ3Y?;°“ëØMgR>›Hû´ò!ª1ĞÁfEWg;œÃØ,înLdeâ8Âouû|¤“Í«ıt{®ğjs7Np‚¹³9BôÚÉÔ^M&x+Dëèg¤gUO.üâÆËôóàX{»í†„±nƒ·º}>ÒÉæÕn êÊ¸]%V*7‘×y=&,!?Ãâ%îÒ°Wë`UTr5ü»8fx“÷÷˜¬#C4Ù
+Ûü»$ÁGR2NfLõÏ÷ÇÀ[„§#é%ù$f¤3ÃÑñŒË»¾¨)½_L!ÃK×‚JÈguzqÚ‰@¾Zw®·‘NVÅ^¬Um¤t7V=Y›¯‡¾¾p[vYeDjd%‡Í,#6×/ş8ÌÒ§Ê®©¿pœ	»jn!fb¾NÍ9ê±ñÕ¨7@£¬¨(@{­«Ş˜|¹r0HÁdõÆEVoÇºvõ9ê`«7f²—™*ß¥äĞç°i6'|W»X¬7®Y½|ÕÓúÊ}Ô¨7@µ®¨7Â‹W½1«åj\x$–ÏÇÄF/)0fì»«ûëT­eš@â}B£¨ƒz½²¼ìúH7å‹¡¯Ç¿¿àï÷GÆÍKÏŠQx6¦Vyòù`ÃçƒÊÉûùíÏG@+oºö/F$õÿÛÕ’#YÃöyŠ¼@%ü‘Ç˜U 0ƒ^d4Ğ3÷†¤$GTUoi‡?2EQŸÿ{üõ±†j/0’µÖ‚gÆ/ÿûo§îĞşy°0zÄXûyÌÊ”§üÇÁQ‘X6şyÕ8|èšgt/=fjÆß:ı@Ps!Gşøüë-V¡kôÅ¸Be‹tCß‚*$2·{ƒtä^)6¬…Ğ)›¾@„ô0óxç‡ıÜ+²}ÈpÜâ?Cú­¿Ğ}â±šŠÿì!š¬LlÏ¾ÊI‡^ú4\w.ŸGX:ZLWÏªµ‹­ /LQÕ‰ØDAMÓ'N”ˆWFB¹êÇ‹šÄ§îÈº)’æÙäÖæ+î–@—´CT‚=,fï˜GˆsO	1}I"–­ :}g'”cévúç}7èD`$ªh\Ä¿ğ4›en	è¨^jsÕ×à~ñ>Åïpû>âûñAÁJäòÇÎøÆétfG¹)l37uÀ`^€©qgíû#¼Æ“u‰#ÆØFU	.ÕûÄl}v §r¡2yïÕ¸Ğ°0!nĞÕ=Bñ	RÍÕ~E‡m¡-6Wäã‚ØqıFQÃûjß%t¼v|±İü¢z-µ8’Ñ¦ªP:K^æKÁKĞØÛÊ¢Àiv½^e*3ãûÁ{]ô}‹ÑŞõ”÷‹xúó£V¹O·üÏŠÇİŒ%• @ÆÂp‰Jç±<>XÛ MPÖ¬ß’ Î)NVô˜ìÃíÏÖRº!Áƒ[Ò¥Ş±Å£s6ÖÆè?>.ôV37hKkA¢x ®>ÆU ıuR€PC‡‚„ôóoTäˆ·å¬3RVâ¤É9ncocÛ» Ò4£XÃûVú-ŞA•K"^|ºr	Î2"·)Ş)•µìêĞØû5´#T! ¬>@ûP¶×û'¦Œş‚¨ĞÈ¿¡Ş$Â¿ÜúNsì†ÓÏ¹ şq‡.CòÈ+eAÁ½÷ş	®9¢¾ Œ,/Ÿ,/~4å3}!Û¥pc¤Ä›Àù	
+ˆµï`İJ©·¹İ;ŞÒ—ãİÖc'd['I×¦¹™ãlì”òf%š[7:$LP©†ÆË¿]´4Mu| üÉL!Cu^J†£÷«qC}¯³ªÑS{ë!.dıæï¦ë4ß‹Ô	 ÆE®b»š™‹cìE¢îÒx$ôşÿPé:}òQ¡XSËĞã8‘}‡rØL¡Tíq‹o¿i9„ãKõêĞ‰§XÊuHçÊŸv$‚$s~†z5<ıú¦v7:êò_ÖVC½¦ê“Ë÷…®ß€­§‚c‘­ßQÂcƒÔğ]·[µwX¼$BTp­›S®ú¹BÎ›&ú¾È¥hŠƒ?Á{ßˆÑÕòN.(fuy*fñ‰¿æhMr@+ºŞîw,şß&ĞmùÈör Àzƒ¹ş>/”ùXÆzAxÚ¾Bºwº®~ô—t\ÕòiŸ„4t˜´0 ¨úĞ%¡Ü6ğàD>Â«]ÇO@æk"!$‰‘DY„ ÎpYäCGB¶—¡l–^·ƒİMoGmHßE‰	qÒo¢SÅ(×à5Ğ‚é)RÈ)ìİ<E86åwéÓ.à—OtØT»‡*F„` Ö\ßš9E)–%¨•JÈ²èßEìÕ<‡méj£Zš-4g^õêş¶1¿¢g"/yÂéô<~à!WW©è•–~U†¿“ÍDşˆû}Ô|‡Ò„œ”s1eFSpT9 «´Oş
+gdC'ÅĞRÊèè†gÃKŠ6”ê  n†Ìáhº}9´®BÅë6éçl~Ã…E‰1£y¡ 3=Ñ¶±I‘[Çj‘lñ™éd$èJï(»Ñ ·°ÌÆæ„3ïĞ°İ®ilrú1Vö	Û }{À›Ì4ŞwÖ={w ³'{]÷È¡Æõo'`ã:GdsÈ«MÏkk…tñ-RJvx¤'áÙ-àwBEù·ÎûçdÈLûFØsòOĞÔ(¼Aú|£5ªĞª
+G…elY€W¥´İ±	QJC€5ô«Îµü4}¾Aäÿ¶€q;ü†+ ²s127qì“CÄJ 4†¬=‰fSU@*{«£C`‘‚ä±Ù±Cñòæ¬] *wó‰;Œ ›¯ªÂ@GV3_±¥±j&MÒ9¢ökŞÀ¨Ë”3€=75.8uûDB¯èÆ¬Ï·6*Í€‰½m><wÙ†L©~Q#r¡ìP»yÉ5Ütx¬:Èj3ÇpÕJ27 ,ñˆ;DÉÁwî´†êk9oM>£\ó:SwªiÁË .Yñˆ*­Û¾ µüÂé¯~\5L¯ŞğØÏ™cv5E ÂåÑ‘0Wí\bÑ!‰uÔJyn.±F‘sv8ØÑõ V€$Ö…$@íÄ»ÄâŠ’gk•G'Öà&ç§*5‰}Ü5‰• ˆå0ˆupÿšä9*I¬AÁKQâÎ>VuŞ2ê%Ö…"fÎšIÊ5¼±è:ÈÙóE¬¦Dc¸ˆ+b9¸ÄJHbQ|-‰µõ A,_.ˆu°ïNbñê%Îds±xZå-‰ ‰u!‰Å›¨¾‹<X±Ì±š²;VTxE¬äQk@sM´ÃYŸ„Å¢¬2f¾j#Xê®p¼×ì¯±Bû‹­ P‰‰„Y°Aµú;t½“‚Ğî&ØäEŞàèívš?’oğAî£ã,¥Eô '½›$ŒAÓßÊX@¼ÇD5Y{¦ÖV&¼f ]›B£kíé°nÌÓS­æá3!iô çù0â'½ñ˜îêÃ(Ò‘p˜[d”Ó 1èÖ‹¿Z+,V\e]»0X4ÒJpëâ—Õ9TÿáS†Ot¸<ß–¤–ÆâT*IQÊZ #ï³rš¼³]àñP€üŞ¯>	g¥šOŸ<c4A «œ6be1;Ol_ECı‚)¥uÙ–c¼)P‡n`Åbkªq¼í‹Ïl· ·ı'•Jz1š“Áh"%ëğà¯¿Â/ïíËôR…E~c6Å¿rk Òë‚âsÆIfUùn“fóÜ“L:ßsO0·ÆdÚ¤_`œ„Ez\
+t
+ …'MPÒtZê¯(<‘2+á¤¾œ p€¤p@§0u’¦“~ï\
+U_c§× 0ÎÁWM
+_èÆÔµ,(ÌEÆšr³KaÜ ×“c&ƒçğ¢pü#)LØ-(L°jP öz)ØÔ1ÂÓÂj‘¦Ó¢<:…yÎ™ôæTTIa€İæ…ÿóñ¯¿?H¢ò	fU,T 1‡6êÿx~‘êŞ¯U¬áß„¨x™|$ŸÿŞìäuk¤È÷"À€ÎŒCI³ôä/ëêµKâÛ–¦—/qíù)ö½@¿î-Xr1)FÚÑ(ø³3¨¯¡ÙAúXÀJ%5WgwÕÜåé'›ŸIòú>Sv0ŸEŞbíà­»š¤4KÒº#ÕÍÂE†şß;_ÎQ&+®Ußë˜?-lÍêŠ¿„Òâ)ø¢¾„sæ‰mëkÔÒ3)g~2íô@p9¡WÅä'.éá" ÿc¸ÚÿÉ®v$Ùv–÷*îæ•~Ôg^CW¹ÌŞb $uz|“.¡¥#‰	‚fáíıç¨nd«ùøĞ4sFù¡a1d'9qÄÅEy'ÁşáVc	™ø â(qµ
+TŒ(LÍÓƒ§$¢Ã¿ªŒç,nü†¿3š:èıJD‘ÅsŠÜàÈäÑ.°´ği·§­cÆÂ¹èû¢†ÌçfûÿPZ	„WDºôsI4`“¬şNH­dª³óĞ#ú.éuƒatã$PGÎŸÔ²=Rõëô›,8¤ßl˜Ç‚=q“:·Ø“„r¡³g¥˜ÜÁÜ$K>ªeÙ—;Qw„Š·,˜ÓÇq:NŞiL­Üİ‚51>vI{K31(P/{°"<5rìöµ—„Ip>ø²Ú?e*”'ï ¾®c˜”CÒßí¨]N+;’¬íƒ\±ö‘gºÔ!?r
+C+UjğæÉ
+GMáºqÇ/)\é\ıé®Î(®,
+cÇ=f÷?7xpOM1îèÃ™coe´¬xùÕÌÜYqã¶7€È‘95Ô…Eü¤?ëvj¨È:¼Œè‰Úƒà}è
+¸"ş­XaùÀÓÔ©­n<lË¹JĞÃBß€™¾Œ@'¡å‹>C,…V~íÏ$÷l…Êuİ¹&äMå»Et+Hö:Õáå÷	¿ü‚ÃØÔ—mY~¸è¡ü†°bÒï‘€Ë¯Ãô “Ò}pÎ-¨ö”Àõ1u4Uï¯l±LÏ­ÑñØø¦ÏÊg­D¾¶'Ú€jÍ™ªPíJ°!=v¡S2 ÓäÂ‚¨T7‡‹:˜.•şá–Û¶â½8<ÛEt³$Söó@ê`
+˜†ÇSäS ¡"5¯‚‡ Ú	€+›±Ï™Dİj šd¾Ğ]œ>hÆ=\ˆâãr,Fz‹€t&¯Øëğ›*òŒ»÷T?úwÜäÄ‡e®ìÁ™–°™”BBœî8ä€Âë‡Ã3=;c˜‘ÖKhFZ/
+ıP°ÀÆ4@»:`™Ón3Ôò¨eõs˜¡P¡†q™™øºï'=q¡Sòª
+››qƒ-aD[º_pI_ø‡æŠ‚Áæ.z‚­CÙ4]ïğó@ç|/¿àĞìáæ|ÀÌ€ÒŸ”é#jƒæz0ëW /ŒX˜°²ÛB>.ê±Å§aÒBœiálÛwdÀ•‘cÆÛ‰ıˆÌîv8–o¿ŠÊ„ÖqRU#pH“;Y­#Ä±³j2ÒL†Şt•gÎ"Rñ	¿¤ÆÄDë¾–¸(€†š³éìm#çIøMØÇ]
+ı¯ö’Õş‚ãÁë]´°5öxÆú»mĞç”ï kĞ±2Iö o¾ı™-çpåMvXô³<ion›Cêa‚FŞ`¥‡¶:¿šéqõ7 ¦9Æ!ÀRø(JMJ‘S”ñ
+!wí"i©‹†4Àƒ§ÏVUz5Ø¥«Ôï’\ğd…AnJ¢3åŒv‘ÜFöÊYz^?Íî1XãZ¡ ËS(1ª„à(„Å_ƒ¬x®š—Õnzï‡ĞV6‹ r-÷q“ª‘B¥*€Mi´fKøEÆÌ9Ÿæ&ˆ×vÈş’ScçÏı°nÁ²&)ÅÛ.Hh¹¤°UD9ÁŒçTB“½NÀßFôv^ ³\ØIèG.¯h2Áì´s{JüÈÍ©£,ŒUÈ&I’¦e¸Ô¢V (ì'/8îR‡Şå4/(|³-öw ƒ‹D¬æp°Ï1'ÁŞ_g’„K•KOp0ÆµŠXûòıÈÅÇ…
+çào¥ÓÈ1´»Å2!–³%vmê \ÅÖg/WÒt…øc7¹b*P¦Ü5µ‚|]ŞT=‘HÚAQIÒB‡“õft5C/nR+îx¥„æ(F‡d-s9>|5ËÓÏkt%LV«·“,E€¸ÖzjÙàõsq]gğˆ°ŒÃàë·é˜Mo@6½ö“õ}Lí¸…q hZB\òy”§ª³÷+ ‹~µVh ìhe]}xF66Ã½w/ k+åÔ^H¡­WSˆæ&=@Ğæ‡Ï³rÎTMA™xˆ î½‡ÿáé!™Şk=ÁàÜšÚ†YíšÌÔ¢• G¡K¹@÷Iâ„±-ç–´lWĞÊˆ£uDÕq1h”ˆ[²,‡8^N@¦í¿ —.-n%›U£$Ø‘æ†Â:{\øıºğ¨J#T‰QĞõ;Ö8À³şıºĞUàêõšìÛà`€>® Øæ*q‹ ç…ßdG mªÂñ¼&‡›ş‡¶°ù’ßğr§»ß|Ø¤ ±›1Ó:J;æ·u¯­!¢m¨Ÿ9¤ëÑƒ!pßæ	uº”ƒá=ÖÂ#è/Íµ‡o<•…÷Ğ)µpç~8t^€ cÔIˆŸ³?‡)İRº/npÆŒ—è=ıÍÛí•¹àµp¹­{¥»dëmQ¸‹æıŠâàa8Ó¹z{#sâ=ºŠÈûu¡G ­_pÈWÈtcy;ÑÄ[?İÀ­—‡ã&Ç¤ûgˆoİl–ß·ftŞ[oW–â¸ ÉqãøUKZÃLêä8À cŸ;–‡{ŒşpÜ…ÎqÓyÊ9›ìä8°3fWr {ÿ6ÀÃqñGráL#8Éq ¤§ä8Q“ã ì$ÇÑ}åá8Û¹]’ãì“ã&†£*W'-â7‡‘Ò“Uñ/˜7ÙÓ$ÇáË¶“ã v}8îBç¸éJÕ9›œ$Ç]è±8)ê'lT€â8˜sNrÜ¤B™—ãhª=w¡“à;ş‚×äpÓå¸‰z3¦û9<œãb.ïÇáé3T dIqVšŠÕ‡(¸jvº{ŠìCT`öŒ˜ìó –¾€­ı‚µ’ &™)‚8>âò&aÊ(X÷ã&mÀLÚ€LZ‹eÒ.¶9v“vB1×„ ½dÒÈ¤èIË¯zæéb|’Ğ[^Ÿ:+R·ãIÙ=e±r×LY ;iÉí÷“²«HÄ›¿ÈX?	ë8ó•he¾ÔéÊñºÙÊİ[fë¢hµÈHú­>ÙJ+K{æv‹dåxÚG²şûõ¯×_›òªôHŞï?İ	;¨÷Ï«("Ùªz!üÂÇØâkÈR`Òğ™¡Å"c×êÁ!\ÎF§¨Ê…©±~Ø•È›Ô ÌG[€®–sø~¥@a§Ç›Õc&øÑ""Ğ„^	7ıòZ9~¿pİÚ)v\_Ë¸Ñ0‚æ}ŠCXºqM<R:rê8Ú’Œí·%x¿ òg¢¢hæwì^à{Ü?ª±%eŸb4lÓöÂ;"H,SÜaÿ.w-¦œ”8«èÃr,3‹%Äå›¶hæÊs¥T1’÷#!&kÂï„0œÌÆÿB<Ku;OÂ÷ (–;\`æ­‘Ãùœ< ƒÉĞŞü
+Ù3bûêjÉ!Jì’:–5°6Ùo;ÜÏ­ŸhQ)Vß´ö¢ï@MÄA´Ìş‚al¸)òZÊpYt»W%İí—1¥®­ï×D°„à/“³¹> î«’saÁçPê]Ñ‚â…â==”|»*€¶â tMc¼JÁÑ;“Dß¯->ş¢”=P–À»_`]„˜·•gÌéI«æZ	xrùßÕ¶ÇqDßùóÈÌ¨oÓÀ0`I6¬x?„A@-W&r,)ğ×çœª®Y‰6ø°sØİÕÕu=ågƒM'Dõæˆ$§âœd£@/º;kÒ™é©Ì­.)ÀÿpAM¨IÅ Ì5 ]2„Åpc‡E|¶çª Ò-Y±µæÀ"èc4c¤¨¢uû&l]L#¿|±¯Tt‹€š¸ÃiÊ;ä’±zkÚ(IeëáƒÚĞ´OxV (¶/uÒ{iÅß¬±ÌÂ#8P¥Ò¬®Õ¥ ¢hD}x_Å´TRCQZövŒ @<ø(}WKr”Pì5w°ë
+7ËwFP›¦O÷¶TÓ)æ$wåtp—™U¼8Rì4¤³ ŞS ‘ÍĞ£4ö\DúÚ‘Ø!iÂË*‹±Ä[•¡a‡‚Œ‹±i•O”Z|ë@SZÖÄ+,eXbåeÄ8‹¤”‘{B„tPÔòZ	ä%vÜ)&¶5ŸåXå<3Pu§@M‡»‘:thÑf nËRgÍ¡(Ù%õ•Y¨>ÍîÅ*gj`æÆÃ›Ü0U¥`È‰NîwÎ;º’˜ãì<™¬âP×¨JZF	ÒQÒïH³åšP%g…v¢”Ã®¢¬Î²è“VOèkÈ2Ù0~Š¼•tÂR…¬Ø¯)Ã“#±  Ó4‹EÕWIœ«ä\ÄƒªÖº¤xCâ2i‚c5é%©’ˆò=†º]™¡‚À—P(êQ-œ
+’†D{×«S;T(2¦¥Ô­"ù)È{±n™å¡t+gÓ‡Æ<¨ÍİÊmP›’§)
+Ô7°URtó†$›HÈçJ©û±cÜµ¬ú:Ï¨H^kY­b|ëçì»Ë4(S¢Ì‰ª‚Á¯T/Bal7áÂ4P² è˜*Œƒ¢Äú´R½h«ÇÁ†Ôûı`×g¥-H 	¢ÖOíÉi¯/˜50Ğ$	Bì	NˆœÄ|åÛ²µ,UDà‚„OTpÇ;bË_b¶{!Ò}ÿçXèiRÓÖ¸(±õZÍšÔR6š
+\h&h|ï¸ÓÚ•ÜdØ4£¤8‰
+TXam¸FÕEN¨SGbi×òX¥›¥³yaŸ3Ë}Z(wÀG\qnÃÃFèÔQù¬+Œ0GÅÖ (2¶èt#QvÍ/ªmµê|(”¬{5PïÃJ…ØO`E%(Á4âÌ%ÏU"Ü‹h
+²ÚjÊùš¹ğ5n™×p™—ÜD34mN+cÈÚÜ†a™gmeØ•; ƒŸ)öhò@!%c@Ù¥…;òİÁ€‚®F¨· rnÙ\ZİÛt®ùÓm…½ô Ù8´0L¹èÆÀğ–V½2#AıeÊ¹Ç–´Â¾Î»µyp.³âÂ¹"’½tıìº`ŒHf¸Æhá}‚"ŸYUëH²Uí=‘:‡ŒN“BGVC$;DtÀ8æCê&²m¾ËôYBÏ#ÄÃhkn²D×‚YsL¬¶G ˜”o×¦*Ô¦±DPœ5h*Cè¯5èŞ‹WI ÿl›M,@[)ÚÑv…±ÒWaYïy’ÍÔĞ,Õfw¶`Îƒ“UÙe¥ÔR”rŸ21Aw|ei¶Ù[5MË
+)Z0ŸNT¤Ò5z—âjßÛ4û<B‡76©¾&}c3$o”)µ¯Fãj¹•àé [;díä‹ •¨)»éj‘tàÈ
+ã¸˜,H‚†V3ßHPvB–%ˆ¡T	†rV³Tõ±ƒ Ôqo@É‹:1 I…”•E:.•ÌåHâ%RºÔŞmYEœ˜da×r×‚qp­E½6úFëKI÷ÖYñ,«½ÂÊCá©<P7ŒxKÍ(†qšÿbÖ¨Í.ğkT¥ı†¢Æ9c†öØN©SË¶ÖC+
+«1d!0`ĞÅæ‡v§ºb/ê˜A³Tüä$ÑyVêœa6S¡oéHá7Q`°”5jÊj=“Ë&gÀ¾JäudÉ€—’~Å:%t§ Ô,²™¦¨…œU[£©Ò¸e«`™çR²cF$z8ÚQ¤í]V¡mô­(†p±£©£Rp1×g6$abg*†°7‰lD£ˆ‚Ñò:ıeß÷uP˜ÅN‰îŒJÒÍEöª›A¾?[dWrJš£AlÇ×jC.2w¦,$ĞV³6C¹UÕªc-õ@NùšÃ0F¹s3$/0¶æñ>-Š§úŠ9r9~fARıËÌN×İêëâ¬¾/ÃY3[oì¨TlíŒSÃˆS¼Õ‘’Æq"hØ•è«]?=iHåÒ”å%Ï†h™÷¤…,.ÏQ*‰{Z8õ1UO¢TÙ)IY%);F÷¥oºDÌœV¯!£‰ŠM?=iHåÊk˜ty!€3<İVD8¹™c0ºní@áW°IÛámøYğÚÖ>‡N¿œ}’ˆ‰}kî”Ø—pMÿ¼9Ë(9(ïNªı=aFPšØÀãÕJR‚L²Áƒ5kiS—ÚöÂTq[E1õqœH'ÍË­zr(´(+;£Ÿ«6²™É¯ë
+÷†„ K–EN[@Q›x¶Ç¹ßÌ&ÖEåÎ{O°ù†å´
+‰œ”ÙÃ6dÑf‚<[Ñ$ëöj3pçñ²š5˜t&XÎ†Ç½(uşÛL`Xg ØÔdÔ¢o(¤2+ÿl3Áò2	7°´b—£Í™«ÚL`V\f‚\¥Â3á9pX0sRH
+¢ÆJ…gXpÔÕ ¬væK»\E²·.8#³b'ÒBnxÜZO4Zé»;ûpö÷³ï~|=áçÕöìåaúúë—?¾~û	ùÍ7¯Ş`ååÖÿÛM~Ú~8“¦>m?M(ÈüÉGä4ıT
+¹ ˜ÃöşìŸçqš~Ù`õü2–txÜàkw³?L?ßî§ıía?]"Æßï›dÉù§MpÓùşöñãáWıÏWÓ¯Ïÿ½ï‡Şß>=í§k|½’…«Ã“öÇ÷·‡kœ®›mÿª/zùîÛí9ßÕ{¼¾§ÊĞ±j1ZNp¤¯)ê^L?}¸»İİ<]T“+h²’ÿÓîMö
+ó.ğ ¿Ûkˆù›èøpxz¸=Ü@Äqº<wu¿‘_MÿØÌø}8ğ¯ËÍ‹gå“ïh|'£	hÔöÄ¿Uc|ûîù£q¨Æ:5mw“şv1LÄ¼zûf‡ µ˜U8¤gÂÁQÜŸÆ²Ä$w‹¦iz{sd$ì§ÿÑóø’À¸Œ96ô:¿Qƒsíiÿ‡NÍâS“óçÀö‡ÇI¢|k×û#/Şïo§ïä·‡Ç½ÅÔt}õ8ı¬',^Û\0`owûİşğ§~¿Ai>¿Âó¸ÜæQ~È%¸øY7•ãä²”M—z}¯‚¯>>ïçŞ@4*§‡~°‡â'}æÜål³³ˆşRíìV2òöi÷|Ìqá³DÆUVmx¼¿zş¬_+AÈ”¤x±ÙşçËí#ş£“®Ò5\§Îó/ó'á/azÑeÈ½‰‚Îw/ŸnŸ—›é11}{}Ü?>şşññêé÷g5K+ÍB]Ù®Ñáwÿg¼ÚvÛ6‚è{¾b¥Â¢®”¬¾%±ëº­›Àq ñiRÖÖäª—1 ¯ïœ™Y^,u$’MîÎåÌ9gr˜suYòäó÷(qonñßÃÓF;ûÈƒá^A=ÒI…QÆI
+×sRs‰áËp
+è%D³+|ÌñÏ+eZvà÷`ƒ16›¦ÔÓÔRtÑ+ï¯Ë¬ïSDtºä“Ä‡<ËH8g(Ö\¼Æ}ÓóŞhLÉIÀtqã>ÿõı4`D¯iË˜‡$¾`â­ÛéTøcÊëîä8©ÙÀ5Û&r3|¦JÑÖ}”ûŒ&c2
+õ:}òô8¥uò»Æú'=PCÍİÿ:ë1ıªÇÍÄ'pG„üÓÉà*Oë½¯²Ä×%µäî.º¹‰ş ?„üû-Â’›>5~@šâ©ºÏæ=1*×Ìç8§şç! ÕÎå.Í2$Š°Bé…EàLRWÕÃ¶°9ĞÌñè½OŸ¥@öA
+VgíLí2ÓÈ¯Ü»“‡Šƒ·XªâRNËÃğŸºß¦¶°ş~¾Xøêß=~¹<dµL!q_¸¥ƒò4åŸÀ2
+ËıtÄäã[UƒZtñA­B t¿¡¦æªL§Î!ßN<İç¶pù¶$1£2ª¶‘´¥ÔJşòS«¬uØîÉ‘É;Tw¿+o+Û\kÂÂZ{†Ïu’š ¥ p÷kÁœ~±(
+ı7—ÎS3ñ“Ì>6íJ¸E´w€
+Éûá¤ æì&¦f¾\EËÕ„µ‰]€6AVâc–,¤¬İ¥Lu\™«Zk‹Ëİ®Y[Ï–´"±'¼×‚²ÿÚV¢Â9yÈz
+µ‹ş@(¬sù~›épw((™.–QTY°÷ft„­MvÀ™¦„“/¿l7äqs‰“Œõ‚…Òïú7›W”E'nSI6>ñÜ£ˆD 2Â„ü¶Nãµ^íÆ\Ê…b½’ÔH#6?dXp¢NÍ3$¶"¹6ËÇ~†‰¦ÒÕ¤£ıÒfN1I#¬“èÜH·ÆçÆTîİøêËÜ<V'“y„½ÛšŠÎuZP;Å¼¬j@Î»3X=ĞPeJ.ôŸıÎ±M|,i ‡›!Á“vıdël)e œ>tÅ!ÆáÛ-û LÈ"¡N–„G”ş7¾ı˜bş˜É!ÄsŠ|¦=€ñ4¶©w¶.J1ø~2éF’×<JÌ¿° ‹Âê~ÖÉ‡Ø²1Yx#!‰_ÿ“g
+¶CP8Öæµ•Şe¶˜™m(ø:#ÆŒ…/ßZ‘æÍåd¹X²Ï3Ùñë‘äHæb,´î¬&W*$š5ºŞ¨i‰@¤°İb©eÒÃ4â÷>€«MRCÁÀ"D©éù˜õ=£	¾ÄóßnÅ…&N¦Ş
+i´å8S=%7Ÿzq¶ê,Pôœ³4ùU™â´aÇä¹;ó’RÔ.pıÍ(”X­]BŸê È^Wë\!¡7MàÔP§Ÿ*ä&“ ¬³sMŠG¹+å°=Ÿ	9œ6Pqk^ğ7pÍ,pÍ4l½Ì/SQóË!¹¹Áè&±Åˆ+@+ƒ„QUù¿s”rÅ™
+¼H¿OÇµn©p2‰ÅX1ÍÍ£å|ö’æòÂyQ™,–À[8í®æ1Ç‘‡r:-IÊİˆ”<nø9©B]$b?™#+iôr¯¯Â§”¸”÷^›Ë¯‰ÖhFøùÆñ´şV1¿ĞîF¯^*h¼Šf“#û
+ªuè@V.cqÎÓpõš;P®ApŒ¦&Ôÿ)Df­K
+–À"	9…½…—-NË S_Éú…„`²İ¯mšG-?±M`£—k†İà¾ıäê3kV1¬´û°^O¥ì(¶à7ÇĞåİ»ÿ [ª—
+endstream 
+endobj 
+326 0 obj 
+<<
+/Subtype /Form
+/Resources 
+<<
+/ExtGState 
+<<
+/GS0 160 0 R
+>>
+/ColorSpace 
+<<
+/CS0 155 0 R
+>>
+>>
+/Type /XObject
+/BBox [21.0098 192.27 574.266 801.548]
+/Filter /FlateDecode
+/Length 1879
+/OC 340 0 R
+/Group 339 0 R
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰”—]äD„ßû¾ÀÖÔÿÏ#Œ/,.€VÀ"m#í×§lgVÛîŠx™¥?§3¢ìÊ,»üúÓíëíå»oÿüõÇoŸşY¾ÿøºÜ^^ßìòé}±¦ÕÜÿÖäúßÒ–åıÓß·—ûÕ?ßo©Dc]^ªuÆ·|HÉ›’òò!Ûj‚KË·ßo17ãB\|)=AZœ3!´åƒ‹Æ•¸)›P*#\5Î¹3QO„M&¤Dˆà«©®1Âecs „ÏÁd–½q>õK{©¢;àk\R³›ÏZFn‘³m–Cˆ¸ÚÛ"#¢íÆWB„ÚŒM~Zi_Ö\˜–ĞLò•iÑX‹D‹X‹DKØß¢ÅgSŠgZ4Ö"Ñ¢Ö"ÑÒ?&ŸÙK¸ÑÓUÍ”Pkÿ©H~}Wú‡é[# tÓõ‡'‰%°A¤húwÅr@©J`­ƒ€bAÔcëõ[ª‡Uu%™Û9Gæ8½§Bœß¿)qzÿfÄùı;W{äú-ˆìMkiÑX‹D‹X‹DKv&•Ä´ô½Å‡Â´h¬E¢E	¬E¬%÷^iƒK&†¾ã‡œôÈutKéfä2¢@Wš{„@îBsœÉˆû.›5.¤’‹ pÅ€Ë! ^àb(`×y`¶àÅJkç,«Û8Y=ÎV?õâä€=QØğÀıNØîÀİ®ìÛ26Jh” Ø(°Q
+@£€F	€R % 1*˜B&äšŒíì£ĞG°+‰rº(×¡‰ûuìá~;T³é'	âQÛ/`€	€= ›¤ tIh“ Ø'°Q­ï<1Êõí;¥k§8¦´J	ìÕ `³Ø‰k·xÎqmSªvT	liéMËìë|0Á²–0ì©ÄS!ˆcJ`Ç”À	A‚8öæŠ§‘AÀqD	<ìÄuóŸxDT€BP2ª
+ás0ÙOW.VS]e)‚8¶9¦vL	ì˜Ä1%ğÈ¬Ó” ®A\ß™d·Ñ=²uQ¯‹d]ä€pŞ-O•nÇ2Ï*İL¬Pp;@Ê”3)³$SbeengÔÌêT*ç\RGoƒ5^7 )7ää)½ÑšÔ®í”€OÙ‰FŸÒ?#—Hûñ>™®/é)‡¸!pÃŞ	6ÿ¶ŸAÀö£n?ƒ€ó¶¸Ay¿v‰§¡WÈ¦$°£ _Kû9TÑ7¨š¯_Ë)‡¸(¬´PHÛÊ¾§Aà:6"°:ò~L!uôw/”ëpR¯9úI¤YÜl)`ïQoQƒ€[ÔN4&¶¿œnØƒÀOÙˆë¹mJÀ~>ØÏ• ¦+=wk%p·öm?Sàæ¬3µ6âé  §J`O=ôT	ìé  §J`Oƒİ'uâ˜[›}b)‚8¦vL	ì˜Ä1%°c¾˜hÙ®>¸)Ûà `lƒJà68Ø•Àm0Ä½Ù?”À~AüPû¡öCâ‡Ø!˜û¤Pè­²¹ë®}Ê¡vLâ˜Ø1%°cBÇ”À¥íD@ìèİ6çÇ†{Š|‘$î)2	¤lj
+Ç{ÍK"Ÿ11ÿş9ä¾D&ïMåxÏ#¢yIäQ.õı)òÈ}L2ÔîyD4/‰ê‘ëş9ä¾D&î¼oÇ5>D4/‰ê‘×øş9ä¾D&¿Ï±‡{ÍK"zô£¹?E¹¯‘I Vãs=Şóˆh^9Ôƒ[šº©İŸ"§_#ÏØ†~6:Vüˆh-$²V\Œ­™í¥šèéÈ¡9„ #‡xäPB‘C	¼>B!­4Sãc—í+Øœqõ1è~a—§Í|‰øYddş<2‘R¯d…”À+¤^!!È
+)WH²BÍ›Ô£×/ vdtL	ìØ  cƒ€)tL	ìXtÙäÆÆ¤AÀ1I	<&Iƒ€c’xL“¢o&Æë±sJ`µBµJ`µJ`µBµJ`µÁššÙ¯„v²	Ñ5x{í§§(‚8¦vl#2sLˆİ<%Ö½Ô3?z/m™;Õ
+AÔ*Õ*Õ
+AV?õ_ØÒö 8v¦+««+›×æM_äjM,t£‚hQkQk‚h©k›óLK[Ç¸Êš˜¤E)[”¸E	AĞF´1ÆLÔ¶µEÕ³ÚSËN6™V#Q«V;¨vP­XíN$¢6¹júgà”"8Û5Å‘øãöËíëíåõÍ.¯oKß¿ÛbûMuYŞ^¾Y“–—¸|\n/?vèÏ÷»•YúÈéŒO­.Õ:cCOøé~[¯Üo)ySRîÿ¹½m˜İã[){ìò!w»J©O7¥µo¹Tşß]ú(×ç¸’[Áåığñué?ÿ	0 XYÀ€
+endstream 
+endobj 
+325 0 obj 
+<<
+/Subtype /Form
+/Resources 
+<<
+/ExtGState 
+<<
+/GS0 159 0 R
+>>
+/ColorSpace 
+<<
+/CS0 155 0 R
+>>
+>>
+/Type /XObject
+/BBox [283.387 806.632 574.417 835.137]
+/Filter /FlateDecode
+/Length 816
+/OC 342 0 R
+/Group 341 0 R
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰ÜVËnT1İß¯¸?€;Îk	bC~ (ƒÄ ÑöÿEî#¹‰;D…º@#ÍØ‰'>>vì˜ùËÇé÷tóöáéÇı×ÓÓüîîvnn?›ùô8›õ3?~M7òÒ÷Ç‰c„äÒ‡i~ƒàÍDàS˜¾Mœ8ÄÃÀ@¾3`°‘Kı	8\8ƒ`ÕOp† Ö18ã ¥¡‹hh`€b»mÎ,Œ`Ş`?0 z€,›È2H ìG,ÙåÌQÖÂ(ÕÎ¾ÏSèöXcpv›²ší[8‚&ÚQ.¶Q-9†8@è<X…à"ø0Ø÷˜9ŠBîBğ¼Lt‡0˜ÌA„â(Ï[ŒÒÃ}n¸ö‚\`q3›‰‰ŞÍ§Ë´l-ßÙµÉ·æç"ry}ı&Æ,ÆMD“e·ËËÃ./ÿLYŞO»²P¬ëB9ª,7E/Š^À½àŞ“ÅóTíöÕí;óQ¼L¯‡‘ÀŒ fz`ç©º‘Ş¸,w|upYåB‹o8³¹ÑÅ+z±-zz¢$>.‹XÇ#(·%Ôb¸«…úÕÑKzB£Qæà›zÂ¶ ‚ˆ)ô¸Bë<!i!cMÑµíÀË*WgØhl',õÈ2nâã&>n]psäª”ì"Št×…jBY¨ğ=~½Şè{²È%‘‹\Œ¹ä[/²ÎÊBµ¶½Û¢W/»^lº)ÕRŠÍ%Á‰''‰s’8÷ì¦Ñê†rÜ·V×fJz[©%umGéÄkrˆj¹ĞFØÓXôj‹Ä*äUÔ^EíUÔ÷Ó§«3%?zbÊùÿŸgŠÂ0k³ZJzº¼V˜şh/ÍUmoê¿$â~[ÙU¢ÖKçÂõ*D£GÇDÃ&£Ød[ïíØ–QìüeãO=;IJ¬oc¡vEnP‹Æâê£¸úçfÀ\^qÀ¼| ¼æÈPÚ Z€Ô<L¨iJÔv%jÛµ}	ƒä5H^å«Å³Ÿ½kH}×Ş‡HmDÄj§ƒ×ŞVäÕŞ@zÚ–™òşîvÎ? #ßCÂ
+endstream 
+endobj 
+324 0 obj 
+<<
+/Subtype /Form
+/Resources 
+<<
+/ExtGState 
+<<
+/GS0 343 0 R
+>>
+/ColorSpace 
+<<
+/CS0 344 0 R
+>>
+>>
+/Type /XObject
+/BBox [75.2838 106.025 517.456 113.92]
+/Filter /FlateDecode
+/Length 11908
+/OC 345 0 R
+/Group 346 0 R
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰dW»®d¹Ìû+ú|VOJ
+í9ràØhØwğîş?\U¤tzzqƒ«jI$EQÅ:?ıù×ßÿûï¾~şåo??ÿ{¤gzöÕ¯2ì9[¾æzşú¯Ç?¿<~úùïéùúí™ô÷üí…ŸşŠŸşó¶eı˜Ÿ£_½ÖùÌi`kÏ×w™üşÈWš|ù ^mb\/]¿¶«—ñ6êWëE+ZûDå*«¹%üßséŒ¾=æ•ëóOéJ)ÃõºRï~lWÊqŠxVîå+ç!Ô‚¾V)Ïqµ´0Æqî{üzØ5“²Ë&N/Û{ÜÖÒ*¢íiÂíÕ¼®{.]>úµ’N’e™óñ±åÜ!6†“FÃpUûâ¢o8ìÈÿ×á=¼†)ùªŸ¨\C©2ü\p¸şÄ¾GåZ]À*gÖìğç›Ã]dÄºó1`¿^µi›P»rZî-•~Cä´efÉ*êê³à2 R­^:äôuPİäÕ?á>­§'À·GğÈÅuœ¡Jˆ½v-ç²>Òæ™m×¬å}q«^uºcØ*ó†ß…UÒâ°ğ…PöÑ1N
+£Úû•½ÓeLö”]ao×GÁ+™¶çxM-vÈ×Zİ.%Îb“GñC€¯o5 \ 2‡#Œ‡y(
+ĞËBo£ğêå${ƒ3İƒÅø„¨·¦™Ì'X†€1ÒœÂXGü¬
+9­™Ïdäª,Ä •=‡Âé|Å	h•ÖS¾°9Kš+,Ğ«ÙÚ€i÷u¯"É3Î”LÎÌ{R.àŸaäzrt²‡exİô.Kó‹šˆ¡?6@°pã³ÑıƒÜøÒ›ÊƒàÅuËs(J¥ïhûPö„ä¥ˆJ}—`¼Ú¶Ë»«Û.‰eŞ>çUN8¹nŸôëåj±5¼á5—¢ğrWƒH°½­@ÖÈ'17DrÕ«t¨¼W~ÖUßTF¬ŸM†¸óm°ãég]±bè-îUP61šwØõğÛJ19†A¿å}âÛ£¢€¦Óq­¨Ê¦l`h•×ÙÕtjÓf’©å¡Ø¼!ºÍâÉxöeMoÖ÷áéš†‹|k¢8'£»j]î/¡ÙŸYyyk¥u‰á‘¨Êwhµ¨–¹ØŞ /âõØÀPs&bo]`­àõhìtX±+ ,ú2ô{Nw„ZØçT’c¸ï	°àY¾ÁÔw{‘™Jô€â3j/Hç*w9Ğ;
+·Ô?aRòöğ–µó;áÈ9¬Uõó¤Ğ´àÅ…É6l%zúb;`ÛdhÁ7z
+ûæüò†t–ş Ql’dÌÊiST‚ü½Iµ´FC U/àÅ…¥ÕÛÉ†y~|B¬±qC²kç9³y¿œ…éÉ­o¤üPŞ³£¨Õ%PÔÉyêşê¸jÿ*J-‹‡½†$ğ&²t`<uZÍQÊ^N€$”'Y·k\YÇæf8Ò8ı´ÅÇn¯ ¥Šˆ(¢Pş©³a¡Ã"–ÿâ¾ÚuÉå604ŸÄ6c“9'ù„-N$<Ì ÖW9ªµ¸iåu—i¶c4,ù)¢Œ<ºGDşsMPÕ«qá©_Hˆ+MZ8@EÊü­V|=sN»²ƒÑÄ³ùÂ•ØÚsÑEä¡]É„¬ÏüÑ½÷ì1©H»$N‰xØ£õNÀ°}õh’NS×´VŒıIç{ªK…S€péÍ:l¬O,òåiXI’ÒK	i˜ŒcT¼d~@ŒvîÀÖ®j¶ Ò\‡ÓåbCÑ–^?á÷€]ŸSlş‡— ¸`3Úâ>à÷\Ú,Ä=¨!QÜ‡ƒ­îÂQ§ù‡«k^Ïò&"¦ÄÙV¶Ã¿€vØ7€“-v¥1?á>îNÑ‘÷½°¼”2¾—@tÄËnµ9ìü&•êneu²áıÖÑŠN¬I#Ö(r¡…„HŠÏ55¿ÄtA8Ì°™i{m"%P%ÅøIñzD!ÙòSÍ7¤m€ê·Sş©»£9úù·×PØÁúî91¸€)L_«+L*’35º4kÙc¶_æˆT =LÔ­ù‹’”äA{ŞsÕ×ñÆ":ô½Ö®¡œVÕë¨ˆ7 Ò<X•‘#¸ƒŞX»Ò:Ê ÚíC·SĞ!İA‘D7ÑGñ¨}Ô@—Ì\è`ŸÓmÔıÕÇ6nCP¤ƒ˜ƒæEç‰…Ø“úP6ŞoÀ,ğÅü¨ÀÓÆv }‘šà`f;0)Í¡ÙJ#@…xætóşeâ_üøŒÅ¬#Mz‰…¢
+¹K3€<,É[Í-EÉzá8«’hOwÅÀŠÙØT“„ ÅëĞŞ€ËÆ€. -SÒ[;²ÑĞ™Ò† ÍæŞåÀeãòå{Nw„¾Pßaß÷pó`Zí†¸w½ŒåÑ›ädş¡ºi·8$œ¸t®âA»}B—†>L²ÑºÄ¿ËFãQBb\µÎU£5ÑfÌ!ü2j°UcÀ­Ã¬«ßüº†;‹€[(ÕV}‡³ÚÑFÙh|Ú-ì•Éöñâ:¦øøØ0r¥ü·l´­£)Ü²u!ó±Æ­q°²¦dVÇ8/p§|K‚‘Dß›ln²	(²1*ş­ëÊâÔ\B“PLùÈÁö‡AÈ”zØ_ºÎ6 ÔÙ&@°M gÚh»=ÁsvØpÚf„Xf9gEãåf‡›m¸Ö«W+këcŒ{é‡mpš¡H47”Lg‚öÎ6ü¡ÖÃ6±XlC+c3
+“—Ça@«oscÛğl¹¼±®£Q‰ñ¢5¨>¤=Œş˜[ş„[¢æêb`m-4ª>è¶
+¸µWÖZˆ6ôÄùĞÃşÖB7‹dgÙ;¤ôÒ ¨½q~©´C*:é<¤r ³à2û„çÄ‘¥£‡†¹j’lÅd*AçNÒn¹+¯ bZœvHz@ ·” mÒØ)zåÈ7œîğ´®îKöáÉŞ@)½%ÓÀ”}'íydB_··dÂtÉw27Œìá”k}BgèÇ†×«XØ»œ½†§¥$ÀR¡'<ó	­’s€×còbê=g™êq!Otw@úšÙŸß=Ün'*-œbXlmÃ°¢J
+§¨|…>ÇïpºAŸ±PPçë‡aÑK<\kx9Èä‹­dÌò~>Œ´¯øĞü‚Ô·ƒĞ	qjª”³))îcÄ_V@&™gŸ]	çeÀ9"Ğ)\­ï0I¢ãIâj‡tä„—¸g ó¶0Í¹¿Àv)+ô‡dL<¤| gé««¡ÜE;¥›oÄ¦ ·Ä:—n£ğŒP–jpµË¥&£@8]<økc$&ÿŸí2É¶kÅèT<‚\¢;Ù°çßÍˆçıŸûî¨qş1)4±‡U¥H¹Bq6je§ ï„ßœÈP‹1xF•ÄÇ¿LI9ğnÏj0ßöU!uO9´Pí=*`÷×tO§17ã…ğêy)~ü¡ÎQPøü¿]aÔ²Ù¿Ø‹:Z,`é¾qVx›×óƒG<ÕØÔ¸­ü‰ªÃ§96è ¥]U¡8LGô”9c"§ á#GBö?€³[lìhps.¿{H€Ù-æœ×S¥ÿu(jtyÿ=š“R"¹JQp<)ˆ»T»~óò*vŠ±#¨ò$$4eü`¼CÑÔŞvWŞqµ Ld
+úCªŒ%Ÿ‰(˜.][vsSÛÒÑ=uP¾Ôÿ¨W5Ù1é§>¶?güşÍgßeæeWŞÈ?.t*Gj JU¾A;Ù%ÆDáöğ›ªÇ=ÙMjà¿Ü»úk‰|y¤%ƒâ&üüB?avğà°ËÔ‡ìD¸ŒiŒ¥LséZà]5·*²6’w1/éÒª‡šFQD·äñ²ş!K7nG£':ÛxŠÍ`.x?WÕXŸãréAºØ4<io¿”j‰€¶tÕ¨x î§tjLD[ç€Tï-éà^·úk’¥ì8/¸ØÄfõ—»jñ5Pï½ÎŒ¡Ê4S¼¶ÔüÃü¡K·BZ,ç&Á›ü_üex	pV‹á!³/%QÕ»:zä:,Ù5•bËW]W‰‘ûZŸÑií~èärì‘oéß¥9[cjõj˜¿³¤’Ù }¹¬ªŒ¶î6Cz‘Ï©ËxiŒıfK\"Ñÿ‰%®Îè6-¯+šä¿S%!ø$‘\(‘ZI5D2kW*‘™Øß(Ó”‹¥G.Ñ’µg¥gŸ¿ïşàŞS¨‘îúøíµ2v¯û"ZnàJ-Ğ·kÌAŸŸ©Ô]©ñ‹c©ÕHíØÕV´dK¿û(P¨5<*}\¹F^m»^#ØHF*å¼USİÜÑ&mùåŠ£K´%>ZÊ?_îu»n#”f!ÜÒrCó_T|wò¢¶Š[ùÅ_«²&ÕÃ«EÑSaZ€<·ZÜ¶4zøn8´]Êr‘É×5XöÇ­­§âûV¥ ¤™U–²æ «ÿ½G†ûã¶Âqg“¦\åÈUœ2§%£H.mtTmË:èºß>b»ÁyNóûjˆU
+Â_µ!¢Ùá”íREıá
+Ép6¤!~5Çô|]}ˆåtå&RÖ ¢6Ÿºƒ!˜o+æ:Ÿå£¬Âq·0óôõî6ğ¹ÜÖT¢\Zü½ÜàV:E«=„{;V¯¡é’¨[}«äÊ«å‡Rk'ÌÚõış˜ÑÕ=3à/aÅV€Œ0¢í&Êu‘õk»Ôõ6nƒ³Q	ñ»•{hMå[’Û°pÖˆ‡=lş†Eg›ëñZ'˜tªFÕ^¤Á«êìé¸^Ó‘£zì€¿›zÓ[[Q†IepÁ~š–Ü
+,‰`Î*/Â+‘#¼²íHğp„—`SíàETÏÁàÜ/ñ‹øz‰_î8Ÿë—Bìøœb;ey“æ¶|¤ ª ¿”d=¿TÂr]'=R‡*ß]nÖiI0ôËZÚÙOÎ­ èw6.µ›Tbv.äºæ…AªpªÆ ÓÆÓ“9^ë¬Tµ$ñ¥¹N¸ßS‰‘¸P›¡[¹åó6o4°›İÑ‘ú³@^ñ(möÛÈ$Wéú?úx¦«=L[„uJ™A~TÊÁeîØêRİ&6H~£~ÇìQM§×ùlt5Ícpˆhƒ“ùùYŒ§Ãé±ªï³U:®ĞëKÂ=”ÈÊU]—Bè‡^ã—ój9®Ûí)½¾UÜŞèû~éJï’ïéß¥=_kc®¤Ìßûû–ap“Ç?.§_çZˆáR¯/9Õ•zİyRïrh;Üæ¿8Ä^÷ÆN#õdÂf£»R÷°#Zsag«J‰9Š—¢wAnÄo¦%™˜H½C(Se Ik4Å£MÍäÇ·_Æl5ñt¤©R3ı™¬DqaE$¸8¬íCÇVNmê8µ'ªjMø¾° ô$?U?ßÑ¹xÛ’4°+à.İ«.Ÿ¢lÂÙ’W%ÎÖWÍ„a.^:9ªµ™Nü@Ö¸„Óôs«< „‚èô³á~ÆóLš.íŸÄgEÉl“¡Ìú(sù@ÒñĞpåµ°Â¹xåBM	Âüh<¶“_wk–£ô©Ã¼´©ôâ(®Ö}†ğ»):ø¦è`OÑ€ÒÏ½S£Z¾W
+ìí^©uíAê;#CÅÒÉm>™ 2?;Ezæ*°*°y‹xÓ3Øà&o”Z(Ó3,7ö™ƒozÆôm;Ó3hÌ›ŸAô³›ŸqPús"ÅòÀŸeª}ó3ÿ2ÇËÏ1ßó3—*™‘u¡¶_~6ïAstÈdÏÏ³o~¶Á‚w âVH—üoV†2´/ç!‡%³ü¹ÏV*4v(õÿp;;.b‚Ã„ˆyŠTÎ	|ı+Øık˜´C¸Ğ Â~şìvÀ€‡Ô« @c}À`'yÀ vMÿrHÿr
+ÿâ*ç–ÿÁ'úøxÔñ=ıù,·şñ¯àë_ƒÒîú—Ú×¿@”İ×¿pP³ë_ Ö®
+×şÅ¿ìOıùî_\ª]â…Îşz£]&»æú?è~5üİ)ÃR'óßM¥Ëù¨åå!nğ\R#Ç©D vûŒnùô©_q£Î¾'zÒ6üöÚó®Àd;Pë•çËö5Y|M»L*4f³ôÄ±:Šˆoï|E¸«‘{\Õ¯Ş¥,Ï¹ÙNÅÍ¥¸Ç]NÜ+£„¢á¯°È”İgU©ŠŒ=Yæ`Ğzıv)ÇCıÄº×b.ùçdó÷ÿ8‚ûÎÿÉHJÁTûûó5©Ô,˜UWÂ÷•ub5¾ŠKOÒo½Ò,çíu9mc”õqUB|øÊ“ìÁÈZ
+Ã.<Ğob×şÆqß§İØÍ×(ã=Ï*Ñ[NV÷´ø‰4âÇE½“âÿÉøV™$c&eF8÷pšjGb°;¢oÅ’fÇJKòDKìÏ4ÿÖùzâdC°?ÇS\+SN¯¡!gA,!gyòúÔlbˆWÌ®{ÿ‹ßÄ½ó&7U9³à ¼N¨§Qóîh³[‹ò¤uêøp•S97E‡Û¿qJé"Ê¬¹»%<JûŒö­”\Ï‡L	.ùÙşMÙ íp†ç;ÎàjÌ;k×*ıUÚåşXÃæÍ -ËDS…cœğ¾=¯÷-8.^Mî¿İŸÈHüK­ü€ÔûM´ ¯‡‘hÓóüŒEí~ÚøĞğ´ì{R¼Ô¿ßşüÙîşğö^ï&[ßşğç~î(tÍªwÿ¤±s.Ù÷„L›?ßDŒDOÅ*«e*ÇÖæKô°ç¬[@£)!›Sé¼›îÚa±%ï_„±÷ıoŸUÑz‘N×­ñZXUîxƒr¹Ôø2k¾—ÅFadùø”œu°OD6ôÆqÁÑñuüËí¢211ü­ ûQ0’±Æ¶ŒÄÕ_1“!˜^¾™˜S’ˆ¼ßp^ã|F§w´6¨æãu‡â7˜JM“ëÉ®¬nŠ²úØöşŒÓRWá€ãl—9–]9DıZ…VP‡ó°tÚHíßíˆÀÀŸR9©E>A P_á×?Á¦¾õmµÎ±ıŠ…˜­GI­J ¾›cM…Ã:Ì šî3»)g,´.J£ä“M/c@Æ^µŒ¦x‡ÙŸ©±	[šêPFó™E¦›¸ å<q¶õ¥d¼QlÍ¬Ræbvšg¸í»j´ÙÁîQ¶*Ë®lìè÷kJ7Æo³œ‹ÍÀÉré1…ú[üÚ#@™ÌoëØ%äW,ı£VQÙ›ñ-Ÿk<gæo8Ñ]³%–GBI"Ù|Qº$óx—
+Z.lq Å|,Ó!ÜğÿÊ7ş;…íAÆY‹ßıôÈg ÕÖËvà;wB×²6Ée­³íxpíõÇïÌvÎ.kñ»Ï< 6>òößÉ²ûÎÈK~ªÔµÎ™ˆÀóî<BÖª’yÉıö‘—.¥á6Oúoèš¥uÀ´ü“)&±«ñem:÷vµLá
+g}(™]J	üE7„TI˜âèZ¢1â·UQÄhã%¢y
+¨º+›J.VOøaËš}Ù’}ô‚Ütíz®Å*!èhYÂü{­ş/S$|‹‡Då±“·ÊOwµ³Ü~lÓ‘LjƒÂHù0éX:#|ÊLóY½º­{†“È¹1*ƒ»yV¨íŠ¯?BöŸ¿“­ùNÆôËÑ+ó~Ñì½ä*så_P
+j2pY>ºˆÑ©¾õrUÄ2íÖ\#–ŸºTš&Ÿ<b×´•Ş%BJš8­fì#›„îÀ˜½Sg¸Û´.¦OëÙæĞÇíÖÈyØèHáy½×W/aÔíÇÓ¥Hº’5/\"Ş¯EˆÍïÊ¾\ªó&Û™¢¹“mtï…ĞÔ;aSHØİW«dfãk…’ÅTËBùÛU|+ÕUôO>‡¼‘Lòëvª÷9¤½Vö9ÁÑçh¶dû®¤kg›ÛD›‰‰l-R0ÔîB$<ëdH¼Ælstôûúœdkl8¿·ıg£®ËF§d+ü6gâVZ8A-Ïgò„(èB'PQMåNòQ.*ì
+k±t…š6’Ìß˜ëÛm¡ÆT9yLl¼–ÓWelf¢2Lä¢;øŒ\k¾eú8óƒQunŒ“öĞ+½;	võ­İŒ­>ëËÓ|§X×ˆÑÇSP‘ËaµëÜrXÅ^¨äğXeµ9ş”ƒcÈÆˆçJÄ`•-¿¸ÜÅ½! ¯"ƒ–\j³©GÅyĞx' ŠÀã»m´…ÿdå®Ï»~‚ïVJ0¾œ;›ÎeŒä»t´naşpµnHĞóÁ~-ÉÌ×?+]ËËñm¸ÉİéëÃŒ®¿ÏŒ¶e½L`²ß¢XvÀ£-	ß0Á˜¥ïJl¡%Õ‰5×T­òöyß»+Î*Rï:Îßù»Añ?~ç¼‘ü7ã¶ëù˜ÿ'ÇÄ>rÎw;ƒayc†?—­ÙãıŸ¡‰óTWƒ¤­ôB½×Û‡“jÜûıÒuTƒLÛ–ÔWıÇïPƒÁ¦Ií†ŞãT£¡É5™¶®½]ú±B:fJ…/î¾?˜Ê\b0U–(ÃmO¢²Ê¨®gú[¼“¿“íx(q{ıøıæ¡˜–ıLõ9ÿ'Ãèû“_?¾F :|z Õ«Ó—ÖŞrUŒJ·9y«Pƒ|&iÊ™fkîãEiGEÆb1r‚M™,ÇÃ•Uc¿ºòü+ÅK$ ÑóW‚õ™_ÿ%@Ò±¾/ÜW9Ô:2÷X9Ú\ÿèK'Äƒ¥TgÛÔ?t{~û•Æ#9lÚäd!Ab±n³g3&]Í?´”¸mÕ[Ô6¹é¤gN0‹ƒ>Ü4¶m£}9VK,»¥ÚfÁØË5uØŠ»µ«[öQÓ¾ÔÓ½h”º—l›;v-6:$òÆºI¼–˜*cÚ ÊÕ®FSEâœX–*˜â¼iôìö¼—µ;Yİ+jjô âwè·Îl±ÿâÔsà©Z*ï÷‰ª·BÏæªOÏ9§ãlkÆx¬´úAçû¤ sÎìÒ»JØ'o¥	:Ğ¬5]g”¤ÓÑ­#lv„`×o½ëéıÉÏîº§çú’b4gn˜ìòÄ›sŒ×¤%lıH§Fêoı@UôWÀ½ÍÑ!ÃŞêÑÜÍç’mO„ÀøüùvG|Ji÷x¨5Öu=4ß¼êıİ³ÆîIóÄ\²¶xeãçï,CÎ”\ïoF0p[æ+CàaJËGKá—ö
+ôÕr˜yêzÉ<6XV~Çğ¹lg_“›âÅ^İü²°¬e"Ã`[ñğ•¢/o ‹]•7‡ò6Ö¿’óÌ¿…cò‘¶F$Ëlä@]©ÔÚA²g­RsÚÈ©¦×Œq3SÌ‡õ¥D}nÊí®—x‚–1F©ÜøºJç¦¸ø>Üıœklªä[ß2ºJ/8Ú¥eÀ!Ô9ùØm
+9…ƒM÷™†½[ì¸aHS{fkä2ÛqÎ­¦Kµüö²FZjxinPÍç’ı2‚o#ŠiÏõJ³Ş(Ò•jAuRƒGØ­¡|wÖu ŸàKÆ&Ñ+kYyoÃTÚßdè”ìî¡ªo SUµ-@Ø}±»d%.‚ßq­9ÈL«Pê-	…oŸk¬şÌ'úakg‘\vì¢‘ƒ_îñîj ‚©íif>zRY¬·ª*?‡Íì8ì>¸^s©ƒVŒï¼Iâ´ùÜñ)¹kı/v•ó2œ3ÅßùÁ³1“ğ!SÃ
+:<ú•§2AˆP»nÖ¸·WpØ†¯oÿ‹!Öşà"¯“vQX–Óä*GóÄ=ıÃßxÚŠ®ó+o#ÃkÂ¡MĞîÊU“1½œI½ªÉ]ŸT‹ÁÉ:Á/Õ~it¥û†½ğ‰«*+GQv~(Àª>O`ÚGÏ˜gªOUñù¿3]ƒë?¸”zaššt½ j%Â—båœ§]ğĞóo.&&3`{j|b^=‘g'\eìrÜÙE5èŞÜ¾læ¦	i537Í…Î¬å—F©}Sû0ìù´ö+­9œr“`«¥“ÕŸŸLˆÃõ86á¡];={‚¥Çù!â×õ8IÎõ87½‘,hÎ	¶¦+YØ X[¡ÆA»Ô§ÆÁ±®ÆIXŞÕ¸S¨ñD©qÒ¡ÆAkî§Æ¹Í¡Æg×ÁÒyéXÎ„¸hÃ#÷ÈI(ÿGsòyQü¼—"t×xn^Ë½TV³Í5}.Y{®’Ò~¦€3Ä!yX@ÁÆï§âÆ…¸$Ó²Õ{è,?ÂÏÊµó{™¯zşà}BhÆM¡ånûZ©±ô§´ÀUZ]JTÎŠRIjû)­…4Í‡ë£HÊ·…ÒrJ¥åœJËÙ” İxEm!¼Ï{RkH,Å şUV”ĞZôí~BË9…f·]]hùB&¦ wİZØsôaË„Ÿ-§Z‰.´X¡Å='Z4ö>µü!³ ½ÜYI.³œ]f6ïÉjQ/¼LÆ“Œ78‘Lo¨,»êSYàSg¨,¸·2
+8wıPY¼ß:Ş8®Çq™•“…Ğ=“:‹¦œ(O³‡–¢Ñ¥?¥E¿İñ1J5íJË)•V²”–{Ü•è´ö”÷¹7”Öú?Ûe.ç­ÑÜ«ğ?ÎÃzn¢ µÿôU@m9ĞÕšb´"Ó+­7*­	}O»!‚®0™>Ûùá?4iâ£YeçşpVUCë@ê+Ë‹7ÒĞãĞıHÍZË àÔ{Œ.åê¬“.µmú29Æ<ùØäpfÇ“Œƒ«s/a2n<ƒB{xËvĞ¬*x˜^x?½ißşêöÌ˜€s‹º™ChCœ:Ñ#y™®;Ì¦ĞtF»ê«¤$ë€übE0{^.œò8zvİ8ùeh&)òVº#)3 F³Yõx såÉ‚‘ÎÊİ&ãşòØ}i[`qö OFİar4²{¥‘cµ>#nŞ«t,6Õx'™'W6•IÇ0ÊEŠcF{JÉ[Õ3`Êìp•Ú}¦–I¨S>°í¥Ò{z=÷œ,œ›ëëV¦·Ô¶}æ.djB¤¹Ê¾A^„8{Âm·ÒH³kñÊF&ìR±QfÜr:»È©B~É.XŒ©˜0c”íÊÃç[„ŒĞ•ÊÃ·'šó‹½ÁÀ¾³Ôÿ`o0°_KOstäPc¡2vAİ{=¡d1	½¡Ä^°î–¯;G(õ}
+%‹áïR)O(YÌÂJ‹õyBI‡çÒPšÌ'”8G(qöPÚ–4²4æ¸¡rå¡Ô{„h()rD(F¦ê%j•*Cöşë…6<şı¾ó†ŞõOö×ŒùßÜÎƒ³$htúİ‚p¯ìß?Ú9ïñŒAFƒ¨N­ó™$ìe‡]/sÑ¹g7‡uj²–ŸG+Gú£5cê/”óc{;!òÎÇöü‡k{(}{{lÏøÚKå0=TÑ;‡q-ë!Ãô–gˆ3š®å9Ã^PmXÙê2‡İ9»İ­)]Ëšºıµ»…C¢&­YÂîŞJş²;¬ÆûAûKIÜWw&ÕÆQjìRÚv’qÓk•(IL¦<ôm•Q|*Kœ¥2ÄéîxØÎ[z‰+Ë•ôGïÔ^Á·69“™×Ÿ}Ö÷!’Ó¤¶e&v,5¤FòËF6“z>R;Å†Áv×åä‘’S­ûSĞöo–©zäÍìô…*¢+=q#"j´ñAu.'nËâùğ'^\»sWnıæd>³½üPö}¥Àš]¿¸#ç©à}‡TV\©ê?!òçà•ÁZ¼ó‘	~Ü•ª!çï`&Ay¥3+íQlë£X —Öb”…½Ä)hÓ:1• à¤èÈ–ŒºPÒÆ{Î ¼ƒ‚š#\‰Õ57Úá’ÛºÒpIÈ×rÔœ U-DAÓ¼I­ôÉ<ÌDŒñ‚ÃÔ†3”ÏzÓâ6÷i,ö’_GWºé‘3FÑÏ–áM	)­í•ïëö¥Qæ÷_g~UÃ­Tš1u:†“İ(¯;º$2ƒ‘}WSS²†gÔÄ˜õÊçEO+ÎKE‚ÔÄ)i¶QiÛéç/r_ÏàlÜhç—ºzØdåÖ¾¾­ê½c€W’z¥y¦e{®1œlÏLÁw¦44às-Z»olög×,yq’"ÍPWsò‹YÛ5W=Á@—ê¨¦ËÃŞvûD#P—‘lıïÕŞé_ØÔaØl¥ò/„w©É%8™:ßFÙ¿@®å¥Æµ#ßÖÌ‡XßñF‡“J]­ìÇqÎ¾Çj‡··„î[¬`S›'bû·¯9¢¼‚ş<‚7]ä½siÑ;ÂÄ†pÊT4HSÅcÁÏ®F?RGSÍo£|ı+²â…Í%û™YÙğˆó
+k·œª)ø@ä-f
+çk‹sj²µwÆµ«b”Z‡š#\ÎßèRª!yæáİÏ^;Y½Ü´¶i-;sÜ ÛÕo¥ƒÚ@B.Ï\İÖImstñ<µ•$¿{ğça†#Û«¶ñ_¸îœiÃ^ºI›K’™6íÚ¶Ô¨Ê–4ÊrW'±ÕÇIí‚,,d:»úX3(g9Ø9Ì¯ï8¬Û:Qí}ø]^É@s«‡—ğWïa;öµßOŒÙ["*òA ¹OâİZFó+p=FÑ¼ñ-æ4HãèÏî½iëVÇƒF¿Ó?%õ»-ô;ï¨^‚&À éÏ„m}êú—qY}yHwß æ¤Á¹!TÕ
+¹F¿İ4ğ}Š”ó=,Š‚³rÒªûaxúVzP¨c®1|5d~§Zœ¨”[¹Ä([2À¨ã ŒÂŸ¹»\Úu}D0fñ S%hºñ‘ñ¾*jåæ;³JŠD<æ4º„•æË•ÂVáÚ3C%s×w“6'FJ1mú÷).ëØjV^‰dg€µÅÄÓuÎf7 xàƒŸƒ¸ÒZ¾Eü7[­‰°ìêf4ø-îL¬ª´HmNQÕİœ~47¯öŒ2©c'v”Aõ>—%(F)„£{Ô´"Ô{Z`Ó—ƒˆ[U#¨ÊÓG±©‡‘‘>ÂµÊ	XÜG…~ÅCú!®„Sï;ŠÿsÄ§¢§°¹Æ¥ÚeŠêô,Ã©Œš™Næ">˜ˆA—”Ôêö¾ƒ’üÔæ3‘Ú
+K›vXØ!¯åÁT
+eÛëÂWYº:²ÚÌ4ÍOmšº?aíÕØã<ã­2ä…í$ÅÒ_¡™tª!J2uø4Í˜{ÔµEV¯“ìºûâ™—•8— Ğ¢q/¦‹4XGŒİD{Óíç(~ßš¨ãiaÂEÌJõæH°Ó]Añìs¾OŞœpõñ'G-26ÕX­z Í†Â¬×Á^K€‹2˜j‰9,ó[-áçD-ìá\òª…°Rw“LÚP×©+~ìâÁŸ‡½r ë /¼÷7µİ2b!$/Ï„¯KWUÌ´r•œUH].Rì›¨•ã€™ä.f‹GGäK/F& ê;`Õ3“Ü &ÅÖV´©ıH–7=#0\d‹£Ÿ¢H­>®Ö²qö&&RîÄ¦hõ*Ø½;ıèŠFyFa30ÉfæëtúœÃøKËáJöiuÎYu»D£S“£›ôÍ|†ÕõyÜÌsáøÉ°•Q‘ÿNVœ¬.'e‘>™Êy3ş3¾ô|g±‘mÍÉÆzšO .Ìè;ÛA÷EL3j2•FÕ‚Ş/	5™T²…C(‰ h²W~L”8f?£0mÕ¶ÒÈ¶µ¹C•³Á'†°ş>5U:ç#ÓZ{F%Ÿ¯Ó·íiwAŠŸ^jíŸlæ>ü^åºËFˆÜ/g~î>;«wpÿÙ{×}°-Äıgù¨ùO€û³ùÏf2‹7ÙYA=^lÓ/v¼Ø–WÚÿôµ:ì>´Y+íãCÜ©¶ã&<§^ÚYEÂÜ«r
+rvâÊÜÃ‰LÀëD(´T€šmiî8‘¿Éu¢]ïÿÇöF/e…$¸°fÙ¼wêd„ß'nv67ˆw°€Ûh2×øÆsÉ­ğ”¡Ò‰å-öPï4[÷-åÓŒÛø•^('•Y\6s[w›mO=w—˜FÈşÍO7Üzæµ‘¸Ñ¨ïã³TA¼c¥Ôd”93ù››ú1Å1$¨«á.©ÄÛ2<Ñ“7ÉwÍÃ¦0À@›ID–`3ÂuUù¬-;ƒ—uYèéEQúópC]óÑ­ğ*ÏWPõ7m‡üÌvG‡ÊvØZªAñ¬K2ñ,@­iâÁÕ’,ÕôZÚÙ~I>¥PÖ ÇiF2Êÿ³]-9VÄ0pß§x7 ÿt¯bÅq„'	Íı%ªÊvÒ£‘F©—´ã8«ÜùÃ˜Ñ­I>’Dµ8”´ x…;åñ ©&½"êV“¾òğô¥]2%W›ä‡ ZŞ€›mÒ·Ï#öT	ğ8Zy„»Q‰¥-i›¢f6¶‚Û,°2È>â32dsXõ Xœd¸õ_£LÚ¯IÂuÑUKC]@TXb5¾ƒÎN•ñ¹¡YBo…Öã>îêlYÓ{Œd(LDb¼”~Ÿç{Ùîç¤Ì“ûÊ<ChÌ³ @È¡›ï`d¨çê—úV5­{õ¿˜Ø}·dÕá^~»—w¿Ù7^·ôÌ]Õà7òuî ®²i˜6äë²³vS&.×Xı*1vÏù?Œ×T‹c|³1ì²“l¢í;.uúútJäµë†—ığË1<-ˆ\›î)´úYİSdUÏ;‹°îwŒˆ–àq¼>Ä¿9UÑƒ9m¥D®]¤ Y$0"lïv¶ØâC¯Òj9q:¯5‹¼AäDYIoD¾±9ñ¨Aä´”S9cõœ^0º1‹êÚ‹3y `òÀÆbDù9“×”Éåa	&_·²˜¼Õ¤v†×TÉP1®!¿Şâ•@Àíºcjôs'ÔÂPµèY¯„r¼í›[;Ÿ*zÅÊ~àlEÎªS`5h°KÄÿ¹Uç±1H„ Îüz+äÀíî+Y­­IÜ¿*sÓ9}÷F"sØÈµ™5æ²îÉk:&%EZ2)‘"SÛdë,¾4©ÜRòİÚ=M_Y¢SŒ¾çO(Üxğ†j,6Ì³)£»®'j¢’jÙ\gŞ@fó~–:DjwºÊ–Wf A?M{RÇ5›¶@çƒ6L9Ì…AC€šÃ…d639z´rº¸¼Yk®‹3ñ]ß(«vX _Ì	|˜2•
+U"Q7ÅSÜªIIŠšwPœŞEQ"ûbşL&d].0‰Œ¼ ;#•3ª:£FIg4=¨6JÔ£±Y„qT=¡rC’€±cëºIïê°ûX®réÅÓÉÀóÆR,³ÑÅÓBé(t‡CSñ!SRñ‘Ù¥;8àöf»†Ñ’) c†„q°¶1hÑÓW®‰Üd(¨ŸÇ÷ã+ş>|ü–ÏW2ş=^Ÿ¿ŸñÓ×ãÏ‘õ#¨Â(e*CŒ‰||¾I…0)ÑÕu‚óÏ;€ÂJácÛêÓ—ã¯  Æ@
+endstream 
+endobj 
+327 0 obj 
+<<
+/Filter /FlateDecode
+/Length 625
+>>
+stream
+H‰|TMo1½çWä¬7óå#Á‰¢G„"Z¦EÛíÿv2™ÍîTíJ?ÏØ~~±s2Ç/ß}<›ãç'g?ı3ßÌI}Ø|÷ø-Úû}ıõñÃËëß‡_õÕ~üzgÍñNâëÙºö³çú¬á^ÃO›SR0”à“-ÁÛúdÔ­ÿœ·‹9 FºÀ ˜wĞM¶F”„SìŞ£ßÿ1­¥Á$æ¨1Á@á2×\®©LLvDv<Ş¡‘ Îªº/$­NoT­z!L˜ ¤(ØM¶P‰ù<bİdï)b‰¼ç²Q¹aò‘ù,n=ï‘Ñ‚‘e6²ÌH@(l_~›öÙ8µå5¸X¶é¢ëéŠÑ%‰ô’gä$Î¡J	µ£ğA’©äà©Øj6‡—Y)-t82y¬™!§`G•«ö¸Ú‹ñ@’u`©¡CÓĞÊT³ÂNc°“ìYú’Õ¦š.&vI¦¹²bfo¾ïƒ¾Ëú5¯GÖ&H{o{1KsÌÛ÷£÷5Ù&jİöò¥dXf·ĞÉËé';
+uTÍJ¤C‰í,;t#…Éë::ûñ¸hA"`"/Z$p.Ñ4YfrŠnÊğ‡Bm:73‚#PÎË{‹Ò\cÈ&Ù«éHn‘;ë1q=*Ò­’oƒÏR¹#Ù	Š(gš¸hÎ€Iõ=¤sÙ†/ë6•®OiDH2\õª®·sõz»ùA¶P¯B—„;ûyó[$,{ìä’¶xµån¡Ôëˆ[j‚ø¢ã,,Ò
+ô\%‘++^Œ•¿áÓ'róş` R¾Dh
+endstream 
+endobj 
+328 0 obj 
+<<
+/Filter /FlateDecode
+/Length 689
+>>
+stream
+H‰tUAÛ0¼ûú@X‘’Hñ=}B€¶‡¤@±ÿ:¤lÇ)¶X ›±hrÈ*¥”rkÔ…Ë+±·òØnLÃõ|Ğ©Îù/êd<Ê}Ûa£Ö­4­Ü*™q©ø»o·Aj£(‰ÍòÜğšì e„¸g¨)ÖÊ <;hä­G’…4Òã­é-ëN;8«-øØ~m8·|F™GÀ'ª’”i»@FË~`4¦Us\]OÔÑ3Gí¯Ôª<.èBã¾ıØ¾m•zåõ)¥|Üo_¾~—òócû³­rìTµ{™u’TórnqôÜ8ó!ˆL“‘Œ1qç ³"trÓ£&—œšBÉJ><èCş½¥°9I4›s$A.†¢V5ÎHp´ÚÄ£¦Z – ‡ÉDÓ=ºâ¥IC’œ¨”›ç¿œ]fqŠ2P»Jú­Æ+Ñ\¢&AtYvÔœ¬ÛBS|ÙÒNÖ©pÔù ’Ânh©öÈò<#÷xa $‹[ğ!WÎ‚¬Ë”³	ió4>± d©ù$èj÷ïŒ|Î«?ÏìÆóŒEeçÛgâ®yj=@[Ê	îéÕ:üˆİj1ÛE>Ûƒ´ScèM$Ú‹…j²SÉ"Û2¶ö¾ÆŒ-ƒxS²pğ‡’‹š6)ÖqÆ)µfê5ÅÑpÿB¹Â~àÜ>Ÿvğ	Æ±ÿ]ËJˆ‘2Ë§+‘÷ö:Sâ~KµX9¿¡³vuJˆ\@é¸şÀ¶û¬ˆ]ŒÆ»©0<¤¨gª}„Îú	Uöe„î²¬_^ó¶eñ¾ßFnvÁ²äTj-Y@»wh–+wX’ä¥÷a{ï·øĞëÜ<Ò/}ávjï·Sw§9°™æ#z¿ôÇq!­™—ø™Ğ}à¤µ _ş
+0 Û—;
+endstream 
+endobj 
+329 0 obj 
+<<
+/Filter /FlateDecode
+/Length 418
+>>
+stream
+H‰ÔUAnÜ0¼ëü€Y‘"Eê9=ôFÓ’ mştäÄk·H7=´@
+$r©áÌPö	§u2n-é¾|-wå¶|+BeçV=(Fp‹a´>”ùÓCY‚=¶÷eqÈa8¨¯!gÏˆÊc´7ç)ÎÒP3èûçò‰OİÜ¸Ê*~ê¦ìÙ	ÔbRŒ’¥;-¢eÏÁ
+ZÉŠJÄÍ6µ-Q¶óY<xt;'€ç‰‚sl`+à¬}&fG¸|$leA½6r¸“Ó­Ü¥ƒÛÌ”˜8”DÆN¢rSİhÎŠEÁài½øy[êtæpõ$zZ‹Â\Ôanw¡¥q×é•¦O«ï.Ò®ø¿)¸6Æºqcòáæ£Ò—§Ÿî‘sï€1ô°„AÇh§zì°ºë\´é)r³éÉ%ÎØ–¦‰Ù³Ôy«_6kÙ°öôùÄ‡eÖz½˜ÏúËıwÌºûÿƒ÷õ÷ìê€¡µ±9¦ÿ…¾Ê¯Y è=óşj½ò¨øü¡ø—¡?K? šéA)
+endstream 
+endobj 
+330 0 obj 
+<<
+/Filter /FlateDecode
+/Length 331
+>>
+stream
+H‰Ô•KKÃ@Çïû)şÇæMf_Ù…ÒC[Ÿ (<ˆH	}LÅ´â×w6QS¡xÑC$°3ÿÌ#¿a ¹´V!Í¥ÒŠE<Ú§+q#^µŠ`IIgA[/I9‡ª1T‹ô£,ıÖ«WÖn×k_´F+”$å:ÖvN%Ú^Ÿ¯+úvlbŞOÜ‘<*¬T…ƒ7$}@³wØŠ.»j+²³[…õî`PÒ¹ÌƒÕĞqbGfĞƒp» •Ñÿ„ûêo"y®)†}r;IŠAsÿÅ‚¸N­Ô =Ê­Ù1Ãæ>¹šÍ´Ù9a<Î®fsN&Ó9Gl(+é1ÎY®")¼|ùnxERÙàQfïQÖâ~tš˜£Å¦IÈb´N(ª]+öMÂç²ÚD³_‚SÙynê×§E“<ğ¿åe‡™]â]€ m­<â
+endstream 
+endobj 
+331 0 obj 
+<<
+/Filter /FlateDecode
+/Length 743
+>>
+stream
+H‰ŒTÛNÛ@}ÏWÌR\Åï	B­¢VÅíU›xoq6ÈkƒÄ×wfÖq Mi•‡¬wçræÌ™ 8Ÿ]À ğ½|üñ!¼09B:M½iäC¶üŞ8nCYÖ°rOxt\:5>9!>¶:WzÆù«a½³”ü8rî³ƒqü €¬øà^EÍ0é³uT5,d.ZYk0.Á#È…1p]j©!ok·,A*-á»“PêÚ<ŞEqÜ´z›Óçh{ÖšBT¸e¿vÅ |ÓBkY®+µ,œ€.UƒNŒ3û€˜¤nû4BS8£tXĞÃ²l«\Ù`o‚,î¢Il1{ærœ¿ÀÉÉx~q=ƒNO¹¾7À½(Œ!Ë1×ÙRæJ·„á@Qb·JVQêrS€¬KQ‘é’–ˆKEö‹<ûFöÁ	â†G#Â]¢]±½5fæÛ=©{“4F©D±G	K%òBª¢ë"Uq„´°¤¼p@Q2Ê+'Jè£~´İ“Ê ¡år[B!–¥ÜYq@¯áÄóã	¸)rÙ¡h¬–· Ú¶ÀS/Œ&ŒÉaÏ}ÍB65kƒîl]Øk’w—VO¶ <ÛÂjRŠFM5 Z+Ÿ}>Şƒ÷
+a`ajÇc&¡ªJÉİ$^ëÂf®×¢Qš—‡¤#øç\€QÑ	º3B”hX(–7)ÉÖÆÈ|È¡Ìş/aè(¡añÏĞ­3¢ÁŞ¢åØ®ïùÅÒ<9Ù/›íàJx›™ôïq¤\ÿÁ!¦“^[0n?•$-ÒÃ\5¨èõ^'Y¶Õ[]¿Ã½rbÛª¶ıRC¦Ï­MçÁÃn‡·ïc}hĞ"÷ÏÔJiQB/»{_/µ×‹Ãl¶êìwyÿÜ'Jó¢YÃì¾Ò ¿tJkêvm—.½ï wXÚÂtõÉª’Œ»‘ª¢İ+YxÎ=Ào AÂ›
+endstream 
+endobj 
+332 0 obj 
+<<
+/Filter /FlateDecode
+/Length 819
+>>
+stream
+H‰|TïOÛ0ıŞ¿â>&UcâÄq„€Â ©‚°Ğir·ÍHİ)?@ã¯ßÙNºJt´Rãø|÷Ş½w.€ùd·£l<zv.]êƒS6Råb­¤‚¹sÖ5J¬7òLP–í‹YˆÚõô³•j×BÌ¶ç¦ø›¹.´À£æ´Í¾©ªTò?aØ"<	µrõ†yQw‹h¶¦è›…*%¬ìª¶\Ôû<ŒY.kÏı=ø½nökäùÄõ«é«Y¬ë½T…„NPtvo±Ñ5Õ<dL%•ğA‡W›]÷­wËVÂ•"W±®?è1wÉP»:·¹y´¦-WZA!køîF¦póÛôöç­Èz-*Ä€TÃÒÚnzoºU.W•î±v#ä6¡EÁônÔÒ®7¢-·º©­&Pšè½Äfß{QÛAİ	ê¿ì;ÇB8ºØ½>7À©J¹Ò›Ô'øø5‹€’ Jˆ"F(d›%œÅàqÂyY¡VÉƒ¨*DÆ1“»Ş ­›‰½õûE/NS¢³yÙ¢U›²5:È÷ «ğFŠV‰~ü´n¨Ê`Nßl=La_6ùõÄ:åõ”)	ÃĞR~°M"Ö{u=;îr!5Ì¿É1ã¿²ãÓÏGßİbİJ³š ÷uı+{X¨—e·S_l`&JE‘ËÙŒ®899š]ÜL!†ÓÓó©ŞÌèOÔ²å(EÉfF„!iú„¥i¬xv(À™Ò¤E¼ÕxïàÉjij¸·w¶lÌûò×-*=`ó}lj±œ K’¤Â”ğ˜…uŒ"ÅØÔİR;Ò
+ÕË‚ø{w;€d ğ(#<‰%h ³ .s'Ë\ªu'³¹½»ãƒuÒ¡™]…$`¼°¤7³İİlıg°Æá1|;\Ò¯á°”¤œN|@mÉ³|©ÍïM¬Z»"{7ß×óäó ²éÈ¹ÒWÓ¹èÉù]	5>Ö‚Å&xl€c“÷ˆ ‡2Âg’ñ"¤FKç©”ÕĞ7æî<ÄÑ¡åÀü ]äÆE1ô@g'Aj²ÇñâÁ_ v½¢x
+endstream 
+endobj 
+333 0 obj 
+<<
+/Filter /FlateDecode
+/Length 686
+>>
+stream
+H‰¤”moÚ0Çßó)îe\)}~ˆ3U•ZÆ¤Vbš*ö¦e/Ò6<¬U!lÒ>ıÎv @¡š6*Aûîşÿ»Ÿ?WûĞK
+F¿@k®nüãSï>¹¬Ÿ™¬ëI‹–¥şû6ºé	1:£]Ÿ˜2”³æeQÖgÂê`H‰³/p~û×A¸¸Õ¤¦jÆWÑè«$_g}a7©U¼(,¤šKgBÌe=õ1ı9ĞÊp‰¡,y±ä/{©v\æÚ‡åÂDCù!­?–Ëª6¶æSÉs—ûa£°‡yóÇ”Ë3ğÕ^“ÑˆIôÍùÍÍ˜7o-lª áÎZ@’«C‘å¼…»]/dE+EV¹ÆhW"§e±¾ªIi–;¢½¶ë0³ş »ª6‰Q#WVdæÎ»¦ûÙí óùÓÃ¥ûäö*c†RWí#³S“vÛIKÚ‚OĞñtiš¦ŸfhœéÅ©LÅ6i1¹g»A¶e»
+ÉÆJëÇÙ‚æTÅ†í‚»×„@Š3ÔIthš x.÷š@‚IóŞè4çõ¨â=†Q¾`³áJw}4ÑK[5ğ3üW5«ï¬­èSô&c–¾ËuÜ9eÔ½jR.UMA›¾ï#âF…ØAÄwn=1» :Éµ N4ZÒØ&i¹É=i;,¢î€X`-@Ó''şTÔ¼Ş{§c1æ†¦fƒ8
+qÔQG,ù·„Ñ<œ¡†Jûòtzã%ø0¡»-Ş}ÿyâş-\¢{— {š ÂöH‡áRÅÙ»»° Q†+îšÔ6‘µ	SÉ$>ÔOÕ
+æm[AY?w;Ö¿»EX×OPÕíê¥[¡cG5\í²\Ä*.h^$ş0 .åvu
+endstream 
+endobj 
+334 0 obj 
+<<
+/Filter /FlateDecode
+/Length 676
+>>
+stream
+H‰¬UÛjÛ@}÷WÌ£TjY+É’!Ä&MKÚRÔ>4.E—•´µ´ÚUúúÎ^ìÈJKkƒXkg÷œ9sf`>NÖğæPe\ö.Y‚“Õ.>)w¿¥ogÛû˜->ÂÅÅâşænA——×|9ÏÌ/^&–³çÎ%>8EM–S()‡+.Š¦„‡~êmÚ?fBè¥ÖÁµ^/c®˜>Ì#/XBºA°í¡¥r”>wö>Fk ½;W?*ıê ŸmQ„µ`…Ş*LØyfªEáe‚Â“IÊŠ%£‰}q—:Uñ¸£H¼ÎŠFBÆM¤[EH<s(ñ„¦ƒ Ä#+ª±ÓÌyV4ç@%ò4+Èr³“€CÑ`ÄÎx	9ã`6må”WYÛ
+ƒ¾BĞqèwa{}ÜVYcéò» ˆñ.‰’~°Z³šñ¬Íiko†œ²J]ó;/…şDkâ­×ÿOë¿ìá.i& ’¯¶EVLª–¡«gÅ9QÙëN¢M/:¥S»øª#°l
+Llú¬íëI´z=”™X¸î*Úã`ğušc‹~¢ğÎÅ~pGb(—öG¦s©ÿ[ÉŞÏ5#Çš-Ròİi5[«ôñ«áÒ‹ü(8ÁÁ°
+!í0 à–ª‹ŸjY4ê‰”®,%	ª¶\¿¶!*×’ÕXÔ	¡÷<u¢´œR"†ÒJóYAàGŞ:ŒÏÉ`;h…lQ­X¹apÊ'Â*–ñ½ÆS¼ìèø4ÉÚó¢fHäÇf:^b´ÆkµI¹Îwâµ7T'—µ-5³a†Q®£´çšLX$Ï}•>AD¼(Q$áÜ2:×M˜ƒÛt¦ÿ	~	0 ˆ.œ5
+endstream 
+endobj 
+336 0 obj 
+<<
+/Subtype /Form
+/Resources 
+<<
+/ExtGState 
+<<
+/GS0 160 0 R
+>>
+/ColorSpace 
+<<
+/CS0 155 0 R
+>>
+>>
+/Type /XObject
+/BBox [21.0098 21.0 574.266 455.211]
+/Filter /FlateDecode
+/Length 956
+/OC 170 0 R
+/Group 169 0 R
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰”—Mn9…÷u
+]À´Dı/gƒÙŒt.q  q€\?lWQhµõèdã2º¾zŸ(‰òîİ?Û×íşoß?=½üîş|8¹íştöîñÙyê­Èß–ƒü­İ¹çÇÿ·û¿åíÇç-×D>—r¢.Ä]ÎL5w—b¤êƒûöaË‘©‡è7J¥¹(ÆîîB¢PÓD¦ÌÑ"z¡ËŠ`O!·9J[×QÖÄu”%ÁÑSN«(©'*©ãÇ à8RÔºä pŒÀ!r¡X›1mƒ€Ó68m)E*ÌV%p%`”
+ùKÒ‰ë"[%"Kİò
+ğ‘¢¯–ÄA@	îR4²J°„P"ªUÂÅ×$ovâS,l ©QÌÆ{ù…»ÄBa5€¤†eb,"©rğ]YY|X=é+â:È˜‚LD<JQ—[è–„oJàq–@¹f+ˆ0ˆ8ˆìô1ŞNë’€AZ%ßÌISâM	<ÎŞ©%¶ÊO	X~
+Àòã [QoFA  ÌYÖ_²$”€±Q°šP Ë¹^Š¥ ”(ûÖ‹çthN¹îg„!¡”hB¼5sI ‰èå8lÖJ”û©mH(%¸Rò–ƒ€éÒ¡Ü®²¶"Ğ¤Æ¼7[†„P¢d*åÖÎ%%ªt|»­-‰7%àJV‚K%ÎV|ä*ÏÜA\İÔ-âåØ5sçnìB³6èAÀÒQ Ûu†]J`»Â°K	l—Ğ®$ÍXÖa3dÇ  J`;¶ƒ0:6% ƒÀvHüÒ­^fĞàÙ«ÄlÇ’˜ìX³Kb²cILvLw±ÁÚííP Ûq†J`;Â°C	l‡ØÄÄşv[Æ8”ÀãPÂÇŞ+p”@Z_9õ\b–ŸÂ¬¯¯œ††ÌGÕÒhR5Ëô ?”À~(ı‹¢tS*óu°Gbn7©´ëTb¯ôd/•nj¼”z5ˆ½Ô×QöÖç’}¦Ş’‘‹8—AÀ\sQç’C#3ŞÓ oé
+À]¸¡ç(õb±³[KbrkILn­ˆÙ­™Ø{E¼ s’,3[¹„‘‹8%p.syÚîOgïNgç/ÓËÃçæÜùôï&Ù¹.¹·}İÂå»´A¢$÷ÀË¾Uƒ/îñËvyóeËÒB×\äÿÏÛyûoñ<³—ço|²o×a¼»K1RõáÕG¹ÊïE.¿ğÕ_''Ÿ RdG
+endstream 
+endobj 
+335 0 obj 
+<<
+/Subtype /Form
+/Resources 
+<<
+/ExtGState 
+<<
+/GS0 159 0 R
+>>
+/ColorSpace 
+<<
+/CS0 155 0 R
+>>
+>>
+/Type /XObject
+/BBox [283.387 749.514 564.496 778.018]
+/Filter /FlateDecode
+/Length 889
+/OC 172 0 R
+/Group 171 0 R
+/Matrix [1.0 0.0 0.0 1.0 0.0 0.0]
+>>
+stream
+H‰ÜVËn1İÏWÌàÆÎ{	bC~ ]Q.R‰¶ÿ/2“IÆñÜ6lR±3®íŸWÍ_>N¿¦»·Ï¯?¿^^çw÷ótwÿYÍ——Ymÿæ—ËÏéîC:úş2Aé0{Á;3¿A°–f"pÑÏÏß&Ø Ş»&À€qú ĞÔfğ)ç¨DD0š"AzĞCt ü°DØ°Š€|l°	0`ã „U"ÙA ¦¶ch@ƒĞöq°ÀšP–ÜhÜ–R£q[òtl‡å›€:Ğ ƒÖ@İ"UTº	p í¨„öÕ¨„Ağ|Ü§Æ@ãnp0KD°|Ü§VƒæãÖ x€/ÇİôàhçûïÂ:„ˆ£a9d\¿ÄcÜT!ñ,Ø•)÷):˜ù²Lë§õgª­âO«i’i²™rÙÉÙLDWÊîöú‹~·×ßŒÉŞ³İ8(Ñõ ¤*¥LñKÅ/Í¿ô½*™×©Æí§ùgÂ£&\&V«éCÉÆ”hLµ]§ZFV3õÂò‹«–Í.°8†™†˜øtöKlñK£×)ô	e5Kçá¸”Í¹„[w·@Põ Fu ŒŒ5ÈiãEç¾­îÛê¹ÜÃ©õîŒuF·¾ìµ÷Oé™å÷‚Ô¯dJ‡·¾tæŒn{_è¢®vArµË5W»¢å:È	‚œ!()‚’#(IRj%İ‚]üÚáî×î³ŸŸ2^!OÂ4Õ­lGóğD=ÊŠEL²ˆizÑ¿ı{Ö?1²#+q²¹’î|Po$ÈŒ'6S_¸<q}âz„QVŒ¢b<U43Ã03F„-fÅ¯±È13LºÈ0(6§0±ä8Ôp÷H¹]×{|äºïqútsı9ÖhZíÿóúëè[_Ş*æËÄ¨aÌÑœáì“ldïY¼Î–hÛ*íôçzjşÏViÂĞm3›Ñ	Ÿ„2	aâºô‡}—±]ø{ÊNU%N¾(.Åå¥9¹nû­³cÛöŒ Ø0„‹r‘@)(EOô’üB)vÇ®½±Œ»°†<:¾)8OÅ*~µb+öş¼è“çØ?Ë`ÿ—™º{N½ò6ºõÅâØ·¾t„ºÿ¶©;2ê>{r]”©?çu%¼¸ŸÓ¿ pÑZÙ
+endstream 
+endobj 
+337 0 obj 
+<<
+/Filter /FlateDecode
+/Length 284
+>>
+stream
+xœ’ÏJÃ@ÆïßaÈi!hé)%ˆŠE°²İLÒ¥ËlÜ?­Rò¦}n’Š„ö8³¿o¾™°Ê“pR+µH ’¨Ê Y±¡Nw\yÌó¡xé«GZjo±Ô{‚#hòJÍ»v¨,¦I{«ßî6(¶X²ËøWŞ!³<çM“r…Æ±=MÙ4QH§0‹nŒƒÜ“³bóYÊÚS}%@Å{ƒ=¹´u=QxG‚•D@Ik4{”¶çÛ‘+ÀšÓ¶0œl…&µèğÕK–sÆcÜuZxËâù 8^tZ_ñÀı¨ BÂi†u)°h5]Ì¢ÿ¦Ÿíj´şyæçXã–áÉ¥›@§ı—wâ@~/T±n
+endstream 
+endobj 
+338 0 obj 
+<<
+/Filter /FlateDecode
+/Length 284
+>>
+stream
+xœ’ÏJÃ@ÆïßaÈi!hé)%ˆŠE°²İLÒ¥ËlÜ?­Rò¦}n’Š„ö8³¿o¾™°Ê“pR+µH ’¨Ê Y±¡Nw\yÌó¡xé«GZjo±Ô{‚#hòJÍ»v¨,¦I{«ßî6(¶X²ËøWŞ!³<çM“r…Æ±=MÙ4QH§0‹nŒƒÜ“³bóYÊÚS}%@Å{ƒ=¹´u=QxG‚•D@Ik4{”¶çÛ‘+ÀšÓ¶0œl…&µèğÕK–sÆcÜuZxËâù 8^tZ_ñÀı¨ BÂi†u)°h5]Ì¢ÿ¦Ÿíj´şyæçXã–áÉ¥›@§ı—wâ@~/T±n
+endstream 
+endobj 
+346 0 obj 
+<<
+/K false
+/Type /Group
+/S /Transparency
+>>
+endobj 
+345 0 obj 
+<<
+/OCGs 11 0 R
+/Type /OCMD
+>>
+endobj 
+344 0 obj [/ICCBased 347 0 R]
+endobj 
+343 0 obj 
+<<
+/ca 1.0
+/SA true
+/OPM 0
+/CA 1.0
+/AIS false
+/BM /Normal
+/Type /ExtGState
+/op true
+/SMask /None
+/OP true
+>>
+endobj 
+347 0 obj 
+<<
+/N 3
+/Filter /FlateDecode
+/Length 2574
+>>
+stream
+H‰œ–yTSwÇoÉ•°Ãc[€°5la‘QIBHØADED„ª•2ÖmtFOE.®c­Ö}êÒõ0êè8´×8GNg¦Óïï÷9÷wïïİß½÷ó  '¥ªµÕ0 Ö ÏJŒÅb¤	 
+  2y­.-;!à’ÆK°ZÜ	ü‹^i½"LÊÀ0ğÿ‰-×é @8(”µrœ;q®ª7èLöœy¥•&†Qëñq¶4±j½ç|æ9ÚÄ
+V³)gB£0ñiœW×•8#©8wÕ©•õ8_ÅÙ¥Ê¨QãüÜ«QÊj@é&»A)/ÇÙgº>'K‚ó ÈtÕ;\ú”Ó¥$ÕºF½ZUnÀÜå˜(4TŒ%)ë«”ƒ0C&¯”é˜¤Z£“i˜¿óœ8¦Úbx‘ƒE¡ÁÁBÑ;…ú¯›¿P¦ŞÎÓ“Ì¹Aüom?çW=
+€x¯Íú·¶Ò- Œ¯Àòæ[›Ëû 0ñ¾¾øÎ}ø¦y)7ta¾¾õõõ>j¥ÜÇTĞ7úŸ¿@ï¼ÏÇtÜ›ò`qÊ2™±Ê€™ê&¯®ª6ê±ZL®Ä„?â_øóyxg)Ë”z¥ÈÃ§L­UáíÖ*ÔuµSkÿSeØO4?×¸¸c¯¯Ø°.ò ò· åÒ R´ßŞô-•’2ğ5ßáŞüÜÏ	ú÷Sá>Ó£V­š‹“då`r£¾n~ÏôY &à+`œ;ÂA4ˆÉ ä€°ÈA9Ğ =¨- t°lÃ`;»Á~pŒƒÁ	ğGp|	®[`Lƒ‡`<¯ "AˆYA+äùCb(Š‡R¡,¨ *T2B-Ğ
+¨ê‡†¡Ğnè÷ĞQètº}MA ï —0Óal»Á¾°Sàx	¬‚kà&¸^Á£ğ>ø0|>_ƒ'á‡ğ,ÂG!"F$H:Rˆ”!z¤éF‘Qd?r9‹\A&‘GÈ”ˆrQ¢áhš‹ÊÑ´íE‡Ñ]èaô4zBgĞ×Á–àE#H	‹*B=¡‹0HØIøˆp†p0MxJ$ùD1„˜D, V›‰½Ä­ÄÄãÄKÄ»ÄY‰dEò"EÒI2’ÔEÚBÚGúŒt™4MzN¦‘Èşär!YKî ’÷?%_&ß#¿¢°(®”0J:EAi¤ôQÆ(Ç()Ó”WT6U@ æP+¨íÔ!ê~êêmêæD¥eÒÔ´å´!ÚïhŸÓ¦h/èº']B/¢éëèÒÓ¿¢?a0nŒhF!ÃÀXÇØÍ8ÅøšñÜŒkæc&5S˜µ™˜6»lö˜Iaº2c˜K™MÌAæ!æEæ#…åÆ’°d¬VÖë(ëk–Íe‹Øél»—½‡}}ŸCâ¸qâ9
+N'çÎ)Î].ÂuæJ¸rî
+î÷wšGä	xR^¯‡÷[ŞoÆœchgŞ`>bş‰ù$á»ñ¥ü*~ÿ ÿ:ÿ¥…EŒ…ÒbÅ~‹ËÏ,m,£-•–İ–,¯Y¾´Â¬â­*­6X[İ±F­=­3­ë­·YŸ±~dÃ³	·‘ÛtÛ´¹iÛzÚfÙ6Û~`{ÁvÖÎŞ.ÑNg·Åî”İ#{¾}´}…ı€ı§ö¸‘j‡‡ÏşŠ™c1X6„Æfm“;'_9	œr:œ8İq¦:‹ËœœO:Ï¸8¸¤¹´¸ìu¹éJq»–»nv=ëúÌMà–ï¶ÊmÜí¾ÀR 4	ö
+n»3Ü£ÜkÜGİ¯z=Ä•[=¾ô„=ƒ<Ë=G</zÁ^Á^j¯­^—¼	Ş¡ŞZïQïBº0FX'Ü+œòáû¤útøŒû<öuñ-ôİà{Ö÷µ__•ß˜ß-G”,ê}çïé/÷ñ¿ÀHh8ğm W 2p[àŸƒ¸AiA«‚Nı#8$X¼?øAˆKHIÈ{!7Ä<q†¸Wüy(!46´-ôãĞaÁa†°ƒa†W†ï	¿¿@°@¹`lÁİ§YÄˆÉH,²$òıÈÉ(Ç(YÔhÔ7ÑÎÑŠèÑ÷b<b*böÅ<õ‹ÕÇ~ûL&Y&9‡Ä%ÆuÇMÄsâsã‡ã¿NpJP%ìM˜IJlN<DHJIÚtCj'•KwKg’C’—%ŸN¡§d§§|“ê™ªO=–§%§mL»½Ğu¡váx:H—¦oL¿“!È¨ÉøC&13#s$ó/Y¢¬–¬³ÙÜìâì=ÙOsbsúrnåºçsOæ1óŠòvç=ËËïÏŸ\ä»hÙ¢óÖê‚#…¤Â¼Â…³‹ãoZ<]TÔUt}‰`IÃ’sK­—V-ı¤˜Y,+>TB(É/ÙSòƒ,]6*›-•–¾W:#—È7Ë*¢ŠÊe¿ò^YDYÙ}U„j£êAyTù`ù#µD=¬ş¶"©b{Å³ÊôÊ+¬Ê¯: !kJ4Gµm¥ötµ}uCõ%—®K7YV³©fFŸ¢ßYÕ.©=bàá?SŒîÆ•Æ©ºÈº‘ºçõyõ‡ØÚ†kï5%4ı¦m–7Ÿlqlio™Z³lG+ÔZÚz²Í¹­³mzyâò]íÔöÊö?uøuôw|¿"Å±N»ÎåwW&®ÜÛeÖ¥ïº±*|ÕöÕèjõê‰5k¶¬yİ­èş¢Ç¯g°ç‡^yïkEk‡Öş¸®lİD_pß¶õÄõÚõ×7DmØÕÏîoê¿»1mãál {àûMÅ›ÎnßLİlÜ<9”úO ¤[ş˜¸™$™™üšhšÕ›B›¯œœ‰œ÷dÒ@®ŸŸ‹Ÿú i Ø¡G¡¶¢&¢–££v£æ¤V¤Ç¥8¥©¦¦‹¦ı§n§à¨R¨Ä©7©©ªª««u«é¬\¬Ğ­D­¸®-®¡¯¯‹° °u°ê±`±Ö²K²Â³8³®´%´œµµŠ¶¶y¶ğ·h·à¸Y¸Ñ¹J¹Âº;ºµ».»§¼!¼›½½¾
+¾„¾ÿ¿z¿õÀpÀìÁgÁãÂ_ÂÛÃXÃÔÄQÄÎÅKÅÈÆFÆÃÇAÇ¿È=È¼É:É¹Ê8Ê·Ë6Ë¶Ì5ÌµÍ5ÍµÎ6Î¶Ï7Ï¸Ğ9ĞºÑ<Ñ¾Ò?ÒÁÓDÓÆÔIÔËÕNÕÑÖUÖØ×\×àØdØèÙlÙñÚvÚûÛ€ÜÜŠİİ–ŞŞ¢ß)ß¯à6à½áDáÌâSâÛãcãëäsäüå„ææ–çç©è2è¼éFéĞê[êåëpëûì†ííœî(î´ï@ïÌğXğåñrñÿòŒóó§ô4ôÂõPõŞömöû÷Šøø¨ù8ùÇúWúçûwüü˜ı)ıºşKşÜÿmÿÿ ÷„óû
+endstream 
+endobj 
+348 0 obj 
+<<
+/ModDate (D:20190603151958+02'00')
+/CreationDate (D:20190510134713+02'00')
+/Title (Fahrgastrechteformular)
+>>
+endobj xref
+0 349
+0000000000 65535 f 
+0000000015 00000 n 
+0000021120 00000 n 
+0000000501 00000 n 
+0000001016 00000 n 
+0000021004 00000 n 
+0000020955 00000 n 
+0000021052 00000 n 
+0000001052 00000 n 
+0000001551 00000 n 
+0000001654 00000 n 
+0000020904 00000 n 
+0000017436 00000 n 
+0000032014 00000 n 
+0000032114 00000 n 
+0000032216 00000 n 
+0000032304 00000 n 
+0000002319 00000 n 
+0000002593 00000 n 
+0000002870 00000 n 
+0000003146 00000 n 
+0000003367 00000 n 
+0000003654 00000 n 
+0000003942 00000 n 
+0000004162 00000 n 
+0000004457 00000 n 
+0000004754 00000 n 
+0000005033 00000 n 
+0000005317 00000 n 
+0000005600 00000 n 
+0000005888 00000 n 
+0000006157 00000 n 
+0000006449 00000 n 
+0000006740 00000 n 
+0000007036 00000 n 
+0000007315 00000 n 
+0000007647 00000 n 
+0000007968 00000 n 
+0000008374 00000 n 
+0000008596 00000 n 
+0000008995 00000 n 
+0000009217 00000 n 
+0000009762 00000 n 
+0000009984 00000 n 
+0000010568 00000 n 
+0000031580 00000 n 
+0000035217 00000 n 
+0000034813 00000 n 
+0000034122 00000 n 
+0000031774 00000 n 
+0000035458 00000 n 
+0000033631 00000 n 
+0000035673 00000 n 
+0000036148 00000 n 
+0000035900 00000 n 
+0000036580 00000 n 
+0000036364 00000 n 
+0000036821 00000 n 
+0000037040 00000 n 
+0000037272 00000 n 
+0000037485 00000 n 
+0000031892 00000 n 
+0000040911 00000 n 
+0000040332 00000 n 
+0000041150 00000 n 
+0000041433 00000 n 
+0000039764 00000 n 
+0000038966 00000 n 
+0000001094 00000 n 
+0000001206 00000 n 
+0000001256 00000 n 
+0000001451 00000 n 
+0000001501 00000 n 
+0000042296 00000 n 
+0000042525 00000 n 
+0000042808 00000 n 
+0000001703 00000 n 
+0000001946 00000 n 
+0000002132 00000 n 
+0000010790 00000 n 
+0000011123 00000 n 
+0000014668 00000 n 
+0000043764 00000 n 
+0000014740 00000 n 
+0000014882 00000 n 
+0000014953 00000 n 
+0000014814 00000 n 
+0000015088 00000 n 
+0000015159 00000 n 
+0000015020 00000 n 
+0000015295 00000 n 
+0000015366 00000 n 
+0000015227 00000 n 
+0000015504 00000 n 
+0000015575 00000 n 
+0000015436 00000 n 
+0000015704 00000 n 
+0000015775 00000 n 
+0000015636 00000 n 
+0000015907 00000 n 
+0000015978 00000 n 
+0000015838 00000 n 
+0000016109 00000 n 
+0000016182 00000 n 
+0000016040 00000 n 
+0000016315 00000 n 
+0000016388 00000 n 
+0000016246 00000 n 
+0000016525 00000 n 
+0000016598 00000 n 
+0000016456 00000 n 
+0000016736 00000 n 
+0000016809 00000 n 
+0000016667 00000 n 
+0000016880 00000 n 
+0000016953 00000 n 
+0000017095 00000 n 
+0000017168 00000 n 
+0000017026 00000 n 
+0000017299 00000 n 
+0000017372 00000 n 
+0000017230 00000 n 
+0000044338 00000 n 
+0000044411 00000 n 
+0000044553 00000 n 
+0000044626 00000 n 
+0000044484 00000 n 
+0000044757 00000 n 
+0000044688 00000 n 
+0000045871 00000 n 
+0000045247 00000 n 
+0000045609 00000 n 
+0000008285 00000 n 
+0000046833 00000 n 
+0000046209 00000 n 
+0000046571 00000 n 
+0000008906 00000 n 
+0000047795 00000 n 
+0000047171 00000 n 
+0000047533 00000 n 
+0000009673 00000 n 
+0000048757 00000 n 
+0000048133 00000 n 
+0000048495 00000 n 
+0000010479 00000 n 
+0000044873 00000 n 
+0000049667 00000 n 
+0000049095 00000 n 
+0000049403 00000 n 
+0000044821 00000 n 
+0000045086 00000 n 
+0000050524 00000 n 
+0000049955 00000 n 
+0000050262 00000 n 
+0000045034 00000 n 
+0000011407 00000 n 
+0000050808 00000 n 
+0000011445 00000 n 
+0000011503 00000 n 
+0000011634 00000 n 
+0000011762 00000 n 
+0000011892 00000 n 
+0000053465 00000 n 
+0000012372 00000 n 
+0000057356 00000 n 
+0000013118 00000 n 
+0000057913 00000 n 
+0000013667 00000 n 
+0000062182 00000 n 
+0000014441 00000 n 
+0000014505 00000 n 
+0000014554 00000 n 
+0000014618 00000 n 
+0000043233 00000 n 
+0000021219 00000 n 
+0000021333 00000 n 
+0000063073 00000 n 
+0000029967 00000 n 
+0000029595 00000 n 
+0000029139 00000 n 
+0000027658 00000 n 
+0000027350 00000 n 
+0000062993 00000 n 
+0000022070 00000 n 
+0000022387 00000 n 
+0000022515 00000 n 
+0000022772 00000 n 
+0000022954 00000 n 
+0000023050 00000 n 
+0000023190 00000 n 
+0000023286 00000 n 
+0000023426 00000 n 
+0000023608 00000 n 
+0000023704 00000 n 
+0000023800 00000 n 
+0000023940 00000 n 
+0000024036 00000 n 
+0000024132 00000 n 
+0000024272 00000 n 
+0000024412 00000 n 
+0000024552 00000 n 
+0000024692 00000 n 
+0000024832 00000 n 
+0000024928 00000 n 
+0000025024 00000 n 
+0000025121 00000 n 
+0000025218 00000 n 
+0000025315 00000 n 
+0000025413 00000 n 
+0000025511 00000 n 
+0000025608 00000 n 
+0000025705 00000 n 
+0000025802 00000 n 
+0000025899 00000 n 
+0000025996 00000 n 
+0000026093 00000 n 
+0000026190 00000 n 
+0000026287 00000 n 
+0000026384 00000 n 
+0000026481 00000 n 
+0000026578 00000 n 
+0000026676 00000 n 
+0000026774 00000 n 
+0000026871 00000 n 
+0000027056 00000 n 
+0000027153 00000 n 
+0000027250 00000 n 
+0000063177 00000 n 
+0000063242 00000 n 
+0000063306 00000 n 
+0000063370 00000 n 
+0000063434 00000 n 
+0000030248 00000 n 
+0000030183 00000 n 
+0000030315 00000 n 
+0000030389 00000 n 
+0000030463 00000 n 
+0000030541 00000 n 
+0000030616 00000 n 
+0000030694 00000 n 
+0000030769 00000 n 
+0000030844 00000 n 
+0000030919 00000 n 
+0000030997 00000 n 
+0000031062 00000 n 
+0000031137 00000 n 
+0000031212 00000 n 
+0000031290 00000 n 
+0000031355 00000 n 
+0000031430 00000 n 
+0000031505 00000 n 
+0000029892 00000 n 
+0000029683 00000 n 
+0000029749 00000 n 
+0000029817 00000 n 
+0000029520 00000 n 
+0000029235 00000 n 
+0000029370 00000 n 
+0000029445 00000 n 
+0000029064 00000 n 
+0000027850 00000 n 
+0000027916 00000 n 
+0000027984 00000 n 
+0000028059 00000 n 
+0000028134 00000 n 
+0000028209 00000 n 
+0000028285 00000 n 
+0000028361 00000 n 
+0000028437 00000 n 
+0000028513 00000 n 
+0000028589 00000 n 
+0000028665 00000 n 
+0000028741 00000 n 
+0000028817 00000 n 
+0000028893 00000 n 
+0000028969 00000 n 
+0000027582 00000 n 
+0000027430 00000 n 
+0000027506 00000 n 
+0000062795 00000 n 
+0000062861 00000 n 
+0000029301 00000 n 
+0000062927 00000 n 
+0000033845 00000 n 
+0000034333 00000 n 
+0000037703 00000 n 
+0000040614 00000 n 
+0000035026 00000 n 
+0000040010 00000 n 
+0000064064 00000 n 
+0000063498 00000 n 
+0000063803 00000 n 
+0000034610 00000 n 
+0000040171 00000 n 
+0000064917 00000 n 
+0000064350 00000 n 
+0000064655 00000 n 
+0000039419 00000 n 
+0000038503 00000 n 
+0000038575 00000 n 
+0000065770 00000 n 
+0000065203 00000 n 
+0000065508 00000 n 
+0000038008 00000 n 
+0000038211 00000 n 
+0000038300 00000 n 
+0000038736 00000 n 
+0000038805 00000 n 
+0000066680 00000 n 
+0000066056 00000 n 
+0000066418 00000 n 
+0000039622 00000 n 
+0000039691 00000 n 
+0000041788 00000 n 
+0000042086 00000 n 
+0000067575 00000 n 
+0000067276 00000 n 
+0000067018 00000 n 
+0000042154 00000 n 
+0000042227 00000 n 
+0000042013 00000 n 
+0000041707 00000 n 
+0000068280 00000 n 
+0000067853 00000 n 
+0000117726 00000 n 
+0000116621 00000 n 
+0000114453 00000 n 
+0000129924 00000 n 
+0000130626 00000 n 
+0000131392 00000 n 
+0000131887 00000 n 
+0000132295 00000 n 
+0000133115 00000 n 
+0000134011 00000 n 
+0000134774 00000 n 
+0000136769 00000 n 
+0000135527 00000 n 
+0000137947 00000 n 
+0000138308 00000 n 
+0000068053 00000 n 
+0000068117 00000 n 
+0000068166 00000 n 
+0000068230 00000 n 
+0000138821 00000 n 
+0000138783 00000 n 
+0000138733 00000 n 
+0000138669 00000 n 
+0000138949 00000 n 
+0000141606 00000 n 
+trailer
+
+<<
+/Info 348 0 R
+/ID [<aa7f218abf874e89960f9584dd402478> <6dcf708b15c17ea7fbb5f97f18e1f5df>]
+/Root 1 0 R
+/Size 349
+>>
+startxref
+141737
+%%EOF

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,7 @@
 |
 */
 
+use App\Http\Controllers\Backend\Export\RightsClaimFormController;
 use App\Http\Controllers\Frontend\AccountController;
 use App\Http\Controllers\Frontend\EventController;
 use App\Http\Controllers\Frontend\Export\ExportController;
@@ -189,6 +190,7 @@ Route::middleware(['auth', 'privacy'])->group(function() {
     Route::prefix('export')->group(function() {
         Route::get('/', [ExportController::class, 'renderForm'])->name('export.landing');
         Route::get('/generate', [ExportController::class, 'renderExport'])->name('export.generate');
+        Route::get('/rights-claim/{id}', [RightsClaimFormController::class, 'render'])->name('export.rights-claim');
     });
 
     Route::post('/createfollow', [FrontendUserController::class, 'CreateFollow'])


### PR DESCRIPTION
Früher Aufschlag für vorausgefüllte Fahrgastrechte. Weil Träwelling keine multi-stop journeys kann, ist das vielleicht nicht so mega hilfreich, aber es ist ein Anfang.

Implementation Details:
* Der Button wird nur angezeigt, wenn die Ankunftszeit ist `>60 min` verspätet ist. Der Button wird nur dem Status-Autor selbst angezeigt.
* Das PDF wird während eines Requests "ausgefüllt" und nirgendwo zwischen gespeichert. War eigentlich mein Plan, lohnt sich aber nicht, weil das Ausfüllen sehr schnell ist.
* Das Blanco-PDF und viele Gedanken kommen von Travelynx ([siehe hier](https://github.com/derf/travelynx/blob/master/lib/Travelynx/Controller/Passengerrights.pm)) und TRWL verhält sich hier sehr ähnlich.
* Vorzeitige Abbrüche der Reise (z.B. frühzeitige Wende nach dem Checkin) werden über `trwl:refreshTrips` nicht abgespeichert, dadurch wird der Button nicht dargestellt.

<img width="771" alt="image" src="https://user-images.githubusercontent.com/2796271/195674722-68ce7bc2-f5ae-41db-b9e6-c5cfc93ff377.png">

Und so sieht es dann im Formular aus:

<img width="1382" alt="image" src="https://user-images.githubusercontent.com/2796271/195675294-92d40bda-a17a-459e-b699-28181208c341.png">

To Do:

*  `trwl:refreshTrips` erweitern, dass `$stopover->isCancelled` geupdated wird. (Hewlp, werfen wir dann Leute raus? Notification schicken, dass sie über #1103 ihre Destination ändern können?)
* Leute notifizieren, wenn gewollt. Kann man über `trwl:refreshTrips` machen, habe ich mal in einem weiteren Branch angefangen, habe aber noch Fragen dazu.
* Formular in anderen Sprachen zur Verfügung stellen. (Evtl. müssen dann die Formularfelder umgestrickt werden?)
* Button nur für gewisse Operator anzeigen.
* Überall "BETA" dranschreiben, wo geht.