### PR TITLE
:arrow_up: :green_heart: use nodejs 19 for automatic builds

### DIFF
--- a/.github/workflows/nodejs-prod.yml
+++ b/.github/workflows/nodejs-prod.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 17.x, 18.x ]
+        node-version: [ 18.x, 19.x ]
 
     steps:
       - uses: actions/checkout@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine as NodeBuildContainer
+FROM node:19-alpine as NodeBuildContainer
 COPY . /usr/src/trwl
 WORKDIR /usr/src/trwl
 RUN npm install && npm run prod && rm -rf node_modules


### PR DESCRIPTION
Resolves #1122 which does a half-baked job on updating the dependencies. 

Removing nodejs 17 from our build matrix, and adding 19. [According to the docs](https://nodejs.org/en/blog/announcements/v19-release-announce/), 18 will become the new LTS so we might keep it around for longer.

IMO there is nothing too special about the new update that we could run with, but nonetheless, it's always good to stay up-to-date with dependencies.