### PR TITLE
:technologist: Add default status visibility to /auth/user

### DIFF
--- a/app/Http/Resources/UserBaseResource.php
+++ b/app/Http/Resources/UserBaseResource.php
@@ -33,11 +33,11 @@ class UserBaseResource extends JsonResource
             'preventIndex'    => $this->prevent_index,
             $this->mergeWhen(isset($this->UserSettingsResource),
                 [
-                    'role'          => $this->role,
-                    'home'          => $this->home,
-                    'dbl'           => $this->always_dbl,
-                    'language'      => $this->language,
-                    'defaultStatusVisibility' => $this->default_status_visibility
+                    'role'                      => $this->role,
+                    'home'                      => $this->home,
+                    'dbl'                       => $this->always_dbl,
+                    'language'                  => $this->language,
+                    'defaultStatusVisibility'   => $this->default_status_visibility
                 ]),
             $this->mergeWhen(isset($this->UserResource),
                 [

--- a/app/Http/Resources/UserBaseResource.php
+++ b/app/Http/Resources/UserBaseResource.php
@@ -37,7 +37,7 @@ class UserBaseResource extends JsonResource
                     'home'          => $this->home,
                     'dbl'           => $this->always_dbl,
                     'language'      => $this->language,
-                    'default_status_visibility' => $this->default_status_visibility
+                    'defaultStatusVisibility' => $this->default_status_visibility
                 ]),
             $this->mergeWhen(isset($this->UserResource),
                 [

--- a/app/Http/Resources/UserBaseResource.php
+++ b/app/Http/Resources/UserBaseResource.php
@@ -36,7 +36,8 @@ class UserBaseResource extends JsonResource
                     'role'          => $this->role,
                     'home'          => $this->home,
                     'dbl'           => $this->always_dbl,
-                    'language'      => $this->language
+                    'language'      => $this->language,
+                    'default_status_visibility' => $this->default_status_visibility
                 ]),
             $this->mergeWhen(isset($this->UserResource),
                 [


### PR DESCRIPTION
This could be useful for apps like träweldroid to pre-select the default value, simply passing in "null" as visibility doesn't fully work, as the ui wouldn't know which visibility to pre-select