### PR TITLE
:ambulance: add null check to alternative destinations mapper

### DIFF
--- a/app/Http/Controllers/Backend/Transport/StationController.php
+++ b/app/Http/Controllers/Backend/Transport/StationController.php
@@ -73,7 +73,7 @@ abstract class StationController extends Controller
                 return [
                     'id'              => $stopover->id,
                     'name'            => $stopover->trainStation->name,
-                    'arrival_planned' => $stopover->arrival_planned->format('H:i'),
+                    'arrival_planned' => ($stopover->arrival_planned ?? $stopover->departure_planned)->format('H:i'),
                 ];
             });
     }


### PR DESCRIPTION
There are still problems when calling some pages, i.e. the profile page. This is what's logged:

```
[2022-10-17 10:54:46] production.ERROR: Call to a member function format() on null {"view":
{"view":"xxxxxxx/resources/views/includes/status.blade.php","data":[]},"userId":xxxxxxx,"exception":"[object] (
Spatie\\LaravelIgnition\\Exceptions\\ViewException(code: 0):Call to a member function format() on null
at xxxxxxxx/app/Http/Controllers/Backend/Transport/StationController.php:76) [stacktrace]
#0 [internal function]: App\\Http\\Controllers\\Backend\\Transport\\StationController::App\\Http\\Controllers\\Backend\\Transport\\{closure}()
#1 xxxxxxxx/vendor/laravel/framework/src/Illuminate/Collections/Arr.php(560): array_map()
```

