### PR TITLE
:zap: Improve CI performance by running tests in parallel

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -47,4 +47,4 @@ jobs:
         env:
           DB_CONNECTION: sqlite
           DB_DATABASE: database/database.sqlite
-        run: php artisan test --coverage --min=36.5
+        run: php artisan test --parallel --coverage --min=36.5


### PR DESCRIPTION
See https://blog.laravel.com/laravel-parallel-testing-is-now-available

PHP Tests [now take ~2:20](https://github.com/Traewelling/traewelling/actions/runs/3577663474/jobs/6016920961) instead of the 3:30-5:00 before. 🎉