### PR TITLE
:recycle: enable year-in-review via config key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,5 +67,9 @@ MIX_LEGAL_TEL="01234 / 56789"
 TELEGRAM_ADMIN_ID=123456789
 TELEGRAM_TOKEN=12345678:abcdefghijklmnop
 
+# ORTS Backend for support tickets
 TICKET_HOST=https://example.org
 TICKET_APIKEY=xxx
+
+# Should the year in review be visible to the users?
+YEAR_IN_REVIEW_ACTIVE=false

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -32,7 +32,10 @@ class Kernel extends ConsoleKernel
         $schedule->command('trwl:refreshTrips')->withoutOverlapping()->everyMinute();
         $schedule->command('trwl:hideStatus')->daily();
         $schedule->command('trwl:cache:leaderboard')->withoutOverlapping()->everyFiveMinutes();
-        $schedule->command('trwl:cache-year-in-review')->withoutOverlapping()->dailyAt('2:00');
+
+        if (config('trwl.year_in_review_active')) {
+            $schedule->command('trwl:cache-year-in-review')->withoutOverlapping()->dailyAt('2:00');
+        }
     }
 
     /**

--- a/app/Http/Controllers/Frontend/Stats/YearInReviewController.php
+++ b/app/Http/Controllers/Frontend/Stats/YearInReviewController.php
@@ -19,6 +19,10 @@ class YearInReviewController extends Controller
      * @return JsonResponse
      */
     public function show(Request $request): JsonResponse {
+        if (config('trwl.year_in_review_active') === false) {
+            abort(403);
+        }
+
         $validated = $request->validate([
                                             'year' => ['nullable', 'integer', 'min:2019', 'max:' . Date::now()->year],
                                         ]);

--- a/config/trwl.php
+++ b/config/trwl.php
@@ -40,5 +40,6 @@ return [
     'cache'             => [
         'global-statistics-retention-seconds' => env('GLOBAL_STATISTICS_CACHE_RETENTION_SECONDS', 60 * 60),
         'leaderboard-retention-seconds' => env('LEADERBOARD_CACHE_RETENTION_SECONDS', 5 * 60)
-    ]
+    ],
+    'year_in_review_active' => env('YEAR_IN_REVIEW_ACTIVE', false),
 ];

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -92,7 +92,7 @@
                     </div>
                 @endif
 
-                @if(\Illuminate\Support\Facades\Date::now()->isBefore(\Illuminate\Support\Facades\Date::createFromDate(2022,12,26)))
+                @if(config('trwl.year_in_review_active'))
                     <div class="alert alert-info">
                         <h4 class="alert-heading">
                             <i class="fa-solid fa-champagne-glasses"></i>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -70,7 +70,7 @@
                                         {{__('stats')}}
                                     </a>
                                 </li>
-                                @if(\Illuminate\Support\Facades\Date::now()->isBefore(\Illuminate\Support\Facades\Date::createFromDate(2023,1,10)))
+                                @if(config('trwl.year_in_review_active'))
                                     <li class="nav-item">
                                         <a class="nav-link" href="/your-year/">
                                             <i class="fa-solid fa-champagne-glasses"></i>


### PR DESCRIPTION
This PR introduces a configuration key `YEAR_IN_REVIEW_ACTIVE` which when enabled:

* Shows link to Year-In-Review in the main menu
* Shows an advertisement in the dashboard
* Enables the cache-reneval cron of the Year-In-Review statistics
* Enables the `/year-in-review` page for users who have the link