### PR TITLE
:bug: Use real time data to order check ins

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -76,6 +76,11 @@ class UserController extends Controller
         Gate::authorize('view', $user);
         return $user->statuses()
                     ->join('train_checkins', 'statuses.id', '=', 'train_checkins.status_id')
+                    ->join('train_stations', 'train_stations.ibnr', '=', 'train_checkins.origin')
+                    ->join('train_stopovers', function($join) {
+                        $join->on('train_stopovers.trip_id', '=', 'train_checkins.trip_id');
+                        $join->on('train_stopovers.train_station_id', '=', 'train_stations.id');
+                    })
                     ->with([
                                'user', 'likes', 'trainCheckin.Origin', 'trainCheckin.Destination',
                                'trainCheckin.HafasTrip.stopoversNEW', 'event'
@@ -99,7 +104,8 @@ class UserController extends Controller
                               });
                     })
                     ->select('statuses.*')
-                    ->orderByDesc('train_checkins.departure')
+                    ->orderByDesc('train_stopovers.departure_real')
+                    ->orderByDesc('train_stopovers.departure_planned')
                     ->paginate($limit !== null && $limit <= 15 ? $limit : 15);
     }
 


### PR DESCRIPTION
Without this PR the earlier check-in would jump to the top, as the planned departure is after the planned departure of the ICE
![image](https://user-images.githubusercontent.com/16060205/198695451-be52045f-b6c2-46c6-bdd4-b24ee8d0bab1.png)
