### PR TITLE
:sparkles: Add sums to pdf export

### DIFF
--- a/app/Http/Controllers/Backend/Export/ExportController.php
+++ b/app/Http/Controllers/Backend/Export/ExportController.php
@@ -83,10 +83,14 @@ abstract class ExportController extends Controller
      * @throws DataOverflowException
      */
     private static function exportPdf(Carbon $begin, Carbon $end): \Illuminate\Http\Response {
+        $statuses = ExportBackend::getExportableStatuses(auth()->user(), $begin, $end);
+
         return Pdf::loadView('pdf.export-template', [
-            'statuses' => ExportBackend::getExportableStatuses(auth()->user(), $begin, $end),
-            'begin'    => $begin,
-            'end'      => $end
+            'statuses'     => $statuses,
+            'begin'        => $begin,
+            'end'          => $end,
+            'sum_duration' => $statuses->reduce(fn($sum, $s) => $sum + $s->trainCheckin->duration),
+            'sum_distance' => $statuses->reduce(fn($sum, $s) => $sum + $s->trainCheckin->distance) / 1000,
         ])
                   ->setPaper('a4', 'landscape')
                   ->download(

--- a/app/Http/Controllers/Backend/Export/ExportController.php
+++ b/app/Http/Controllers/Backend/Export/ExportController.php
@@ -25,13 +25,9 @@ abstract class ExportController extends Controller
      */
     public static function getExportableStatuses(User $user, Carbon $timestampFrom, Carbon $timestampTo): Collection {
         $statuses = Status::with([
-                                     'trainCheckin',
-                                     'trainCheckin.HafasTrip',
                                      'trainCheckin.HafasTrip.stopoversNEW',
                                      'trainCheckin.Origin',
                                      'trainCheckin.Destination',
-                                     // 'trainCheckin.originStation',
-                                     // 'trainCheckin.destinationStation'
                                  ])
                           ->join('train_checkins', 'statuses.id', '=', 'train_checkins.status_id')
                           ->where('statuses.user_id', $user->id)

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -205,6 +205,7 @@
     "export.title.status": "Status",
     "export.title.stopovers": "Zwischenhalte",
     "export.title.type": "Fahrttyp",
+    "export.total": "Gesamt",
     "leaderboard.distance": "Reiseentfernung",
     "leaderboard.averagespeed": "Schnelligkeit",
     "leaderboard.duration": "Reisedauer",

--- a/resources/lang/de_by.json
+++ b/resources/lang/de_by.json
@@ -323,6 +323,7 @@
     "export.title.origin.coordinates": "Abfahrtskoordinata",
     "export.title.origin.time": "Abfahrtszeit (plant)",
     "export.title.destination.location": "Ahnkunftsörtla",
+    "export.total": "Summe",
     "leaderboard.points": "Pünktla",
     "leaderboard.top": "Top",
     "leaderboard.no_data": "Vu dem Monet gaits leidr koa Toplischdn.",

--- a/resources/lang/de_he.json
+++ b/resources/lang/de_he.json
@@ -165,6 +165,7 @@
     "export.title.status": "Status",
     "export.title.stopovers": "Zwischenhalte",
     "export.title.type": "Fahrttyp",
+    "export.total": "Summe",
     "leaderboard.distance": "Reiseentfernung",
     "leaderboard.averagespeed": "Horddischigkeit",
     "leaderboard.duration": "Reisedauer",

--- a/resources/lang/de_pfl.json
+++ b/resources/lang/de_pfl.json
@@ -165,6 +165,7 @@
     "export.title.status": "Status",
     "export.title.stopovers": "Zwischehalte",
     "export.title.type": "Rääsetyp",
+    "export.total": "Summe",
     "leaderboard.distance": "Entfernung vun de Rääs",
     "leaderboard.averagespeed": "Schnellichkäät",
     "leaderboard.duration": "Rääsedauer",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -184,6 +184,7 @@
     "export.title.status": "Status",
     "export.title.stopovers": "Stopovers",
     "export.title.type": "Type",
+    "export.total": "Total",
     "leaderboard.distance": "Distance",
     "leaderboard.averagespeed": "Speed",
     "leaderboard.duration": "Duration",

--- a/resources/views/pdf/export-template.blade.php
+++ b/resources/views/pdf/export-template.blade.php
@@ -175,7 +175,7 @@
                         <td></td>
                         <td></td>
                         <td></td>
-                        <td style="font-style: italic;">Gesamt:</td>
+                        <td style="font-style: italic;">{{ __('export.total') }}:</td>
                         <td class="number-field">{{ $sum_duration }} min</td>
                         <td class="number-field">{{ number($sum_distance) }} km</td>
                         <td></td>

--- a/resources/views/pdf/export-template.blade.php
+++ b/resources/views/pdf/export-template.blade.php
@@ -62,7 +62,11 @@
             }
 
             .export-container table tr:nth-child(even) {
-                background: #EEE
+                background: #EEE;
+            }
+
+            .export-container table tfoot {
+                border-top: 4px double black;
             }
 
             .footer .page-number:after {
@@ -85,12 +89,16 @@
                 height: 50px;
             }
 
+            .number-field {
+                text-align: right;
+                white-space: nowrap;
+            }
+
             .right {
                 float: right;
             }
 
             .center {
-
                 text-align: center;
                 font-style: italic;
             }
@@ -101,12 +109,11 @@
         <div class="footer-wrapper">
             <div class="footer fixed-section">
                 <div class="right">
-                    <span class="page-number">{{ __('export.page') }}</span>
+                    <span class="page-number">{{ __('export.page') }} </span>
                 </div>
                 <div class="center">
-                    0 {{ __('export.reason.private') }} |
-                    1 {{ __('export.reason.business') }} |
-                    2 {{ __('export.reason.commute') }}
+                    *: 0- {{ __('export.reason.private') }} | 1- {{ __('export.reason.business') }} |
+                    2- {{ __('export.reason.commute') }}
                 </div>
                 <div class="left">
                     <span class="promo">
@@ -143,7 +150,7 @@
                         <th>{{ __('export.arrival') }}</th>
                         <th>{{ __('export.duration') }}</th>
                         <th>{{ __('export.kilometers') }}</th>
-                        <th>{{ __('export.reason') }}</th>
+                        <th>{{ __('export.reason') }}*</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -155,12 +162,25 @@
                             <td>{{ $status->trainCheckin->origin_stopover->departure_planned?->isoFormat(__('datetime-format')) }}</td>
                             <td>{{ $status->trainCheckin->Destination->name }}</td>
                             <td>{{ $status->trainCheckin->destination_stopover->arrival_planned?->isoFormat(__('datetime-format')) }}</td>
-                            <td>{{ $status->trainCheckin->duration }} min</td>
-                            <td>{{ number($status->trainCheckin->distance / 1000) }} km</td>
-                            <td><i>{{ $status->business->value }}</i></td>
+                            <td class="number-field">{{ $status->trainCheckin->duration }} min</td>
+                            <td class="number-field">{{ number($status->trainCheckin->distance / 1000) }} km</td>
+                            <td class="number-field"><i>{{ $status->business->value }}</i></td>
                         </tr>
                     @endforeach
                 </tbody>
+                <tfoot>
+                    <tr>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td style="font-style: italic;">Gesamt:</td>
+                        <td class="number-field">{{ $sum_duration }} min</td>
+                        <td class="number-field">{{ number($sum_distance) }} km</td>
+                        <td></td>
+                    </tr>
+                </tfoot>
             </table>
         </div>
 


### PR DESCRIPTION
This is my idea for the first part of #1174. There is no statistics regarding travel reasons, i don't know how we can implement that without kicking people who use the exporter for the Finanzamt.

<img width="1046" alt="image" src="https://user-images.githubusercontent.com/2796271/202900230-4f144bce-c2ed-4c05-b942-187e1c9dcf91.png">


Changes:
* Table Footer with summed numbers
* Duration and Distance are aligned to the right, and the unit will not wrap to the next line.
* Small Adjustments to the Reasons Footnote

Let me know what you think (: