### PR TITLE
:sparkles: Added endpoint for current user status

### DIFF
--- a/app/Http/Controllers/API/v1/AuthController.php
+++ b/app/Http/Controllers/API/v1/AuthController.php
@@ -278,48 +278,4 @@ class AuthController extends Controller
                                        'expires_at' => $newToken->token->expires_at->toIso8601String()]
         )->header('Authorization', $newToken->accessToken);
     }
-
-    /**
-     * @OA\Get(
-     *      path="/auth/user/now",
-     *      operationId="userState",
-     *      tags={"Auth"},
-     *      summary="User state",
-     *      description="This request returns whether the currently logged-in user has an active check-in or not.",
-     *      @OA\Response(
-     *          response=200,
-     *          description="successful operation",
-     *          @OA\JsonContent(
-     *              @OA\Property(property="data", type="object",
-     *                      ref="#/components/schemas/StatusResource"
-     *              )
-     *          )
-     *       ),
-     *       @OA\Response(response=401, description="Unauthorized"),
-     *       @OA\Response(response=404, description="No active check-in"),
-     *       security={
-     *          {"token": {}},
-     *          {}
-     *       }
-     *     )
-     *
-     *
-     * @param Request $request
-     *
-     * @return JsonResponse
-     * @api v1
-     */
-    public function userState(Request $request): JsonResponse {
-        $user = $request->user();
-        try {
-            $latestStatus = StatusResource::collection(UserBackend::statusesForUser(user: $user, limit: 1))[0];
-            if ($latestStatus->trainCheckin->destination_stopover->arrival_real->isPast()) {
-                    return $this->sendError('No active status');
-            } else {
-                return $this->sendResponse($latestStatus);
-            }
-        } catch (Exception) {
-            return $this->sendError('No status found');
-        }
-    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,6 +37,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
             Route::post('refresh', [v1Auth::class, 'refresh']);
             Route::post('logout', [v1Auth::class, 'logout']);
             Route::get('user', [v1Auth::class, 'user']);
+            Route::get('user/now', [v1Auth::class, 'userState']);
         });
     });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,7 +37,6 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
             Route::post('refresh', [v1Auth::class, 'refresh']);
             Route::post('logout', [v1Auth::class, 'logout']);
             Route::get('user', [v1Auth::class, 'user']);
-            Route::get('user/now', [v1Auth::class, 'userState']);
         });
     });
 
@@ -89,6 +88,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
             Route::post('createMute', [UserController::class, 'createMute']);
             Route::delete('destroyMute', [UserController::class, 'destroyMute']);
             Route::get('search/{query}', [UserController::class, 'search']);
+            Route::get('statuses/active', [StatusController::class, 'getActiveStatus']);
         });
         Route::group(['prefix' => 'settings'], function() {
             Route::put('acceptPrivacy', [PrivacyPolicyController::class, 'acceptPrivacyPolicy'])


### PR DESCRIPTION
This PR adds an API endpoint `/api/v1/auth/user/now` for requesting whether the requesting user has an active check-in or not.

If the user has an active check-in, the belonging status will be sent with a `200` response.
If the user does not have an active check-in, `404` will be sent.

closes #1158