### PR TITLE
:bug: Fix ics generation when GET-Params are missing

### DIFF
--- a/app/Http/Controllers/Frontend/IcsController.php
+++ b/app/Http/Controllers/Frontend/IcsController.php
@@ -33,8 +33,8 @@ class IcsController extends Controller
                 limit:       $validated['limit'] ?? 1000,
                 from:        Carbon::parse($validated['from']),
                 until:       Carbon::parse($validated['until']),
-                useEmojis:   (bool) $validated['emojis'] ?? true,
-                useRealTime: (bool) $validated['realtime'] ?? false,
+                useEmojis:   $validated['emojis'] ?? true,
+                useRealTime: $validated['realtime'] ?? false,
             );
             return response($calendar->get())
                 ->header('Content-Type', 'text/calendar')


### PR DESCRIPTION
Today I like to create hotfixes for hotfixes. Sorry! :c 