### PR TITLE
:memo: Improve APIv1 structure and add documentation

### DIFF
--- a/app/Http/Controllers/API/v1/Controller.php
+++ b/app/Http/Controllers/API/v1/Controller.php
@@ -69,6 +69,10 @@ use Illuminate\Http\JsonResponse;
  *     description="Leaderboard related endpoints"
  * )
  * @OA\Tag(
+ *     name="Statistics",
+ *     description="Statistics related endpoints"
+ * )
+ * @OA\Tag(
  *     name="Settings",
  *     description="User/Profile-Settings"
  * )

--- a/app/Http/Controllers/API/v1/Controller.php
+++ b/app/Http/Controllers/API/v1/Controller.php
@@ -61,6 +61,10 @@ use Illuminate\Http\JsonResponse;
  *     description="Follow and unfollow users, manage your followers"
  * )
  * @OA\Tag(
+ *     name="Hide and Block",
+ *     description="Mute and block users"
+ * )
+ * @OA\Tag(
  *     name="Leaderboard",
  *     description="Leaderboard related endpoints"
  * )

--- a/app/Http/Controllers/API/v1/Controller.php
+++ b/app/Http/Controllers/API/v1/Controller.php
@@ -57,11 +57,11 @@ use Illuminate\Http\JsonResponse;
  *     description="Information regarding users"
  * )
  * @OA\Tag(
- *     name="Follow",
+ *     name="User/Follow",
  *     description="Follow and unfollow users, manage your followers"
  * )
  * @OA\Tag(
- *     name="Hide and Block",
+ *     name="User/Hide and Block",
  *     description="Mute and block users"
  * )
  * @OA\Tag(

--- a/app/Http/Controllers/API/v1/Controller.php
+++ b/app/Http/Controllers/API/v1/Controller.php
@@ -8,7 +8,7 @@ use Illuminate\Http\JsonResponse;
  * @OA\Info(
  *      version="1.0.0 - alpha",
  *      title="Träwelling API",
- *      description="Träwelling user API description. This is an incomplete documentation with still many errors.",
+ *      description="Träwelling user API description. This is an incomplete documentation with still many errors. The API is currently not yet stable. Endpoints are still being restructured. Both the URL and the request or body can be changed. Breaking changes will be announced on the Discord server: https://discord.gg/72t7564ZbV",
  *      @OA\Contact(
  *          email="support@traewelling.de"
  *      ),

--- a/app/Http/Controllers/API/v1/Controller.php
+++ b/app/Http/Controllers/API/v1/Controller.php
@@ -33,24 +33,36 @@ use Illuminate\Http\JsonResponse;
  *     description="Logging in, creating Accounts, etc."
  * )
  * @OA\Tag(
- *     name="User",
- *     description="Information regarding users"
- * )
- * @OA\Tag(
- *     name="Dashboard",
- *     description="API Endpoints of Dashboard"
- * )
- * @OA\Tag(
- *     name="Status",
- *     description="Endpoints for accessing and manipulating Statusses and their additional data"
+ *     name="Checkin",
+ *     description="Checkin related endpoints. Regular process is departures -> trip -> checkin"
  * )
  * @OA\Tag(
  *     name="Events",
  *     description="Events that users can check in to"
  * )
  * @OA\Tag(
+ *     name="Status",
+ *     description="Endpoints for accessing and manipulating Statusses and their additional data"
+ * )
+ * @OA\Tag(
+ *     name="Dashboard",
+ *     description="API Endpoints of Dashboard"
+ * )
+ * @OA\Tag(
  *     name="Likes",
  *     description="Likes regarding a single status"
+ * )
+ * @OA\Tag(
+ *     name="User",
+ *     description="Information regarding users"
+ * )
+ * @OA\Tag(
+ *     name="Follow",
+ *     description="Follow and unfollow users, manage your followers"
+ * )
+ * @OA\Tag(
+ *     name="Leaderboard",
+ *     description="Leaderboard related endpoints"
  * )
  * @OA\Tag(
  *     name="Settings",

--- a/app/Http/Controllers/API/v1/FollowController.php
+++ b/app/Http/Controllers/API/v1/FollowController.php
@@ -158,8 +158,8 @@ class FollowController extends Controller
 
     /**
      * @OA\Get(
-     *      path="/settings/followers",
-     *      operationId="getFollowers",
+     *      path="/settings/follow-requests",
+     *      operationId="getFollowRequests",
      *      tags={"User", "Settings"},
      *      summary="List all followers",
      *      @OA\Response(

--- a/app/Http/Controllers/API/v1/FollowController.php
+++ b/app/Http/Controllers/API/v1/FollowController.php
@@ -20,7 +20,43 @@ use InvalidArgumentException;
 
 class FollowController extends Controller
 {
-
+    /**
+     * @OA\Post(
+     *      path="/user/createFollow",
+     *      operationId="createFollow",
+     *      tags={"User"},
+     *      summary="Follow a user",
+     *      @OA\RequestBody(
+     *          required=true,
+     *          @OA\JsonContent(
+     *              @OA\Property(
+     *                  property="userId",
+     *                  title="userId",
+     *                  format="int64",
+     *                  description="ID of the to-be-followed user",
+     *                  example=1
+     *              )
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=201,
+     *          description="successful operation",
+     *          @OA\JsonContent(ref="#/components/schemas/User")
+     *       ),
+     *       @OA\Response(response=400, description="Bad request"),
+     *       @OA\Response(response=409, description="Already following"),
+     *       @OA\Response(response=403, description="User is blocked"),
+     *       security={
+     *           {"token": {}},
+     *           {}
+     *       }
+     *     )
+     *
+     * @param Request          $request
+     * @param FollowController $instance
+     *
+     * @return JsonResponse
+     */
     public static function createFollow(Request $request, FollowController $instance): JsonResponse {
         $validated    = $request->validate(['userId' => ['required', 'exists:users,id']]);
         $userToFollow = User::find($validated['userId']);

--- a/app/Http/Controllers/API/v1/FollowController.php
+++ b/app/Http/Controllers/API/v1/FollowController.php
@@ -130,7 +130,7 @@ class FollowController extends Controller
      * @OA\Get(
      *      path="/settings/followers",
      *      operationId="getFollowers",
-     *      tags={"Follow", "Settings"},
+     *      tags={"User/Follow", "Settings"},
      *      summary="List all followers",
      *      @OA\Response(
      *          response=200,
@@ -164,7 +164,7 @@ class FollowController extends Controller
      * @OA\Get(
      *      path="/settings/follow-requests",
      *      operationId="getFollowRequests",
-     *      tags={"Follow", "Settings"},
+     *      tags={"User/Follow", "Settings"},
      *      summary="List all followers",
      *      @OA\Response(
      *          response=200,
@@ -195,7 +195,7 @@ class FollowController extends Controller
      * @OA\Get(
      *      path="/settings/followings",
      *      operationId="getFollowings",
-     *      tags={"Follow", "Settings"},
+     *      tags={"User/Follow", "Settings"},
      *      summary="List all users the current user is following",
      *      @OA\Response(
      *          response=200,

--- a/app/Http/Controllers/API/v1/FollowController.php
+++ b/app/Http/Controllers/API/v1/FollowController.php
@@ -73,6 +73,42 @@ class FollowController extends Controller
         }
     }
 
+    /**
+     * @OA\Delete(
+     *      path="/user/destroyFollow",
+     *      operationId="destroyFollow",
+     *      tags={"User"},
+     *      summary="Unfollow a user",
+     *      @OA\RequestBody(
+     *          required=true,
+     *          @OA\JsonContent(
+     *              @OA\Property(
+     *                  property="userId",
+     *                  title="userId",
+     *                  format="int64",
+     *                  description="ID of the to-be-unfollowed user",
+     *                  example=1
+     *              )
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=201,
+     *          description="successful operation",
+     *          @OA\JsonContent(ref="#/components/schemas/User")
+     *       ),
+     *       @OA\Response(response=400, description="Bad request"),
+     *       @OA\Response(response=409, description="Already following"),
+     *       security={
+     *           {"token": {}},
+     *           {}
+     *       }
+     *     )
+     *
+     * @param Request          $request
+     * @param FollowController $instance
+     *
+     * @return JsonResponse
+     */
     public static function destroyFollow(Request $request, FollowController $instance): JsonResponse {
         $validated      = $request->validate(['userId' => ['required', 'exists:users,id']]);
         $userToUnfollow = User::find($validated['userId']);

--- a/app/Http/Controllers/API/v1/FollowController.php
+++ b/app/Http/Controllers/API/v1/FollowController.php
@@ -26,7 +26,7 @@ class FollowController extends Controller
      * @OA\Post(
      *      path="/user/createFollow",
      *      operationId="createFollow",
-     *      tags={"Follow"},
+     *      tags={"User/Follow"},
      *      summary="Follow a user",
      *      @OA\RequestBody(
      *          required=true,
@@ -80,7 +80,7 @@ class FollowController extends Controller
      * @OA\Delete(
      *      path="/user/destroyFollow",
      *      operationId="destroyFollow",
-     *      tags={"Follow"},
+     *      tags={"User/Follow"},
      *      summary="Unfollow a user",
      *      @OA\RequestBody(
      *          required=true,
@@ -226,7 +226,7 @@ class FollowController extends Controller
      * @OA\Delete(
      *      path="/user/removeFollower",
      *      operationId="removeFollower",
-     *      tags={"Follow"},
+     *      tags={"User/Follow"},
      *      summary="Remove a follower",
      *      @OA\RequestBody(
      *          required=true,
@@ -282,7 +282,7 @@ class FollowController extends Controller
      * @OA\Put(
      *     path="/user/acceptFollowRequest",
      *     operationId="acceptFollowRequest",
-     *     tags={"Follow"},
+     *     tags={"User/Follow"},
      *     summary="Accept a follow request",
      *     @OA\RequestBody(
      *     required=true,
@@ -332,7 +332,7 @@ class FollowController extends Controller
      * @OA\Delete(
      *      path="/user/rejectFollowRequest",
      *      operationId="rejectFollowRequest",
-     *      tags={"Follow"},
+     *      tags={"User/Follow"},
      *      summary="Reject a follow request",
      *      @OA\RequestBody(
      *          required=true,

--- a/app/Http/Controllers/API/v1/FollowController.php
+++ b/app/Http/Controllers/API/v1/FollowController.php
@@ -175,8 +175,6 @@ class FollowController extends Controller
      *              @OA\Property(property="meta", ref="#/components/schemas/PaginationMeta"),
      *          )
      *       ),
-     *       @OA\Response(response=400, description="Bad request"),
-     *       @OA\Response(response=409, description="Already following"),
      *       security={
      *           {"token": {}},
      *           {}
@@ -189,6 +187,33 @@ class FollowController extends Controller
         return UserResource::collection(FollowBackend::getFollowRequests(user: auth()->user()));
     }
 
+    /**
+     * @OA\Get(
+     *      path="/settings/followings",
+     *      operationId="getFollowings",
+     *      tags={"User", "Settings"},
+     *      summary="List all users the current user is following",
+     *      @OA\Response(
+     *          response=200,
+     *          description="successful operation",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="data", type="array",
+     *                  @OA\Items(
+     *                      ref="#/components/schemas/User"
+     *                  )
+     *              ),
+     *              @OA\Property(property="links", ref="#/components/schemas/Links"),
+     *              @OA\Property(property="meta", ref="#/components/schemas/PaginationMeta"),
+     *          )
+     *       ),
+     *       security={
+     *           {"token": {}},
+     *           {}
+     *       }
+     *     )
+     *
+     * @return AnonymousResourceCollection
+     */
     public function getFollowings(): AnonymousResourceCollection {
         return UserResource::collection(FollowBackend::getFollowings(user: auth()->user()));
     }

--- a/app/Http/Controllers/API/v1/FollowController.php
+++ b/app/Http/Controllers/API/v1/FollowController.php
@@ -26,7 +26,7 @@ class FollowController extends Controller
      * @OA\Post(
      *      path="/user/createFollow",
      *      operationId="createFollow",
-     *      tags={"User"},
+     *      tags={"Follow"},
      *      summary="Follow a user",
      *      @OA\RequestBody(
      *          required=true,
@@ -43,7 +43,9 @@ class FollowController extends Controller
      *      @OA\Response(
      *          response=201,
      *          description="successful operation",
-     *          @OA\JsonContent(ref="#/components/schemas/User")
+     *          @OA\JsonContent(
+     *              @OA\Property(property="data", type="object", ref="#/components/schemas/User")
+     *         )
      *       ),
      *       @OA\Response(response=400, description="Bad request"),
      *       @OA\Response(response=409, description="Already following"),
@@ -78,7 +80,7 @@ class FollowController extends Controller
      * @OA\Delete(
      *      path="/user/destroyFollow",
      *      operationId="destroyFollow",
-     *      tags={"User"},
+     *      tags={"Follow"},
      *      summary="Unfollow a user",
      *      @OA\RequestBody(
      *          required=true,
@@ -93,9 +95,11 @@ class FollowController extends Controller
      *          )
      *      ),
      *      @OA\Response(
-     *          response=201,
+     *          response=200,
      *          description="successful operation",
-     *          @OA\JsonContent(ref="#/components/schemas/User")
+     *          @OA\JsonContent(
+     *              @OA\Property(property="data", type="object", ref="#/components/schemas/User")
+     *          )
      *       ),
      *       @OA\Response(response=400, description="Bad request"),
      *       @OA\Response(response=409, description="Already following"),
@@ -126,7 +130,7 @@ class FollowController extends Controller
      * @OA\Get(
      *      path="/settings/followers",
      *      operationId="getFollowers",
-     *      tags={"User", "Settings"},
+     *      tags={"Follow", "Settings"},
      *      summary="List all followers",
      *      @OA\Response(
      *          response=200,
@@ -160,7 +164,7 @@ class FollowController extends Controller
      * @OA\Get(
      *      path="/settings/follow-requests",
      *      operationId="getFollowRequests",
-     *      tags={"User", "Settings"},
+     *      tags={"Follow", "Settings"},
      *      summary="List all followers",
      *      @OA\Response(
      *          response=200,
@@ -191,7 +195,7 @@ class FollowController extends Controller
      * @OA\Get(
      *      path="/settings/followings",
      *      operationId="getFollowings",
-     *      tags={"User", "Settings"},
+     *      tags={"Follow", "Settings"},
      *      summary="List all users the current user is following",
      *      @OA\Response(
      *          response=200,
@@ -222,7 +226,7 @@ class FollowController extends Controller
      * @OA\Delete(
      *      path="/user/removeFollower",
      *      operationId="removeFollower",
-     *      tags={"User"},
+     *      tags={"Follow"},
      *      summary="Remove a follower",
      *      @OA\RequestBody(
      *          required=true,
@@ -255,12 +259,7 @@ class FollowController extends Controller
      * @return JsonResponse
      */
     public function removeFollower(Request $request): JsonResponse {
-        $validated = $request->validate([
-                                            'userId' => [
-                                                'required',
-                                                Rule::in(auth()->user()->followers->pluck('user_id')),
-                                            ]
-                                        ]);
+        $validated = $request->validate(['userId' => ['required',]]);
         try {
             $follow = Follow::where('user_id', $validated['userId'])
                             ->where('follow_id', auth()->user()->id)
@@ -283,7 +282,7 @@ class FollowController extends Controller
      * @OA\Put(
      *     path="/user/acceptFollowRequest",
      *     operationId="acceptFollowRequest",
-     *     tags={"User"},
+     *     tags={"Follow"},
      *     summary="Accept a follow request",
      *     @OA\RequestBody(
      *     required=true,
@@ -316,12 +315,7 @@ class FollowController extends Controller
      * @return JsonResponse
      */
     public function approveFollowRequest(Request $request): JsonResponse {
-        $validated = $request->validate([
-                                            'userId' => [
-                                                'required',
-                                                Rule::in(auth()->user()->followRequests->pluck('user_id'))
-                                            ]
-                                        ]);
+        $validated = $request->validate(['userId' => ['required',]]);
 
         try {
             FollowBackend::approveFollower(auth()->user()->id, $validated['userId']);
@@ -338,7 +332,7 @@ class FollowController extends Controller
      * @OA\Delete(
      *      path="/user/rejectFollowRequest",
      *      operationId="rejectFollowRequest",
-     *      tags={"User"},
+     *      tags={"Follow"},
      *      summary="Reject a follow request",
      *      @OA\RequestBody(
      *          required=true,
@@ -370,12 +364,7 @@ class FollowController extends Controller
      * @return JsonResponse
      */
     public function rejectFollowRequest(Request $request): JsonResponse {
-        $validated = $request->validate([
-                                            'userId' => [
-                                                'required',
-                                                Rule::in(auth()->user()->followRequests->pluck('user_id'))
-                                            ]
-                                        ]);
+        $validated = $request->validate(['userId' => ['required',]]);
         try {
             FollowBackend::rejectFollower(auth()->user()->id, $validated['userId']);
             return $this->sendResponse();

--- a/app/Http/Controllers/API/v1/LikesController.php
+++ b/app/Http/Controllers/API/v1/LikesController.php
@@ -9,6 +9,8 @@ use App\Http\Resources\UserResource;
 use App\Models\Like;
 use App\Models\Status;
 use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Facades\Auth;
@@ -61,12 +63,39 @@ class LikesController extends Controller
     }
 
     /**
-     *
+     * @OA\Post(
+     *      path="/status/{id}/like",
+     *      operationId="addLikeToStatus",
+     *      tags={"Likes"},
+     *      summary="Add like to status",
+     *      description="Add like to status",
+     *      @OA\Parameter (
+     *          name="id",
+     *          in="path",
+     *          description="Status-ID",
+     *          example=1337,
+     *          @OA\Schema(type="integer")
+     *      ),
+     *      @OA\Response(
+     *          response=201,
+     *          description="successful operation",
+     *          @OA\JsonContent(
+     *                      ref="#/components/schemas/SuccessResponse"
+     *          )
+     *       ),
+     *       @OA\Response(response=400, description="Bad request"),
+     *       @OA\Response(response=403, description="User not authorized to access this status"),
+     *       @OA\Response(response=404, description="No status found for this id"),
+     *       @OA\Response(response=409, description="Status already liked by user"),
+     *       security={
+     *           {"token": {}},
+     *           {}
+     *       }
+     *     )
      *
      * @param int $statusId
      *
      * @return JsonResponse
-     * @throws PermissionException
      */
     public function create(int $statusId): JsonResponse {
         try {
@@ -75,10 +104,42 @@ class LikesController extends Controller
             return $this->sendResponse(code: 201);
         } catch (StatusAlreadyLikedException) {
             return $this->sendError(code: 409);
+        } catch (PermissionException) {
+            return $this->sendError(code: 403);
+        } catch (ModelNotFoundException) {
+            return $this->sendError(code: 404);
         }
     }
 
     /**
+     * @OA\Delete(
+     *      path="/status/{id}/like",
+     *      operationId="removeLikeFromStatus",
+     *      tags={"Likes"},
+     *      summary="Remove like from status",
+     *      description="Removes like from status",
+     *      @OA\Parameter (
+     *          name="id",
+     *          in="path",
+     *          description="Status-ID",
+     *          example=1337,
+     *          @OA\Schema(type="integer")
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="successful operation",
+     *          @OA\JsonContent(
+     *                      ref="#/components/schemas/SuccessResponse"
+     *          )
+     *       ),
+     *       @OA\Response(response=400, description="Bad request"),
+     *       @OA\Response(response=404, description="No status found for this id"),
+     *       security={
+     *           {"token": {}},
+     *           {}
+     *       }
+     *     )
+     *
      * @param int $statusId
      *
      * @return JsonResponse
@@ -88,7 +149,7 @@ class LikesController extends Controller
             StatusBackend::destroyLike(Auth::user(), $statusId);
             return $this->sendResponse();
         } catch (InvalidArgumentException) {
-            return $this->sendError();
+            return $this->sendError('No status found for this id', 404);
         }
     }
 }

--- a/app/Http/Controllers/API/v1/LikesController.php
+++ b/app/Http/Controllers/API/v1/LikesController.php
@@ -20,7 +20,7 @@ class LikesController extends Controller
 {
     /**
      * @OA\Get(
-     *      path="/statuses/{id}/likedby",
+     *      path="/status/{id}/likes",
      *      operationId="getLikesForStatus",
      *      tags={"Likes"},
      *      summary="[Auth optional] Get likes for status",

--- a/app/Http/Controllers/API/v1/LikesController.php
+++ b/app/Http/Controllers/API/v1/LikesController.php
@@ -61,6 +61,8 @@ class LikesController extends Controller
     }
 
     /**
+     *
+     *
      * @param int $statusId
      *
      * @return JsonResponse

--- a/app/Http/Controllers/API/v1/PrivacyPolicyController.php
+++ b/app/Http/Controllers/API/v1/PrivacyPolicyController.php
@@ -36,6 +36,22 @@ class PrivacyPolicyController extends Controller
         return new PrivacyPolicyResource(PrivacyBackend::getCurrentPrivacyPolicy());
     }
 
+    /**
+     * @OA\Post(
+     *     path="/settings/acceptPrivacy",
+     *     tags={"Settings"},
+     *     summary="Accept the current privacy policy",
+     *     description="Accept the current privacy policy",
+     *     @OA\Response(response=204, description="Success"),
+     *     @OA\Response(response=400, description="Already accepted"),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     security={
+     *           {"token": {}},
+     *           {}
+     *     }
+     * )
+     * @return JsonResponse
+     */
     public function acceptPrivacyPolicy(): JsonResponse {
         try {
             PrivacyBackend::acceptPrivacyPolicy(user: auth()->user());
@@ -44,7 +60,7 @@ class PrivacyPolicyController extends Controller
                 'ptime' => $exception->getPrivacyValidity(),
                 'utime' => $exception->getUserAccepted()
             ]);
-            return $this->sendError(error: $error);
+            return $this->sendError(error: $error, code: 409);
         }
 
         return $this->sendResponse(code: 204);

--- a/app/Http/Controllers/API/v1/PrivacyPolicyController.php
+++ b/app/Http/Controllers/API/v1/PrivacyPolicyController.php
@@ -9,6 +9,29 @@ use Illuminate\Http\JsonResponse;
 
 class PrivacyPolicyController extends Controller
 {
+    /**
+     * @OA\Get(
+     *     path="/static/privacy",
+     *     tags={"Settings"},
+     *     summary="Get the current privacy policy",
+     *     description="Get the current privacy policy",
+     *     @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(
+     *                  property="data",
+     *                  type="object",
+     *                  @OA\Property(property="validFrom", example="2022-01-05T16:26:14.000000Z"),
+     *                  @OA\Property(property="en", example="This is the english privacy policy"),
+     *                  @OA\Property(property="de", example="Dies ist die deutsche Datenschutzerklärung"),
+     *              )
+     *         )
+     *     )
+     * )
+     *
+     * @return PrivacyPolicyResource
+     */
     public function getPrivacyPolicy(): PrivacyPolicyResource {
         return new PrivacyPolicyResource(PrivacyBackend::getCurrentPrivacyPolicy());
     }

--- a/app/Http/Controllers/API/v1/StatisticsController.php
+++ b/app/Http/Controllers/API/v1/StatisticsController.php
@@ -223,9 +223,17 @@ class StatisticsController extends Controller
      *                                                          minutes"),
      *                    )
      *               ),
+     *            ),
+     *            @OA\Property(
+     *                property="meta",
+     *                type="object",
+     *                @OA\Property(property="from", example="2021-01-01T00:00:00.000000Z"),
+     *                @OA\Property(property="until", example="2021-02-01T00:00:00.000000Z"),
      *            )
      *        )
      *    ),
+     *     @OA\Response(response=400, description="Bad request"),
+     *     @OA\Response(response=401, description="Unauthorized"),
      *     security={
      *     {"token": {}},
      *     {}

--- a/app/Http/Controllers/API/v1/StatisticsController.php
+++ b/app/Http/Controllers/API/v1/StatisticsController.php
@@ -14,6 +14,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Validation\Rule;
+use OpenApi\Annotations as OA;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class StatisticsController extends Controller
@@ -152,6 +153,84 @@ class StatisticsController extends Controller
     }
 
     /**
+     * @OA\Get(
+     *     path="/statistics",
+     *     operationId="getStatistics",
+     *     tags={"Statistics"},
+     *     summary="Get personal statistics",
+     *     @OA\Property(
+     *         property="from",
+     *         description="Start date for the statistics",
+     *         example="2021-01-01T00:00:00.000Z",
+     *         type="string",
+     *         format="date-time"
+     *     ),
+     *     @OA\Property(
+     *         property="until",
+     *         description="End date for the statistics",
+     *         example="2021-02-01T00:00:00.000Z",
+     *         type="string",
+     *         format="date-time"
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @OA\JsonContent(
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="object",
+     *                 @OA\Property(
+     *                      property="purpose",
+     *                      description="The purpose of travel",
+     *                      type="array",
+     *                      @OA\Items(
+     *                          @OA\Property(property="name", ref="#/components/schemas/BusinessEnum"),
+     *                          @OA\Property(property="count", type="integer", example=11),
+     *                          @OA\Property(property="duration", type="integer", example=425, description="Duration in
+     *                                                            minutes"),
+     *                      )
+     *                ),
+     *                @OA\Property(
+     *                    property="categories",
+     *                    description="The categories of the travel",
+     *                    type="array",
+     *                    @OA\Items(
+     *                        @OA\Property(property="name", ref="#/components/schemas/TrainCategoryEnum"),
+     *                        @OA\Property(property="count", type="integer", example=11),
+     *                        @OA\Property(property="duration", type="integer", example=425, description="Duration in
+     *                                                          minutes"),
+     *                    )
+     *                ),
+     *                @OA\Property(
+     *                    property="operators",
+     *                    description="The operators of the means of transport",
+     *                    type="array",
+     *                    @OA\Items(
+     *                        @OA\Property(property="name", example="Gertruds Verkehrsgesellschaft mbH"),
+     *                        @OA\Property(property="count", type="integer", example=10),
+     *                        @OA\Property(property="duration", type="integer", example=424, description="Duration in
+     *                                                          minutes"),
+     *                    )
+     *                ),
+     *                @OA\Property(
+     *                    property="time",
+     *                    description="Shows the daily travel volume",
+     *                    type="array",
+     *                    @OA\Items(
+     *                        @OA\Property(property="date", type="string", example="2021-01-01T00:00:00.000Z"),
+     *                        @OA\Property(property="count", type="integer", example=10),
+     *                        @OA\Property(property="duration", type="integer", example=424, description="Duration in
+     *                                                          minutes"),
+     *                    )
+     *               ),
+     *            )
+     *        )
+     *    ),
+     *     security={
+     *     {"token": {}},
+     *     {}
+     *     }
+     * )
      * @param Request $request
      *
      * @return JsonResponse

--- a/app/Http/Controllers/API/v1/StatisticsController.php
+++ b/app/Http/Controllers/API/v1/StatisticsController.php
@@ -276,6 +276,55 @@ class StatisticsController extends Controller
         return $this->sendResponse(data: $returnData, additional: $additionalData);
     }
 
+    /**
+     * @OA\Get(
+     *     path="/statistics/global",
+     *     operationId="getGlobalStatistics",
+     *     tags={"Statistics"},
+     *     summary="Get global statistics of the last 4 weeks",
+     *     @OA\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @OA\JsonContent(
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="object",
+     *                 @OA\Property(
+     *                     property="distance",
+     *                     description="Globally travelled distance in meters",
+     *                     type="integer",
+     *                     example=1000
+     *                 ),
+     *                 @OA\Property(
+     *                     property="duration",
+     *                     description="Globally travelled duration in minutes",
+     *                     type="integer",
+     *                     example=1000
+     *                 ),
+     *                 @OA\Property(
+     *                     property="activeUsers",
+     *                     description="Number of active users",
+     *                     type="integer",
+     *                     example=1000
+     *                ),
+     *           @OA\Property(
+     *               property="meta",
+     *               type="object",
+     *               @OA\Property(property="from", example="2021-01-01T00:00:00.000000Z"),
+     *               @OA\Property(property="until", example="2021-02-01T00:00:00.000000Z"),
+     *           ),
+     *        )
+     *      ),
+     *     ),
+     *     security={
+     *        {"token": {}},
+     *        {}
+     *     }
+     *     )
+     *
+     *
+     * @return JsonResponse
+     */
     public function getGlobalStatistics(): JsonResponse {
         $from  = Carbon::now()->subWeeks(4);
         $until = Carbon::now();

--- a/app/Http/Controllers/API/v1/StatusController.php
+++ b/app/Http/Controllers/API/v1/StatusController.php
@@ -180,7 +180,7 @@ class StatusController extends Controller
 
     /**
      * @OA\Get(
-     *      path="/statuses/{id}",
+     *      path="/status/{id}",
      *      operationId="getSingleStatus",
      *      tags={"Status"},
      *      summary="[Auth optional] Get single statuses",

--- a/app/Http/Controllers/API/v1/StatusController.php
+++ b/app/Http/Controllers/API/v1/StatusController.php
@@ -256,13 +256,13 @@ class StatusController extends Controller
      *       }
      *     )
      *
-     * @param int $id
+     * @param int $statusId
      *
      * @return JsonResponse
      */
-    public function destroy(int $id): JsonResponse {
+    public function destroy(int $statusId): JsonResponse {
         try {
-            StatusBackend::DeleteStatus(Auth::user(), $id);
+            StatusBackend::DeleteStatus(Auth::user(), $statusId);
             return $this->sendResponse();
         } catch (PermissionException) {
             return $this->sendError('You are not allowed to delete this status.', 403);

--- a/app/Http/Controllers/API/v1/StatusController.php
+++ b/app/Http/Controllers/API/v1/StatusController.php
@@ -228,7 +228,7 @@ class StatusController extends Controller
 
     /**
      * @OA\Delete(
-     *      path="/statuses/{id}",
+     *      path="/status/{id}",
      *      operationId="destroySingleStatus",
      *      tags={"Status"},
      *      summary="Destroy a status",
@@ -274,7 +274,7 @@ class StatusController extends Controller
 
     /**
      * @OA\Put(
-     *      path="/statuses/{id}",
+     *      path="/status/{id}",
      *      operationId="updateSingleStatus",
      *      tags={"Status"},
      *      summary="Update a status",

--- a/app/Http/Controllers/API/v1/StatusController.php
+++ b/app/Http/Controllers/API/v1/StatusController.php
@@ -263,13 +263,12 @@ class StatusController extends Controller
     public function destroy(int $id): JsonResponse {
         try {
             StatusBackend::DeleteStatus(Auth::user(), $id);
+            return $this->sendResponse();
         } catch (PermissionException) {
-            abort(403);
+            return $this->sendError('You are not allowed to delete this status.', 403);
         } catch (ModelNotFoundException) {
-            abort(404);
+            return $this->sendError('No status found for this id.');
         }
-
-        return $this->sendResponse();
     }
 
     /**

--- a/app/Http/Controllers/API/v1/TransportController.php
+++ b/app/Http/Controllers/API/v1/TransportController.php
@@ -32,6 +32,111 @@ use OpenApi\Annotations as OA;
 class TransportController extends Controller
 {
     /**
+     * @OA\Get(
+     *     path="/trains/station/{name}/departures",
+     *     operationId="getDepartures",
+     *     tags={"Checkin"},
+     *     summary="Get departures from a station",
+     *     description="Get departures from a station",
+     *     @OA\Parameter(
+     *         name="name",
+     *         in="path",
+     *         description="Name of the station (replace slashes with spaces)",
+     *         required=true,
+     *     ),
+     *     @OA\Parameter(
+     *         name="when",
+     *         in="query",
+     *         description="When to get the departures (default: now)",
+     *         required=false,
+     *         @OA\Schema(
+     *             type="string",
+     *             format="date-time",
+     *             example="2020-01-01T12:00:00.000Z"
+     *         )
+     *     ),
+     *     @OA\Parameter(
+     *         name="travelType",
+     *         in="query",
+     *         description="Means of transport (default: all)",
+     *         required=false,
+     *         @OA\Schema(
+     *          ref="#/components/schemas/TravelTypeEnum"
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successful operation",
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(
+     *                     externalDocs="https://v5.db.transport.rest/api.html#get-stopsiddepartures",
+     *                     description="HAFAS Train model. This model might be subject to unexpected changes. See also
+     *                     external documentation at
+     *                     [https://v5.db.transport.rest/api.html#get-stopsiddepartures](https://v5.db.transport.rest/api.html#get-stopsiddepartures).",
+     *                     example={ "tripId": "1|200513|0|81|6012023", "stop": { "type": "stop", "id": "8000191",
+     *                     "name": "Karlsruhe Hbf", "location": { "type": "location", "id": "8000191", "latitude":
+     *                     48.99353, "longitude": 8.401939 }, "products": { "nationalExpress": true, "national": true,
+     *                     "regionalExp": true, "regional": true, "suburban": true, "bus": true, "ferry": false,
+     *                     "subway": false, "tram": true, "taxi": true } }, "when": "2023-01-06T13:49:00+01:00",
+     *                     "plannedWhen": "2023-01-06T13:49:00+01:00", "delay": null, "platform": "2",
+     *                     "plannedPlatform": "2", "direction": "Zürich HB", "provenance": null, "line": { "type":
+     *                     "line", "id": "ec-9", "fahrtNr": "9", "name": "EC 9", "public": true, "adminCode": "80____", "productName": "EC", "mode": "train", "product": "national", "operator": { "type": "operator", "id": "db-fernverkehr-ag", "name": "DB Fernverkehr AG" } }, "remarks": null, "origin": null, "destination": { "type": "stop", "id": "8503000", "name": "Zürich HB", "location": { "type": "location", "id": "8503000", "latitude": 47.378177, "longitude": 8.540211 }, "products": { "nationalExpress": true, "national": true, "regionalExp": true, "regional": true, "suburban": true, "bus": true, "ferry": false, "subway": false, "tram": true, "taxi": false } }, "currentTripPosition": { "type": "location", "latitude": 48.725382, "longitude": 8.142888 }, "loadFactor": "high", "station": { "id": 5181, "ibnr": 8000191, "rilIdentifier": "RK", "name": "Karlsruhe Hbf", "latitude": "48.993530", "longitude": "8.401939" } }
+     *                 )
+     *            ),
+     *            @OA\Property(
+     *              property="meta",
+     *              type="object",
+     *              @OA\Property(
+     *                  property="station",
+     *                  ref="#/components/schemas/TrainStation"
+     *              ),
+     *              @OA\Property(
+     *                  property="times",
+     *                 type="object",
+     *                 @OA\Property(
+     *                     property="now",
+     *                     type="string",
+     *                     format="date-time",
+     *                     example="2020-01-01T12:00:00.000Z"
+     *                ),
+     *                @OA\Property(
+     *                    property="prev",
+     *                    type="string",
+     *                    format="date-time",
+     *                    example="2020-01-01T11:45:00.000Z"
+     *               ),
+     *               @OA\Property(
+     *                   property="next",
+     *                   type="string",
+     *                   format="date-time",
+     *                   example="2020-01-01T12:15:00.000Z"
+     *              )
+     *         )
+     *         )
+     *        )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Station not found",
+     *     ),
+     *     @OA\Response(
+     *         response=502,
+     *         description="Error with our data provider",
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Invalid input",
+     *     ),
+     *     security={
+     *        {"token": {}},
+     *        {}
+     *     }
+     * )
+     *
      * @param Request $request
      * @param string  $name
      *
@@ -51,7 +156,7 @@ class TransportController extends Controller
                 travelType:   TravelType::tryFrom($validated['travelType'] ?? null),
             );
         } catch (HafasException) {
-            return $this->sendError(__('messages.exception.generalHafas', [], 'en'), 400);
+            return $this->sendError(__('messages.exception.generalHafas', [], 'en'), 502);
         } catch (ModelNotFoundException) {
             return $this->sendError(__('controller.transport.no-station-found', [], 'en'));
         }

--- a/app/Http/Controllers/API/v1/TransportController.php
+++ b/app/Http/Controllers/API/v1/TransportController.php
@@ -64,11 +64,68 @@ class TransportController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *      path="/trains/trip",
+     *      operationId="getTrainTrip",
+     *      tags={"Checkin"},
+     *      summary="Get the stopovers and trip information for a given train",
+     *      @OA\Parameter(
+     *          name="tripId",
+     *          in="query",
+     *          description="HAFAS trip ID (fetched from departures)",
+     *          example="1|323306|1|80|17072022",
+     *          required=true
+     *     ),
+     *     @OA\Parameter(
+     *          name="lineName",
+     *          in="query",
+     *          description="line name for that train",
+     *          example="S 4",
+     *          required=true
+     *     ),
+     *     @OA\Parameter(
+     *          name="start",
+     *          in="query",
+     *          description="start point from where the stopovers should be desplayed",
+     *          example=4711,
+     *          required=true
+     *     ),
+     *     @OA\Response(
+     *          response=200,
+     *          description="successful operation",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="int64", example=1),
+     *                  @OA\Property(property="category", ref="#/components/schemas/TrainCategoryEnum"),
+     *                  @OA\Property(property="number", type="string", example="4-a6s4-4"),
+     *                  @OA\Property(property="lineName", type="string", example="S 4"),
+     *                  @OA\Property(property="origin", ref="#/components/schemas/TrainStation"),
+     *                  @OA\Property(property="destination", ref="#/components/schemas/TrainStation"),
+     *                  @OA\Property(property="stopovers", type="array",
+     *                      @OA\Items(
+     *                          ref="#/components/schemas/TrainStopover"
+     *                      )
+     *                  ),
+     *              )
+     *          )
+     *       ),
+     *       @OA\Response(response=400, description="Bad request"),
+     *       @OA\Response(response=401, description="Unauthorized"),
+     *       @OA\Response(response=404, description="No station found"),
+     *       @OA\Response(response=503, description="There has been an error with our data provider"),
+     *       security={
+     *          {"token": {}},
+     *          {}
+     *       }
+     *     )
+     */
     public function getTrip(Request $request): JsonResponse {
         $validated = $request->validate([
-                                            'tripId'   => ['required', 'string'],
-                                            'lineName' => ['required', 'string'],
-                                            'start'    => ['required', 'numeric', 'gt:0'],
+                                            'tripId'      => ['required_unless:hafasTripId,null', 'string'],
+                                            'hafasTripId' => ['required_unless:tripId,null', 'string'],
+                                            'lineName'    => ['required', 'string'],
+                                            'start'       => ['required', 'numeric', 'gt:0'],
                                         ]);
 
         try {
@@ -171,7 +228,6 @@ class TransportController extends Controller
      *           {}
      *       }
      *     )
-     * @TODO document the responses
      *
      * @param Request $request
      *
@@ -265,7 +321,8 @@ class TransportController extends Controller
      *      operationId="trainStationAutocomplete",
      *      tags={"Checkin"},
      *      summary="Autocomplete for trainstations",
-     *      description="This request returns an array of max. 10 station objects matching the query. **CAUTION:** All slashes (as well as encoded to %2F) in {query} need to be replaced, preferrably by a space (%20)",
+     *      description="This request returns an array of max. 10 station objects matching the query. **CAUTION:** All
+     *      slashes (as well as encoded to %2F) in {query} need to be replaced, preferrably by a space (%20)",
      *      @OA\Parameter(
      *          name="query",
      *          in="path",

--- a/app/Http/Controllers/API/v1/TransportController.php
+++ b/app/Http/Controllers/API/v1/TransportController.php
@@ -229,7 +229,7 @@ class TransportController extends Controller
      */
     public function getTrip(Request $request): JsonResponse {
         $validated = $request->validate([
-                                            'tripId'      => ['required_without:hafasTripId', 'string'],
+                                            'tripId'      => ['required_without:hafasTripId', 'string'], //ToDo deprecated: remove after 2023-02-28
                                             'hafasTripId' => ['required_without:tripId', 'string'],
                                             'lineName'    => ['required', 'string'],
                                             'start'       => ['required', 'numeric', 'gt:0'],
@@ -237,7 +237,7 @@ class TransportController extends Controller
 
         try {
             $hafasTrip = TrainCheckinController::getHafasTrip(
-                $validated['hafasTripId'] ?? $validated['tripId'],
+                $validated['hafasTripId'] ?? $validated['tripId'], //ToDo deprecated: change to hafasTripId after 2023-02-28
                 $validated['lineName'],
                 (int) $validated['start']
             );

--- a/app/Http/Controllers/API/v1/TransportController.php
+++ b/app/Http/Controllers/API/v1/TransportController.php
@@ -178,7 +178,7 @@ class TransportController extends Controller
      *      tags={"Checkin"},
      *      summary="Get the stopovers and trip information for a given train",
      *      @OA\Parameter(
-     *          name="tripId",
+     *          name="hafasTripId",
      *          in="query",
      *          description="HAFAS trip ID (fetched from departures)",
      *          example="1|323306|1|80|17072022",
@@ -229,15 +229,15 @@ class TransportController extends Controller
      */
     public function getTrip(Request $request): JsonResponse {
         $validated = $request->validate([
-                                            'tripId'      => ['required_unless:hafasTripId,null', 'string'],
-                                            'hafasTripId' => ['required_unless:tripId,null', 'string'],
+                                            'tripId'      => ['required_without:hafasTripId', 'string'],
+                                            'hafasTripId' => ['required_without:tripId', 'string'],
                                             'lineName'    => ['required', 'string'],
                                             'start'       => ['required', 'numeric', 'gt:0'],
                                         ]);
 
         try {
             $hafasTrip = TrainCheckinController::getHafasTrip(
-                $validated['tripId'],
+                $validated['hafasTripId'] ?? $validated['tripId'],
                 $validated['lineName'],
                 (int) $validated['start']
             );

--- a/app/Http/Controllers/API/v1/UserController.php
+++ b/app/Http/Controllers/API/v1/UserController.php
@@ -200,7 +200,7 @@ class UserController extends Controller
      * @OA\Post(
      *      path="/user/createBlock",
      *      operationId="createBlock",
-     *      tags={"Hide and Block"},
+     *      tags={"User/Hide and Block"},
      *      summary="Block a user",
      *      description="Block a specific user. That user will not be able to see your statuses or profile information,
      *      and cannot send you follow requests. Public statuses are still visible through the incognito mode.",
@@ -270,7 +270,7 @@ class UserController extends Controller
      * @OA\Delete(
      *      path="/user/destroyBlock",
      *      operationId="destroyBlock",
-     *      tags={"Hide and Block"},
+     *      tags={"User/Hide and Block"},
      *      summary="Unmute a user",
      *      description="Unblock a specific user. They are now able to see your statuses and profile information again,
      *      and send you follow requests.",
@@ -341,7 +341,7 @@ class UserController extends Controller
      * @OA\Post(
      *      path="/user/createMute",
      *      operationId="createMute",
-     *      tags={"Hide and Block"},
+     *      tags={"User/Hide and Block"},
      *      summary="Mute a user",
      *      description="Mute a specific user. That way they will not be shown on your dashboard and in the active
      *      journeys tab",
@@ -411,7 +411,7 @@ class UserController extends Controller
      * @OA\Delete(
      *      path="/user/destroyMute",
      *      operationId="destroyMute",
-     *      tags={"Hide and Block"},
+     *      tags={"User/Hide and Block"},
      *      summary="Unmute a user",
      *      description="Unmute a specific user. That way they will be shown on your dashboard and in the active
      *      journeys tab again",

--- a/app/Http/Controllers/API/v1/UserController.php
+++ b/app/Http/Controllers/API/v1/UserController.php
@@ -334,17 +334,12 @@ class UserController extends Controller
      *      summary="Mute a user",
      *      description="Mute a specific user. That way they will not be shown on your dashboard and in the active
      *      journeys tab",
-     *      @OA\RequestBody(
-     *          required=true,
-     *          @OA\JsonContent(
-     *              @OA\Property(
-     *                  property="userId",
-     *                  title="userId",
-     *                  format="int64",
-     *                  description="ID of the to-be-muted user",
-     *                  example=1
-     *              )
-     *          )
+     *      @OA\Parameter (
+     *          name="id",
+     *          in="path",
+     *          description="User-ID",
+     *          example=1337,
+     *          @OA\Schema(type="integer")
      *      ),
      *      @OA\Response(
      *          response=201,
@@ -397,17 +392,12 @@ class UserController extends Controller
      *      summary="Unmute a user",
      *      description="Unmute a specific user. That way they will be shown on your dashboard and in the active
      *      journeys tab again",
-     *      @OA\RequestBody(
-     *          required=true,
-     *          @OA\JsonContent(
-     *              @OA\Property(
-     *                  property="userId",
-     *                  title="userId",
-     *                  format="int64",
-     *                  description="ID of the to-be-unmuted user",
-     *                  example=1
-     *              )
-     *          )
+     *      @OA\Parameter (
+     *          name="id",
+     *          in="path",
+     *          description="User-ID",
+     *          example=1337,
+     *          @OA\Schema(type="integer")
      *      ),
      *      @OA\Response(
      *          response=200,

--- a/app/Http/Controllers/API/v1/UserController.php
+++ b/app/Http/Controllers/API/v1/UserController.php
@@ -200,7 +200,7 @@ class UserController extends Controller
      * @OA\Post(
      *      path="/user/createBlock",
      *      operationId="createBlock",
-     *      tags={"User"},
+     *      tags={"Hide and Block"},
      *      summary="Block a user",
      *      description="Block a specific user. That user will not be able to see your statuses or profile information,
      *      and cannot send you follow requests. Public statuses are still visible through the incognito mode.",
@@ -220,7 +220,7 @@ class UserController extends Controller
      *          response=201,
      *          description="successful operation",
      *          @OA\JsonContent(
-     *              ref="#/components/schemas/User"
+     *              @OA\Property(property="data", ref="#/components/schemas/User")
      *          )
      *       ),
      *       @OA\Response(response=400, description="Bad request"),
@@ -270,7 +270,7 @@ class UserController extends Controller
      * @OA\Delete(
      *      path="/user/destroyBlock",
      *      operationId="destroyBlock",
-     *      tags={"User"},
+     *      tags={"Hide and Block"},
      *      summary="Unmute a user",
      *      description="Unblock a specific user. They are now able to see your statuses and profile information again,
      *      and send you follow requests.",
@@ -290,7 +290,7 @@ class UserController extends Controller
      *          response=200,
      *          description="successful operation",
      *          @OA\JsonContent(
-     *              ref="#/components/schemas/User"
+     *              @OA\Property(property="data", ref="#/components/schemas/User")
      *          )
      *       ),
      *       @OA\Response(response=400, description="Bad request"),
@@ -341,7 +341,7 @@ class UserController extends Controller
      * @OA\Post(
      *      path="/user/createMute",
      *      operationId="createMute",
-     *      tags={"User"},
+     *      tags={"Hide and Block"},
      *      summary="Mute a user",
      *      description="Mute a specific user. That way they will not be shown on your dashboard and in the active
      *      journeys tab",
@@ -361,7 +361,7 @@ class UserController extends Controller
      *          response=201,
      *          description="successful operation",
      *          @OA\JsonContent(
-     *              ref="#/components/schemas/User"
+     *              @OA\Property(property="data", ref="#/components/schemas/User")
      *          )
      *       ),
      *       @OA\Response(response=400, description="Bad request"),
@@ -411,7 +411,7 @@ class UserController extends Controller
      * @OA\Delete(
      *      path="/user/destroyMute",
      *      operationId="destroyMute",
-     *      tags={"User"},
+     *      tags={"Hide and Block"},
      *      summary="Unmute a user",
      *      description="Unmute a specific user. That way they will be shown on your dashboard and in the active
      *      journeys tab again",
@@ -431,7 +431,7 @@ class UserController extends Controller
      *          response=200,
      *          description="successful operation",
      *          @OA\JsonContent(
-     *              ref="#/components/schemas/User"
+     *              @OA\Property(property="data", ref="#/components/schemas/User")
      *          )
      *       ),
      *       @OA\Response(response=400, description="Bad request"),

--- a/app/Http/Controllers/API/v1/UserController.php
+++ b/app/Http/Controllers/API/v1/UserController.php
@@ -264,7 +264,7 @@ class UserController extends Controller
 
     /**
      * @OA\Delete(
-     *      path="/user/{userId}/block",
+     *      path="/user/{id}/block",
      *      operationId="destroyBlock",
      *      tags={"User/Hide and Block"},
      *      summary="Unmute a user",

--- a/app/Virtual/Models/Train.php
+++ b/app/Virtual/Models/Train.php
@@ -37,11 +37,7 @@ class Train
 
     /**
      * @OA\Property (
-     *     title="category",
-     *     description="Category of transport. ",
-     *     type="string",
-     *     enum={"nationalExpress", "national", "regionalExp", "regional", "suburban", "bus", "ferry", "subway",
-     *     "tram", "taxi"}, example="suburban"
+     *      ref="#/components/schemas/TrainCategoryEnum"
      * )
      *
      * @var string

--- a/app/Virtual/Models/TrainStopover.php
+++ b/app/Virtual/Models/TrainStopover.php
@@ -27,7 +27,7 @@ class TrainStopover
     private $id;
 
     /**
-     * @OA\Propert (
+     * @OA\Property (
      *     title="name",
      *     description="name of the station",
      *     example="Karlsruhe Hbf"

--- a/app/Virtual/Types/TrainCategoryEnum.php
+++ b/app/Virtual/Types/TrainCategoryEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Virtual\Types;
+/**
+ * @OA\Schema(
+ *     title="category",
+ *     description="Category of transport. ",
+ *     type="string",
+ *     enum={"nationalExpress", "national", "regionalExp", "regional", "suburban", "bus", "ferry", "subway",
+ *     "tram", "taxi"},
+ *     example="suburban"
+ * )
+ */
+class TrainCategoryEnum
+{
+
+}

--- a/app/Virtual/Types/TravelTypeEnum.php
+++ b/app/Virtual/Types/TravelTypeEnum.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Virtual\Types;
+/**
+ * @OA\Schema(
+ *     title="travelType",
+ *     type="string",
+ *     enum={"express", "regional", "suburban", "bus", "ferry", "subway", "tram", "taxi",
+ *     "tram", "taxi"},
+ *     example="suburban"
+ * )
+ */
+class TravelTypeEnum
+{
+
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -91,8 +91,10 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
             Route::put('approveFollowRequest', [FollowController::class, 'approveFollowRequest']);
             Route::post('/{userId}/block', [UserController::class, 'createBlock']);
             Route::delete('/{userId}/block', [UserController::class, 'destroyBlock']);
-            Route::post('createMute', [UserController::class, 'createMute']);
-            Route::delete('destroyMute', [UserController::class, 'destroyMute']);
+            Route::post('/{userId}/mute', [UserController::class, 'createMute']);
+            Route::delete('/{userId}/mute', [UserController::class, 'destroyMute']);
+            Route::post('createMute', [UserController::class, 'createMute']);//TODO deprecated: Remove this after 2023-02-28 (new: /user/{id}/mute)
+            Route::delete('destroyMute', [UserController::class, 'destroyMute']);//TODO deprecated: Remove this after 2023-02-28 (new: /user/{id}/mute)
             Route::get('search/{query}', [UserController::class, 'search']);
             Route::get('statuses/active', [StatusController::class, 'getActiveStatus']);
         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -89,8 +89,8 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
             Route::delete('removeFollower', [FollowController::class, 'removeFollower']);
             Route::delete('rejectFollowRequest', [FollowController::class, 'rejectFollowRequest']);
             Route::put('approveFollowRequest', [FollowController::class, 'approveFollowRequest']);
-            Route::post('createBlock', [UserController::class, 'createBlock']);
-            Route::delete('destroyBlock', [UserController::class, 'destroyBlock']);
+            Route::post('/{userId}/block', [UserController::class, 'createBlock']);
+            Route::delete('/{userId}/block', [UserController::class, 'destroyBlock']);
             Route::post('createMute', [UserController::class, 'createMute']);
             Route::delete('destroyMute', [UserController::class, 'destroyMute']);
             Route::get('search/{query}', [UserController::class, 'search']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -54,7 +54,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
         Route::put('status/{id}', [StatusController::class, 'update']);
         Route::post('status/{id}/like', [LikesController::class, 'create']);
         Route::delete('status/{id}/like', [LikesController::class, 'destroy']);
-        Route::delete('statuses/{id}', [StatusController::class, 'destroy']); //TODO deprecated: Remove this after 2023-02-28 (new: /status/{id})
+        Route::delete('statuses/{statusId}', [StatusController::class, 'destroy']); //TODO deprecated: Remove this after 2023-02-28 (new: /status/{id})
         Route::put('statuses/{id}', [StatusController::class, 'update']); //TODO deprecated: Remove this after 2023-02-28 (new: /status/{id})
         Route::post('like/{statusId}', [LikesController::class, 'create']);  //TODO deprecated: Remove this after 2023-02-28 (new: /status/{id}/like)
         Route::delete('like/{status}', [LikesController::class, 'destroy']); //TODO deprecated: Remove this after 2023-02-28 (new: /status/{id}/like)
@@ -84,8 +84,10 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
             Route::post('export', [StatisticsController::class, 'generateTravelExport']);
         });
         Route::group(['prefix' => 'user'], static function() {
-            Route::post('createFollow', [FollowController::class, 'createFollow']);
-            Route::delete('destroyFollow', [FollowController::class, 'destroyFollow']);
+            Route::post('/{userId}/follow', [FollowController::class, 'createFollow']);
+            Route::delete('/{userId}/follow', [FollowController::class, 'destroyFollow']);
+            Route::post('createFollow', [FollowController::class, 'createFollow']); //TODO deprecated: Remove this after 2023-02-28 (new: /user/{id}/follow)
+            Route::delete('destroyFollow', [FollowController::class, 'destroyFollow']); //TODO deprecated: Remove this after 2023-02-28 (new: /user/{id}/follow)
             Route::delete('removeFollower', [FollowController::class, 'removeFollower']);
             Route::delete('rejectFollowRequest', [FollowController::class, 'rejectFollowRequest']);
             Route::put('approveFollowRequest', [FollowController::class, 'approveFollowRequest']);
@@ -93,8 +95,8 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
             Route::delete('/{userId}/block', [UserController::class, 'destroyBlock']);
             Route::post('/{userId}/mute', [UserController::class, 'createMute']);
             Route::delete('/{userId}/mute', [UserController::class, 'destroyMute']);
-            Route::post('createMute', [UserController::class, 'createMute']);//TODO deprecated: Remove this after 2023-02-28 (new: /user/{id}/mute)
-            Route::delete('destroyMute', [UserController::class, 'destroyMute']);//TODO deprecated: Remove this after 2023-02-28 (new: /user/{id}/mute)
+            Route::post('createMute', [UserController::class, 'createMute']); //TODO deprecated: Remove this after 2023-02-28 (new: /user/{id}/mute)
+            Route::delete('destroyMute', [UserController::class, 'destroyMute']); //TODO deprecated: Remove this after 2023-02-28 (new: /user/{id}/mute)
             Route::get('search/{query}', [UserController::class, 'search']);
             Route::get('statuses/active', [StatusController::class, 'getActiveStatus']);
         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -124,8 +124,10 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
 
     Route::group(['middleware' => ['semiguest:api', 'privacy-policy']], static function() {
         Route::get('statuses', [StatusController::class, 'enRoute']);
-        Route::get('statuses/{id}', [StatusController::class, 'show']);
-        Route::get('statuses/{id}/likedby', [LikesController::class, 'show']);
+        Route::get('status/{id}', [StatusController::class, 'show']);
+        Route::get('status/{id}/likes', [LikesController::class, 'show']);
+        Route::get('statuses/{id}', [StatusController::class, 'show']); //TODO deprecated: Remove this after 2023-02-28 (new: /status/{id})
+        Route::get('statuses/{id}/likedby', [LikesController::class, 'show']); //TODO deprecated: Remove this after 2023-02-28 (new: /status/{id}/likedby)
         Route::get('stopovers/{parameters}', [StatusController::class, 'getStopovers']);
         Route::get('polyline/{parameters}', [StatusController::class, 'getPolyline']);
         Route::get('event/{slug}', [EventController::class, 'show']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -50,10 +50,14 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
         Route::get('dashboard', [StatusController::class, 'getDashboard']);
         Route::get('dashboard/global', [StatusController::class, 'getGlobalDashboard']);
         Route::get('dashboard/future', [StatusController::class, 'getFutureCheckins']);
-        Route::post('like/{statusId}', [LikesController::class, 'create']);
-        Route::delete('like/{status}', [LikesController::class, 'destroy']);
-        Route::delete('statuses/{id}', [StatusController::class, 'destroy']);
-        Route::put('statuses/{id}', [StatusController::class, 'update']);
+        Route::delete('status/{id}', [StatusController::class, 'destroy']);
+        Route::put('status/{id}', [StatusController::class, 'update']);
+        Route::post('status/{id}/like', [LikesController::class, 'create']);
+        Route::delete('status/{id}/like', [LikesController::class, 'destroy']);
+        Route::delete('statuses/{id}', [StatusController::class, 'destroy']); //TODO deprecated: Remove this after 2023-02-28 (new: /status/{id})
+        Route::put('statuses/{id}', [StatusController::class, 'update']); //TODO deprecated: Remove this after 2023-02-28 (new: /status/{id})
+        Route::post('like/{statusId}', [LikesController::class, 'create']);  //TODO deprecated: Remove this after 2023-02-28 (new: /status/{id}/like)
+        Route::delete('like/{status}', [LikesController::class, 'destroy']); //TODO deprecated: Remove this after 2023-02-28 (new: /status/{id}/like)
         Route::post('support/ticket', [SupportController::class, 'createTicket']);
         Route::group(['prefix' => 'notifications'], static function() {
             Route::get('/', [NotificationsController::class, 'index']);

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -576,7 +576,7 @@
         "/user/createFollow": {
             "post": {
                 "tags": [
-                    "User"
+                    "Follow"
                 ],
                 "summary": "Follow a user",
                 "operationId": "createFollow",
@@ -604,7 +604,12 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/User"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/User"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -630,7 +635,7 @@
         "/user/destroyFollow": {
             "delete": {
                 "tags": [
-                    "User"
+                    "Follow"
                 ],
                 "summary": "Unfollow a user",
                 "operationId": "destroyFollow",
@@ -653,12 +658,17 @@
                     }
                 },
                 "responses": {
-                    "201": {
+                    "200": {
                         "description": "successful operation",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/User"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/User"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -681,7 +691,7 @@
         "/settings/followers": {
             "get": {
                 "tags": [
-                    "User",
+                    "Follow",
                     "Settings"
                 ],
                 "summary": "List all followers",
@@ -729,7 +739,7 @@
         "/settings/follow-requests": {
             "get": {
                 "tags": [
-                    "User",
+                    "Follow",
                     "Settings"
                 ],
                 "summary": "List all followers",
@@ -771,7 +781,7 @@
         "/settings/followings": {
             "get": {
                 "tags": [
-                    "User",
+                    "Follow",
                     "Settings"
                 ],
                 "summary": "List all users the current user is following",
@@ -813,7 +823,7 @@
         "/user/removeFollower": {
             "delete": {
                 "tags": [
-                    "User"
+                    "Follow"
                 ],
                 "summary": "Remove a follower",
                 "operationId": "removeFollower",
@@ -863,7 +873,7 @@
         "/user/acceptFollowRequest": {
             "put": {
                 "tags": [
-                    "User"
+                    "Follow"
                 ],
                 "summary": "Accept a follow request",
                 "operationId": "acceptFollowRequest",
@@ -910,7 +920,7 @@
         "/user/rejectFollowRequest": {
             "delete": {
                 "tags": [
-                    "User"
+                    "Follow"
                 ],
                 "summary": "Reject a follow request",
                 "operationId": "rejectFollowRequest",

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1904,6 +1904,9 @@
                     },
                     "422": {
                         "description": "Invalid input"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
                     }
                 },
                 "security": [
@@ -2108,8 +2111,61 @@
                     "409": {
                         "description": "Checkin collision"
                     },
-                    "403": {
-                        "description": "User not authorized"
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
+        "/trains/station/{name}/home": {
+            "put": {
+                "tags": [
+                    "Checkin"
+                ],
+                "summary": "Set a station as home station",
+                "operationId": "setHomeStation",
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "path",
+                        "description": "Name of the station",
+                        "required": true,
+                        "example": "Karlsruhe Hbf"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/TrainStation"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Station not found"
+                    },
+                    "502": {
+                        "description": "Error with our data provider"
                     }
                 },
                 "security": [

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1770,7 +1770,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "description": "HAFAS Train model. This model might be subject to unexpected changes. See also external documentation at [https://v5.db.transport.rest/api.html#get-stopsiddepartures](https://v5.db.transport.rest/api.html#get-stopsiddepartures).",
+                                                "description": "HAFAS Train model. This model might be subject to unexpected changes. See also\n     *                     external documentation at\n     *                     [https://v5.db.transport.rest/api.html#get-stopsiddepartures](https://v5.db.transport.rest/api.html#get-stopsiddepartures).",
                                                 "externalDocs": "https://v5.db.transport.rest/api.html#get-stopsiddepartures",
                                                 "example": {
                                                     "tripId": "1|200513|0|81|6012023",
@@ -3940,24 +3940,36 @@
             "description": "Logging in, creating Accounts, etc."
         },
         {
-            "name": "User",
-            "description": "Information regarding users"
-        },
-        {
-            "name": "Dashboard",
-            "description": "API Endpoints of Dashboard"
-        },
-        {
-            "name": "Status",
-            "description": "Endpoints for accessing and manipulating Statusses and their additional data"
+            "name": "Checkin",
+            "description": "Checkin related endpoints. Regular process is departures -> trip -> checkin"
         },
         {
             "name": "Events",
             "description": "Events that users can check in to"
         },
         {
+            "name": "Status",
+            "description": "Endpoints for accessing and manipulating Statusses and their additional data"
+        },
+        {
+            "name": "Dashboard",
+            "description": "API Endpoints of Dashboard"
+        },
+        {
             "name": "Likes",
             "description": "Likes regarding a single status"
+        },
+        {
+            "name": "User",
+            "description": "Information regarding users"
+        },
+        {
+            "name": "Follow",
+            "description": "Follow and unfollow users, manage your followers"
+        },
+        {
+            "name": "Leaderboard",
+            "description": "Leaderboard related endpoints"
         },
         {
             "name": "Settings",

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -576,7 +576,7 @@
         "/user/createFollow": {
             "post": {
                 "tags": [
-                    "Follow"
+                    "User/Follow"
                 ],
                 "summary": "Follow a user",
                 "operationId": "createFollow",
@@ -635,7 +635,7 @@
         "/user/destroyFollow": {
             "delete": {
                 "tags": [
-                    "Follow"
+                    "User/Follow"
                 ],
                 "summary": "Unfollow a user",
                 "operationId": "destroyFollow",
@@ -823,7 +823,7 @@
         "/user/removeFollower": {
             "delete": {
                 "tags": [
-                    "Follow"
+                    "User/Follow"
                 ],
                 "summary": "Remove a follower",
                 "operationId": "removeFollower",
@@ -873,7 +873,7 @@
         "/user/acceptFollowRequest": {
             "put": {
                 "tags": [
-                    "Follow"
+                    "User/Follow"
                 ],
                 "summary": "Accept a follow request",
                 "operationId": "acceptFollowRequest",
@@ -920,7 +920,7 @@
         "/user/rejectFollowRequest": {
             "delete": {
                 "tags": [
-                    "Follow"
+                    "User/Follow"
                 ],
                 "summary": "Reject a follow request",
                 "operationId": "rejectFollowRequest",
@@ -2506,7 +2506,7 @@
         "/user/createBlock": {
             "post": {
                 "tags": [
-                    "Hide and Block"
+                    "User/Hide and Block"
                 ],
                 "summary": "Block a user",
                 "description": "Block a specific user. That user will not be able to see your statuses or profile information,\n     *      and cannot send you follow requests. Public statuses are still visible through the incognito mode.",
@@ -2569,7 +2569,7 @@
         "/user/destroyBlock": {
             "delete": {
                 "tags": [
-                    "Hide and Block"
+                    "User/Hide and Block"
                 ],
                 "summary": "Unmute a user",
                 "description": "Unblock a specific user. They are now able to see your statuses and profile information again,\n     *      and send you follow requests.",
@@ -2632,7 +2632,7 @@
         "/user/createMute": {
             "post": {
                 "tags": [
-                    "Hide and Block"
+                    "User/Hide and Block"
                 ],
                 "summary": "Mute a user",
                 "description": "Mute a specific user. That way they will not be shown on your dashboard and in the active\n     *      journeys tab",
@@ -2695,7 +2695,7 @@
         "/user/destroyMute": {
             "delete": {
                 "tags": [
-                    "Hide and Block"
+                    "User/Hide and Block"
                 ],
                 "summary": "Unmute a user",
                 "description": "Unmute a specific user. That way they will be shown on your dashboard and in the active\n     *      journeys tab again",
@@ -4105,11 +4105,11 @@
             "description": "Information regarding users"
         },
         {
-            "name": "Follow",
+            "name": "User/Follow",
             "description": "Follow and unfollow users, manage your followers"
         },
         {
-            "name": "Hide and Block",
+            "name": "User/Hide and Block",
             "description": "Mute and block users"
         },
         {

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -573,6 +573,387 @@
                 ]
             }
         },
+        "/user/createFollow": {
+            "post": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Follow a user",
+                "operationId": "createFollow",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "userId": {
+                                        "title": "userId",
+                                        "description": "ID of the to-be-followed user",
+                                        "format": "int64",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "409": {
+                        "description": "Already following"
+                    },
+                    "403": {
+                        "description": "User is blocked"
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
+        "/user/destroyFollow": {
+            "delete": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Unfollow a user",
+                "operationId": "destroyFollow",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "userId": {
+                                        "title": "userId",
+                                        "description": "ID of the to-be-unfollowed user",
+                                        "format": "int64",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "409": {
+                        "description": "Already following"
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
+        "/settings/followers": {
+            "get": {
+                "tags": [
+                    "User",
+                    "Settings"
+                ],
+                "summary": "List all followers",
+                "operationId": "getFollowers",
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/User"
+                                            }
+                                        },
+                                        "links": {
+                                            "$ref": "#/components/schemas/Links"
+                                        },
+                                        "meta": {
+                                            "$ref": "#/components/schemas/PaginationMeta"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "409": {
+                        "description": "Already following"
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
+        "/settings/follow-requests": {
+            "get": {
+                "tags": [
+                    "User",
+                    "Settings"
+                ],
+                "summary": "List all followers",
+                "operationId": "getFollowRequests",
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/User"
+                                            }
+                                        },
+                                        "links": {
+                                            "$ref": "#/components/schemas/Links"
+                                        },
+                                        "meta": {
+                                            "$ref": "#/components/schemas/PaginationMeta"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
+        "/settings/followings": {
+            "get": {
+                "tags": [
+                    "User",
+                    "Settings"
+                ],
+                "summary": "List all users the current user is following",
+                "operationId": "getFollowings",
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/User"
+                                            }
+                                        },
+                                        "links": {
+                                            "$ref": "#/components/schemas/Links"
+                                        },
+                                        "meta": {
+                                            "$ref": "#/components/schemas/PaginationMeta"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
+        "/user/removeFollower": {
+            "delete": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Remove a follower",
+                "operationId": "removeFollower",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "userId": {
+                                        "title": "userId",
+                                        "description": "ID of the to-be-unfollowed user",
+                                        "format": "int64",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation"
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "403": {
+                        "description": "Permission denied"
+                    },
+                    "404": {
+                        "description": "Follow not found"
+                    },
+                    "500": {
+                        "description": "Unknown error"
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
+        "/user/acceptFollowRequest": {
+            "put": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Accept a follow request",
+                "operationId": "acceptFollowRequest",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "userId": {
+                                        "title": "userId",
+                                        "description": "ID of the user who sent the follow request",
+                                        "format": "int64",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation"
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "404": {
+                        "description": "Request not found"
+                    },
+                    "500": {
+                        "description": "Unknown error"
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
+        "/user/rejectFollowRequest": {
+            "delete": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Reject a follow request",
+                "operationId": "rejectFollowRequest",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "userId": {
+                                        "title": "userId",
+                                        "description": "ID of the user who sent the follow request",
+                                        "format": "int64",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation"
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "403": {
+                        "description": "Permission denied"
+                    },
+                    "404": {
+                        "description": "Request not found"
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
         "/statuses/{id}/likedby": {
             "get": {
                 "tags": [
@@ -1635,6 +2016,9 @@
                     },
                     "400": {
                         "description": "Bad request"
+                    },
+                    "403": {
+                        "description": "Forbidden, User is blocked"
                     }
                 },
                 "security": [
@@ -1688,6 +2072,9 @@
                     "400": {
                         "description": "Bad request"
                     },
+                    "403": {
+                        "description": "Forbidden, User is blocked"
+                    },
                     "404": {
                         "description": "User not found"
                     }
@@ -1699,13 +2086,129 @@
                 ]
             }
         },
+        "/user/createBlock": {
+            "post": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Block a user",
+                "description": "Block a specific user. That user will not be able to see your statuses or profile information,\n     *      and cannot send you follow requests. Public statuses are still visible through the incognito mode.",
+                "operationId": "createBlock",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "userId": {
+                                        "title": "userId",
+                                        "description": "ID of the to-be-blocked user",
+                                        "format": "int64",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "401": {
+                        "description": "Not logged in"
+                    },
+                    "409": {
+                        "description": "User is already blocked"
+                    },
+                    "403": {
+                        "description": "User not authorized"
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
+        "/user/destroyBlock": {
+            "delete": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Unmute a user",
+                "description": "Unblock a specific user. They are now able to see your statuses and profile information again,\n     *      and send you follow requests.",
+                "operationId": "destroyBlock",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "userId": {
+                                        "title": "userId",
+                                        "description": "ID of the to-be-unblocked user",
+                                        "format": "int64",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "401": {
+                        "description": "Not logged in"
+                    },
+                    "409": {
+                        "description": "User is not blocked"
+                    },
+                    "403": {
+                        "description": "User not authorized"
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
         "/user/createMute": {
             "post": {
                 "tags": [
                     "User"
                 ],
                 "summary": "Mute a user",
-                "description": "Mute a specific user. That way they will not be shown on your dashboard and in the active journeys tab",
+                "description": "Mute a specific user. That way they will not be shown on your dashboard and in the active\n     *      journeys tab",
                 "operationId": "createMute",
                 "requestBody": {
                     "required": true,
@@ -1763,7 +2266,7 @@
                     "User"
                 ],
                 "summary": "Unmute a user",
-                "description": "Unmute a specific user. That way they will be shown on your dashboard and in the active journeys tab again",
+                "description": "Unmute a specific user. That way they will be shown on your dashboard and in the active\n     *      journeys tab again",
                 "operationId": "destroyMute",
                 "requestBody": {
                     "required": true,
@@ -1801,7 +2304,7 @@
                         "description": "Not logged in"
                     },
                     "409": {
-                        "description": "User is already unmuted"
+                        "description": "User is not muted"
                     },
                     "403": {
                         "description": "User not authorized"
@@ -2876,12 +3379,6 @@
                         "description": "is this profile set to private?",
                         "type": "boolean",
                         "example": false
-                    },
-                    "privacyHideDays": {
-                        "title": "privacyHideDays",
-                        "description": "Hide all statuses after x days",
-                        "type": "integer",
-                        "example": 3
                     },
                     "userInvisibleToMe": {
                         "title": "userInvisibleToMe",

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1724,6 +1724,196 @@
                 ]
             }
         },
+        "/trains/station/{name}/departures": {
+            "get": {
+                "tags": [
+                    "Checkin"
+                ],
+                "summary": "Get departures from a station",
+                "description": "Get departures from a station",
+                "operationId": "getDepartures",
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "path",
+                        "description": "Name of the station (replace slashes with spaces)",
+                        "required": true
+                    },
+                    {
+                        "name": "when",
+                        "in": "query",
+                        "description": "When to get the departures (default: now)",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2020-01-01T12:00:00.000Z"
+                        }
+                    },
+                    {
+                        "name": "travelType",
+                        "in": "query",
+                        "description": "Means of transport (default: all)",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/TravelTypeEnum"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "description": "HAFAS Train model. This model might be subject to unexpected changes. See also external documentation at [https://v5.db.transport.rest/api.html#get-stopsiddepartures](https://v5.db.transport.rest/api.html#get-stopsiddepartures).",
+                                                "externalDocs": "https://v5.db.transport.rest/api.html#get-stopsiddepartures",
+                                                "example": {
+                                                    "tripId": "1|200513|0|81|6012023",
+                                                    "stop": {
+                                                        "type": "stop",
+                                                        "id": "8000191",
+                                                        "name": "Karlsruhe Hbf",
+                                                        "location": {
+                                                            "type": "location",
+                                                            "id": "8000191",
+                                                            "latitude": 48.99353,
+                                                            "longitude": 8.401939
+                                                        },
+                                                        "products": {
+                                                            "nationalExpress": true,
+                                                            "national": true,
+                                                            "regionalExp": true,
+                                                            "regional": true,
+                                                            "suburban": true,
+                                                            "bus": true,
+                                                            "ferry": false,
+                                                            "subway": false,
+                                                            "tram": true,
+                                                            "taxi": true
+                                                        }
+                                                    },
+                                                    "when": "2023-01-06T13:49:00+01:00",
+                                                    "plannedWhen": "2023-01-06T13:49:00+01:00",
+                                                    "delay": null,
+                                                    "platform": "2",
+                                                    "plannedPlatform": "2",
+                                                    "direction": "Zürich HB",
+                                                    "provenance": null,
+                                                    "line": {
+                                                        "type": "line",
+                                                        "id": "ec-9",
+                                                        "fahrtNr": "9",
+                                                        "name": "EC 9",
+                                                        "public": true,
+                                                        "adminCode": "80____",
+                                                        "productName": "EC",
+                                                        "mode": "train",
+                                                        "product": "national",
+                                                        "operator": {
+                                                            "type": "operator",
+                                                            "id": "db-fernverkehr-ag",
+                                                            "name": "DB Fernverkehr AG"
+                                                        }
+                                                    },
+                                                    "remarks": null,
+                                                    "origin": null,
+                                                    "destination": {
+                                                        "type": "stop",
+                                                        "id": "8503000",
+                                                        "name": "Zürich HB",
+                                                        "location": {
+                                                            "type": "location",
+                                                            "id": "8503000",
+                                                            "latitude": 47.378177,
+                                                            "longitude": 8.540211
+                                                        },
+                                                        "products": {
+                                                            "nationalExpress": true,
+                                                            "national": true,
+                                                            "regionalExp": true,
+                                                            "regional": true,
+                                                            "suburban": true,
+                                                            "bus": true,
+                                                            "ferry": false,
+                                                            "subway": false,
+                                                            "tram": true,
+                                                            "taxi": false
+                                                        }
+                                                    },
+                                                    "currentTripPosition": {
+                                                        "type": "location",
+                                                        "latitude": 48.725382,
+                                                        "longitude": 8.142888
+                                                    },
+                                                    "loadFactor": "high",
+                                                    "station": {
+                                                        "id": 5181,
+                                                        "ibnr": 8000191,
+                                                        "rilIdentifier": "RK",
+                                                        "name": "Karlsruhe Hbf",
+                                                        "latitude": "48.993530",
+                                                        "longitude": "8.401939"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "station": {
+                                                    "$ref": "#/components/schemas/TrainStation"
+                                                },
+                                                "times": {
+                                                    "properties": {
+                                                        "now": {
+                                                            "type": "string",
+                                                            "format": "date-time",
+                                                            "example": "2020-01-01T12:00:00.000Z"
+                                                        },
+                                                        "prev": {
+                                                            "type": "string",
+                                                            "format": "date-time",
+                                                            "example": "2020-01-01T11:45:00.000Z"
+                                                        },
+                                                        "next": {
+                                                            "type": "string",
+                                                            "format": "date-time",
+                                                            "example": "2020-01-01T12:15:00.000Z"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Station not found"
+                    },
+                    "502": {
+                        "description": "Error with our data provider"
+                    },
+                    "422": {
+                        "description": "Invalid input"
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
         "/trains/trip": {
             "get": {
                 "tags": [
@@ -3688,6 +3878,23 @@
                     "bus",
                     "ferry",
                     "subway",
+                    "tram",
+                    "taxi"
+                ],
+                "example": "suburban"
+            },
+            "TravelTypeEnum": {
+                "title": "travelType",
+                "type": "string",
+                "enum": [
+                    "express",
+                    "regional",
+                    "suburban",
+                    "bus",
+                    "ferry",
+                    "subway",
+                    "tram",
+                    "taxi",
                     "tram",
                     "taxi"
                 ],

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1020,6 +1020,71 @@
                 ]
             }
         },
+        "/static/privacy": {
+            "get": {
+                "tags": [
+                    "Settings"
+                ],
+                "summary": "Get the current privacy policy",
+                "description": "Get the current privacy policy",
+                "operationId": "e649bec35ba50765db023e745233eda9",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "validFrom": {
+                                                    "example": "2022-01-05T16:26:14.000000Z"
+                                                },
+                                                "en": {
+                                                    "example": "This is the english privacy policy"
+                                                },
+                                                "de": {
+                                                    "example": "Dies ist die deutsche Datenschutzerklärung"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/settings/acceptPrivacy": {
+            "post": {
+                "tags": [
+                    "Settings"
+                ],
+                "summary": "Accept the current privacy policy",
+                "description": "Accept the current privacy policy",
+                "operationId": "4baaf2c20fed6c12e13df7493ffa62ad",
+                "responses": {
+                    "204": {
+                        "description": "Success"
+                    },
+                    "400": {
+                        "description": "Already accepted"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
         "/leaderboard": {
             "get": {
                 "tags": [

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1724,6 +1724,102 @@
                 ]
             }
         },
+        "/trains/trip": {
+            "get": {
+                "tags": [
+                    "Checkin"
+                ],
+                "summary": "Get the stopovers and trip information for a given train",
+                "operationId": "getTrainTrip",
+                "parameters": [
+                    {
+                        "name": "tripId",
+                        "in": "query",
+                        "description": "HAFAS trip ID (fetched from departures)",
+                        "required": true,
+                        "example": "1|323306|1|80|17072022"
+                    },
+                    {
+                        "name": "lineName",
+                        "in": "query",
+                        "description": "line name for that train",
+                        "required": true,
+                        "example": "S 4"
+                    },
+                    {
+                        "name": "start",
+                        "in": "query",
+                        "description": "start point from where the stopovers should be desplayed",
+                        "required": true,
+                        "example": 4711
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "id": {
+                                                    "type": "int64",
+                                                    "example": 1
+                                                },
+                                                "category": {
+                                                    "$ref": "#/components/schemas/TrainCategoryEnum"
+                                                },
+                                                "number": {
+                                                    "type": "string",
+                                                    "example": "4-a6s4-4"
+                                                },
+                                                "lineName": {
+                                                    "type": "string",
+                                                    "example": "S 4"
+                                                },
+                                                "origin": {
+                                                    "$ref": "#/components/schemas/TrainStation"
+                                                },
+                                                "destination": {
+                                                    "$ref": "#/components/schemas/TrainStation"
+                                                },
+                                                "stopovers": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/TrainStopover"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "No station found"
+                    },
+                    "503": {
+                        "description": "There has been an error with our data provider"
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
         "/trains/station/nearby": {
             "get": {
                 "tags": [
@@ -1840,7 +1936,7 @@
                     "Checkin"
                 ],
                 "summary": "Autocomplete for trainstations",
-                "description": "This request returns an array of max. 10 station objects matching the query. **CAUTION:** All slashes (as well as encoded to %2F) in {query} need to be replaced, preferrably by a space (%20)",
+                "description": "This request returns an array of max. 10 station objects matching the query. **CAUTION:** All\n     *      slashes (as well as encoded to %2F) in {query} need to be replaced, preferrably by a space (%20)",
                 "operationId": "trainStationAutocomplete",
                 "parameters": [
                     {
@@ -2958,22 +3054,7 @@
                         "example": "1|323306|1|80|17072022"
                     },
                     "category": {
-                        "title": "category",
-                        "description": "Category of transport. ",
-                        "type": "string",
-                        "enum": [
-                            "nationalExpress",
-                            "national",
-                            "regionalExp",
-                            "regional",
-                            "suburban",
-                            "bus",
-                            "ferry",
-                            "subway",
-                            "tram",
-                            "taxi"
-                        ],
-                        "example": "suburban"
+                        "$ref": "#/components/schemas/TrainCategoryEnum"
                     },
                     "number": {
                         "title": "number",
@@ -3205,6 +3286,12 @@
                         "description": "id",
                         "type": "integer",
                         "example": "12089"
+                    },
+                    "name": {
+                        "title": "name",
+                        "description": "name of the station",
+                        "type": "string",
+                        "example": "Karlsruhe Hbf"
                     },
                     "rilIdentifier": {
                         "title": "rilIdentifier",
@@ -3587,6 +3674,24 @@
                     3
                 ],
                 "example": 1
+            },
+            "TrainCategoryEnum": {
+                "title": "category",
+                "description": "Category of transport. ",
+                "type": "string",
+                "enum": [
+                    "nationalExpress",
+                    "national",
+                    "regionalExp",
+                    "regional",
+                    "suburban",
+                    "bus",
+                    "ferry",
+                    "subway",
+                    "tram",
+                    "taxi"
+                ],
+                "example": "suburban"
             },
             "VisibilityEnum": {
                 "title": "visibility",

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.0",
     "info": {
         "title": "Träwelling API",
-        "description": "Träwelling user API description. This is an incomplete documentation with still many errors.",
+        "description": "Träwelling user API description. This is an incomplete documentation with still many errors. The API is currently not yet stable. Endpoints are still being restructured. Both the URL and the request or body can be changed. Breaking changes will be announced on the Discord server: https://discord.gg/72t7564ZbV",
         "contact": {
             "email": "support@traewelling.de"
         },
@@ -573,31 +573,24 @@
                 ]
             }
         },
-        "/user/createFollow": {
+        "/user/{id}/follow": {
             "post": {
                 "tags": [
                     "User/Follow"
                 ],
                 "summary": "Follow a user",
                 "operationId": "createFollow",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "userId": {
-                                        "title": "userId",
-                                        "description": "ID of the to-be-followed user",
-                                        "format": "int64",
-                                        "example": 1
-                                    }
-                                },
-                                "type": "object"
-                            }
-                        }
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "User-ID",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "example": 1337
                     }
-                },
+                ],
                 "responses": {
                     "201": {
                         "description": "successful operation",
@@ -630,33 +623,24 @@
                     },
                     {}
                 ]
-            }
-        },
-        "/user/destroyFollow": {
+            },
             "delete": {
                 "tags": [
                     "User/Follow"
                 ],
                 "summary": "Unfollow a user",
                 "operationId": "destroyFollow",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "userId": {
-                                        "title": "userId",
-                                        "description": "ID of the to-be-unfollowed user",
-                                        "format": "int64",
-                                        "example": 1
-                                    }
-                                },
-                                "type": "object"
-                            }
-                        }
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "User-ID",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "example": 1337
                     }
-                },
+                ],
                 "responses": {
                     "200": {
                         "description": "successful operation",
@@ -676,6 +660,9 @@
                     "400": {
                         "description": "Bad request"
                     },
+                    "404": {
+                        "description": "User not found"
+                    },
                     "409": {
                         "description": "Already following"
                     }
@@ -691,7 +678,7 @@
         "/settings/followers": {
             "get": {
                 "tags": [
-                    "Follow",
+                    "User/Follow",
                     "Settings"
                 ],
                 "summary": "List all followers",
@@ -739,7 +726,7 @@
         "/settings/follow-requests": {
             "get": {
                 "tags": [
-                    "Follow",
+                    "User/Follow",
                     "Settings"
                 ],
                 "summary": "List all followers",
@@ -781,7 +768,7 @@
         "/settings/followings": {
             "get": {
                 "tags": [
-                    "Follow",
+                    "User/Follow",
                     "Settings"
                 ],
                 "summary": "List all users the current user is following",
@@ -964,7 +951,7 @@
                 ]
             }
         },
-        "/statuses/{id}/likedby": {
+        "/status/{id}/likes": {
             "get": {
                 "tags": [
                     "Likes"
@@ -1010,6 +997,100 @@
                     },
                     "403": {
                         "description": "User not authorized to access this status"
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
+        "/status/{id}/like": {
+            "post": {
+                "tags": [
+                    "Likes"
+                ],
+                "summary": "Add like to status",
+                "description": "Add like to status",
+                "operationId": "addLikeToStatus",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Status-ID",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "example": 1337
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "403": {
+                        "description": "User not authorized to access this status"
+                    },
+                    "404": {
+                        "description": "No status found for this id"
+                    },
+                    "409": {
+                        "description": "Status already liked by user"
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Likes"
+                ],
+                "summary": "Remove like from status",
+                "description": "Removes like from status",
+                "operationId": "removeLikeFromStatus",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Status-ID",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "example": 1337
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "404": {
+                        "description": "No status found for this id"
                     }
                 },
                 "security": [
@@ -1260,6 +1341,202 @@
                 ]
             }
         },
+        "/statistics": {
+            "get": {
+                "tags": [
+                    "Statistics"
+                ],
+                "summary": "Get personal statistics",
+                "operationId": "getStatistics",
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "purpose": {
+                                                    "description": "The purpose of travel",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "properties": {
+                                                            "name": {
+                                                                "$ref": "#/components/schemas/BusinessEnum"
+                                                            },
+                                                            "count": {
+                                                                "type": "integer",
+                                                                "example": 11
+                                                            },
+                                                            "duration": {
+                                                                "description": "Duration in\n     *                                                            minutes",
+                                                                "type": "integer",
+                                                                "example": 425
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "categories": {
+                                                    "description": "The categories of the travel",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "properties": {
+                                                            "name": {
+                                                                "$ref": "#/components/schemas/TrainCategoryEnum"
+                                                            },
+                                                            "count": {
+                                                                "type": "integer",
+                                                                "example": 11
+                                                            },
+                                                            "duration": {
+                                                                "description": "Duration in\n     *                                                          minutes",
+                                                                "type": "integer",
+                                                                "example": 425
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "operators": {
+                                                    "description": "The operators of the means of transport",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "properties": {
+                                                            "name": {
+                                                                "example": "Gertruds Verkehrsgesellschaft mbH"
+                                                            },
+                                                            "count": {
+                                                                "type": "integer",
+                                                                "example": 10
+                                                            },
+                                                            "duration": {
+                                                                "description": "Duration in\n     *                                                          minutes",
+                                                                "type": "integer",
+                                                                "example": 424
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "time": {
+                                                    "description": "Shows the daily travel volume",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "properties": {
+                                                            "date": {
+                                                                "type": "string",
+                                                                "example": "2021-01-01T00:00:00.000Z"
+                                                            },
+                                                            "count": {
+                                                                "type": "integer",
+                                                                "example": 10
+                                                            },
+                                                            "duration": {
+                                                                "description": "Duration in\n     *                                                          minutes",
+                                                                "type": "integer",
+                                                                "example": 424
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "from": {
+                                                    "example": "2021-01-01T00:00:00.000000Z"
+                                                },
+                                                "until": {
+                                                    "example": "2021-02-01T00:00:00.000000Z"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
+        "/statistics/global": {
+            "get": {
+                "tags": [
+                    "Statistics"
+                ],
+                "summary": "Get global statistics of the last 4 weeks",
+                "operationId": "getGlobalStatistics",
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "distance": {
+                                                    "description": "Globally travelled distance in meters",
+                                                    "type": "integer",
+                                                    "example": 1000
+                                                },
+                                                "duration": {
+                                                    "description": "Globally travelled duration in minutes",
+                                                    "type": "integer",
+                                                    "example": 1000
+                                                },
+                                                "activeUsers": {
+                                                    "description": "Number of active users",
+                                                    "type": "integer",
+                                                    "example": 1000
+                                                },
+                                                "meta": {
+                                                    "properties": {
+                                                        "from": {
+                                                            "example": "2021-01-01T00:00:00.000000Z"
+                                                        },
+                                                        "until": {
+                                                            "example": "2021-02-01T00:00:00.000000Z"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "token": []
+                    },
+                    {}
+                ]
+            }
+        },
         "/dashboard": {
             "get": {
                 "tags": [
@@ -1473,7 +1750,7 @@
                 ]
             }
         },
-        "/statuses/{id}": {
+        "/status/{id}": {
             "get": {
                 "tags": [
                     "Status"
@@ -2503,7 +2780,7 @@
                 ]
             }
         },
-        "/user/createBlock": {
+        "/user/{id}/block": {
             "post": {
                 "tags": [
                     "User/Hide and Block"
@@ -2551,11 +2828,14 @@
                     "401": {
                         "description": "Not logged in"
                     },
-                    "409": {
-                        "description": "User is already blocked"
-                    },
                     "403": {
                         "description": "User not authorized"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    },
+                    "409": {
+                        "description": "User is already blocked"
                     }
                 },
                 "security": [
@@ -2564,9 +2844,7 @@
                     },
                     {}
                 ]
-            }
-        },
-        "/user/destroyBlock": {
+            },
             "delete": {
                 "tags": [
                     "User/Hide and Block"
@@ -2614,11 +2892,14 @@
                     "401": {
                         "description": "Not logged in"
                     },
-                    "409": {
-                        "description": "User is not blocked"
-                    },
                     "403": {
                         "description": "User not authorized"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    },
+                    "409": {
+                        "description": "User is not blocked"
                     }
                 },
                 "security": [
@@ -2629,7 +2910,7 @@
                 ]
             }
         },
-        "/user/createMute": {
+        "/user/{id}/mute": {
             "post": {
                 "tags": [
                     "User/Hide and Block"
@@ -2637,24 +2918,17 @@
                 "summary": "Mute a user",
                 "description": "Mute a specific user. That way they will not be shown on your dashboard and in the active\n     *      journeys tab",
                 "operationId": "createMute",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "userId": {
-                                        "title": "userId",
-                                        "description": "ID of the to-be-muted user",
-                                        "format": "int64",
-                                        "example": 1
-                                    }
-                                },
-                                "type": "object"
-                            }
-                        }
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "User-ID",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "example": 1337
                     }
-                },
+                ],
                 "responses": {
                     "201": {
                         "description": "successful operation",
@@ -2690,9 +2964,7 @@
                     },
                     {}
                 ]
-            }
-        },
-        "/user/destroyMute": {
+            },
             "delete": {
                 "tags": [
                     "User/Hide and Block"
@@ -2700,24 +2972,17 @@
                 "summary": "Unmute a user",
                 "description": "Unmute a specific user. That way they will be shown on your dashboard and in the active\n     *      journeys tab again",
                 "operationId": "destroyMute",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "userId": {
-                                        "title": "userId",
-                                        "description": "ID of the to-be-unmuted user",
-                                        "format": "int64",
-                                        "example": 1
-                                    }
-                                },
-                                "type": "object"
-                            }
-                        }
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "User-ID",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "example": 1337
                     }
-                },
+                ],
                 "responses": {
                     "200": {
                         "description": "successful operation",
@@ -4115,6 +4380,10 @@
         {
             "name": "Leaderboard",
             "description": "Leaderboard related endpoints"
+        },
+        {
+            "name": "Statistics",
+            "description": "Statistics related endpoints"
         },
         {
             "name": "Settings",

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -2385,7 +2385,7 @@
         "/user/createBlock": {
             "post": {
                 "tags": [
-                    "User"
+                    "Hide and Block"
                 ],
                 "summary": "Block a user",
                 "description": "Block a specific user. That user will not be able to see your statuses or profile information,\n     *      and cannot send you follow requests. Public statuses are still visible through the incognito mode.",
@@ -2414,7 +2414,12 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/User"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/User"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -2443,7 +2448,7 @@
         "/user/destroyBlock": {
             "delete": {
                 "tags": [
-                    "User"
+                    "Hide and Block"
                 ],
                 "summary": "Unmute a user",
                 "description": "Unblock a specific user. They are now able to see your statuses and profile information again,\n     *      and send you follow requests.",
@@ -2472,7 +2477,12 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/User"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/User"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -2501,7 +2511,7 @@
         "/user/createMute": {
             "post": {
                 "tags": [
-                    "User"
+                    "Hide and Block"
                 ],
                 "summary": "Mute a user",
                 "description": "Mute a specific user. That way they will not be shown on your dashboard and in the active\n     *      journeys tab",
@@ -2530,7 +2540,12 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/User"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/User"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -2559,7 +2574,7 @@
         "/user/destroyMute": {
             "delete": {
                 "tags": [
-                    "User"
+                    "Hide and Block"
                 ],
                 "summary": "Unmute a user",
                 "description": "Unmute a specific user. That way they will be shown on your dashboard and in the active\n     *      journeys tab again",
@@ -2588,7 +2603,12 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/User"
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/User"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -3966,6 +3986,10 @@
         {
             "name": "Follow",
             "description": "Follow and unfollow users, manage your followers"
+        },
+        {
+            "name": "Hide and Block",
+            "description": "Mute and block users"
         },
         {
             "name": "Leaderboard",

--- a/tests/Feature/APIv1/FollowTest.php
+++ b/tests/Feature/APIv1/FollowTest.php
@@ -24,8 +24,7 @@ class FollowTest extends ApiTestCase
         ]);
 
         $response = $this->postJson(
-            uri:     '/api/v1/user/createFollow',
-            data:    ['userId' => $user2->id],
+            uri:     strtr('/api/v1/user/:userId/follow', [':userId' => $user2->id]),
             headers: ['Authorization' => 'Bearer ' . $user1token]
         );
         $response->assertCreated();
@@ -74,9 +73,8 @@ class FollowTest extends ApiTestCase
         $user2      = User::factory()->create();
         UserBackend::createOrRequestFollow($user1, $user2);
 
-        $response = $this->deleteJson(
-            uri:     '/api/v1/user/destroyFollow',
-            data:    ['userId' => $user2->id],
+        $response = $this->delete(
+            uri:     strtr('/api/v1/user/:userId/follow', [':userId' => $user2->id]),
             headers: ['Authorization' => 'Bearer ' . $user1token]
         );
         $response->assertOk();
@@ -86,9 +84,8 @@ class FollowTest extends ApiTestCase
             'follow_id' => $user2->id,
         ]);
 
-        $response = $this->deleteJson(
-            uri:     '/api/v1/user/destroyFollow',
-            data:    ['userId' => $user2->id],
+        $response = $this->delete(
+            uri:     strtr('/api/v1/user/:userId/follow', [':userId' => $user2->id]),
             headers: ['Authorization' => 'Bearer ' . $user1token]
         );
         $response->assertStatus(409);

--- a/tests/Feature/APIv1/TransportTest.php
+++ b/tests/Feature/APIv1/TransportTest.php
@@ -59,7 +59,7 @@ class TransportTest extends ApiTestCase
         //Fetch trip with wrong origin / stopover
         $response = $this->get(
             uri:     '/api/v1/trains/trip'
-                     . '?tripId=' . $departure['tripId']
+                     . '?hafasTripId=' . $departure['tripId']
                      . '&lineName=' . $departure['line']['name']
                      . '&start=' . ($departure['stop']['id'] + 99999),
             headers: ['Authorization' => 'Bearer ' . $this->getTokenForTestUser()]


### PR DESCRIPTION
fixes #1043 

Breaking Changes für Changelog und Discord-Anouncement:
- PUT `statuses/{id}` renamed to `status/{id}` (old Endpoint will reachable until 2023-02-28)
- DELETE `statuses/{id}` renamed to `status/{id}` (old Endpoint will reachable until 2023-02-28)
- POST `like/{statusId}` renamed to `status/{id}/like` (old Endpoint will reachable until 2023-02-28)
- DELETE `like/{status}` renamed to `status/{id}/like` (old Endpoint will reachable until 2023-02-28)
- GET `statuses/{id}` renamed to `status/{id}` (old Endpoint will reachable until 2023-02-28)
- GET `statuses/{id}/likedby` renamed to `status/{id}/likes` (old Endpoint will reachable until 2023-02-28)
- POST `user/createFollow` renamed to `user/{userId}/follow` (old Endpoint will reachable until 2023-02-28)
- DELETE `user/destroyFollow` renamed to `user/{userId}/follow` (old Endpoint will reachable until 2023-02-28)
- GET `trains/trip` now needs `hafasTripId` instead of `tripId` in query