### PR TITLE
:children_crossing: Remove platform from trip-table

### DIFF
--- a/app/Http/Controllers/FrontendTransportController.php
+++ b/app/Http/Controllers/FrontendTransportController.php
@@ -133,6 +133,9 @@ class FrontendTransportController extends Controller
                     return $trainStopover->departure_planned->isAfter($departure);
                 });
 
+            //Show Platform row only if there are information about it
+            $showPlatform = $stopovers->whereNotNull('platform')->count() > 0;
+
             // Find out where this train terminates and offer this as a "fast check-in" option.
             $lastStopover = $hafasTrip->stopoversNEW
                 ->filter(function(TrainStopover $stopover) {
@@ -147,6 +150,7 @@ class FrontendTransportController extends Controller
                 'startStation'    => $startStation,
                 'searchedStation' => isset($validated['searchedStation']) ? TrainStation::findOrFail($validated['searchedStation']) : null,
                 'lastStopover'    => $lastStopover,
+                'showPlatform'    => $showPlatform,
             ]);
         } catch (HafasException $exception) {
             return back()->with('error', $exception->getMessage());

--- a/app/Http/Controllers/FrontendTransportController.php
+++ b/app/Http/Controllers/FrontendTransportController.php
@@ -133,9 +133,6 @@ class FrontendTransportController extends Controller
                     return $trainStopover->departure_planned->isAfter($departure);
                 });
 
-            //Show Platform row only if there are information about it
-            $showPlatform = $stopovers->whereNotNull('platform')->count() > 0;
-
             // Find out where this train terminates and offer this as a "fast check-in" option.
             $lastStopover = $hafasTrip->stopoversNEW
                 ->filter(function(TrainStopover $stopover) {
@@ -150,7 +147,6 @@ class FrontendTransportController extends Controller
                 'startStation'    => $startStation,
                 'searchedStation' => isset($validated['searchedStation']) ? TrainStation::findOrFail($validated['searchedStation']) : null,
                 'lastStopover'    => $lastStopover,
-                'showPlatform'    => $showPlatform,
             ]);
         } catch (HafasException $exception) {
             return back()->with('error', $exception->getMessage());

--- a/resources/views/trip.blade.php
+++ b/resources/views/trip.blade.php
@@ -17,14 +17,14 @@
                 @endisset
 
                 <div class="card">
-                    <div class="card-header"
+                    <div class="card-header bg-dark text-white"
                          data-linename="{{ $hafasTrip->linename }}"
                          data-startname="{{ $hafasTrip->originStation->name }}"
                          data-start="{{ request()->start }}"
                          data-tripid="{{ $hafasTrip->trip_id }}"
                     >
                         <div class="float-end">
-                            <a href="#" class="train-destinationrow"
+                            <a href="#" class="train-destinationrow text-white"
                                data-ibnr="{{$lastStopover->trainStation->ibnr}}"
                                data-stopname="{{$lastStopover->trainStation->name}}"
                                data-arrival="{{$lastStopover->arrival_planned ?? $lastStopover->departure_planned}}">
@@ -47,13 +47,6 @@
                                data-startname="{{ $hafasTrip->originStation->name }}"
                                data-start="{{ request()->start }}"
                                data-tripid="{{ $hafasTrip->trip_id }}">
-                            <thead>
-                                <tr>
-                                    <th>{{__('stationboard.stopover')}}</th>
-                                    <th></th>
-                                    <th class="text-end">{{__('platform')}}</th>
-                                </tr>
-                            </thead>
                             <tbody>
                                 @foreach($stopovers as $stopover)
                                     @if($stopover->cancelled)
@@ -62,7 +55,6 @@
                                             <td>
                                                 <span class="text-danger">{{ __('stationboard.stop-cancelled') }}</span><br/>&nbsp;
                                             </td>
-                                            <td>{{ $stopover->platform }}</td>
                                         </tr>
                                     @else
                                         <tr class="train-destinationrow"
@@ -71,21 +63,13 @@
                                             data-arrival="{{$stopover->arrival_planned ?? $stopover->departure_planned}}"
                                         >
                                             <td>{{ $stopover->trainStation->name }}</td>
-                                            <td>
+                                            <td class="text-end">
                                                 {{ __('stationboard.arr') }}
                                                 {{ $stopover->arrival_planned->isoFormat(__('time-format'))}}
                                                 @isset($stopover->arrival_real)
                                                     <small>(<span
                                                             class="traindelay">+{{ $stopover->arrival_real->diffInMinutes($stopover->arrival_planned) }}</span>)</small>
                                                 @endisset
-                                            </td>
-                                            <td class="text-end">
-                                                {{$stopover->arrival_platform_planned}}
-                                                @if(isset($stopover->arrival_platform_real) && $stopover->arrival_platform_real !== $stopover->arrival_platform_planned)
-                                                    <span class="text-danger text-decoration-line-through">
-                                                        {{ $stopover->arrival_platform_real }}
-                                                    </span>
-                                                @endif
                                             </td>
                                         </tr>
                                     @endif


### PR DESCRIPTION
The platform is unnecessary information, which only makes the table confusing. It would make sense in the station board, but I don't care which platform the train stops at on the way.