### PR TITLE
🐛 Redirect to the intended url with social login providers

### DIFF
--- a/app/Http/Controllers/Frontend/Social/MastodonController.php
+++ b/app/Http/Controllers/Frontend/Social/MastodonController.php
@@ -23,7 +23,7 @@ class MastodonController extends Controller
      * @return SympfonyRedirectResponse|RedirectResponse
      */
     public function redirect(Request $request): SympfonyRedirectResponse|RedirectResponse {
-        $domain = MastodonBackend::formatDomain($request->input('domain') ?? '');
+        $domain    = MastodonBackend::formatDomain($request->input('domain') ?? '');
         $validator = Validator::make(['domain' => $domain], ['domain' => ['required', 'active_url']]);
         $validated = $validator->validate();
 

--- a/app/Http/Controllers/Frontend/Social/MastodonController.php
+++ b/app/Http/Controllers/Frontend/Social/MastodonController.php
@@ -76,10 +76,6 @@ class MastodonController extends Controller
             $user->update(['last_login' => Carbon::now()->toIso8601String()]);
         }
 
-        if (session()->has('url.intended')) {
-            return redirect()->to(session('url.intended'));
-        }
-
-        return redirect()->route('dashboard');
+        return redirect()->intended('/dashboard');
     }
 }

--- a/app/Http/Controllers/Frontend/Social/MastodonController.php
+++ b/app/Http/Controllers/Frontend/Social/MastodonController.php
@@ -76,6 +76,10 @@ class MastodonController extends Controller
             $user->update(['last_login' => Carbon::now()->toIso8601String()]);
         }
 
+        if (session()->has('url.intended')) {
+            return redirect()->to(session('url.intended'));
+        }
+
         return redirect()->route('dashboard');
     }
 }

--- a/app/Http/Controllers/Frontend/Social/TwitterController.php
+++ b/app/Http/Controllers/Frontend/Social/TwitterController.php
@@ -52,6 +52,7 @@ class TwitterController extends Controller
             $user->update(['last_login' => Carbon::now()->toIso8601String()]);
         }
 
+        // ToDo: Remove this if as soon as it's verified that nobody uses it or oAuth is implemented
         if ($request->query->get('return', 'none') === 'token') {
             $token = $request->user()->createToken('token');
             return response()->json([
@@ -59,6 +60,10 @@ class TwitterController extends Controller
                                         'expires_at' => $token->token->expires_at->toIso8601String(),
                                     ])
                              ->header('Authorization', $token->accessToken);
+        }
+
+        if (session()->has('url.intended')) {
+            return redirect()->to(session('url.intended'));
         }
 
         return redirect()->route('dashboard');

--- a/app/Http/Controllers/Frontend/Social/TwitterController.php
+++ b/app/Http/Controllers/Frontend/Social/TwitterController.php
@@ -62,10 +62,6 @@ class TwitterController extends Controller
                              ->header('Authorization', $token->accessToken);
         }
 
-        if (session()->has('url.intended')) {
-            return redirect()->to(session('url.intended'));
-        }
-
-        return redirect()->route('dashboard');
+        return redirect()->intended('/dashboard');
     }
 }


### PR DESCRIPTION
Fetch the intended url from the current session, so that the user is redirected back to it once they logged in via a social login provider (mastodon/twitteR)