### PR TITLE
:technologist: Add stacktrace to error logging

### DIFF
--- a/app/Models/TrainCheckin.php
+++ b/app/Models/TrainCheckin.php
@@ -75,7 +75,9 @@ class TrainCheckin extends Model
                                                   ->first();
         if ($stopOver == null) {
             //To support legacy data, where we don't save the stopovers in the stopovers table, yet.
-            Log::error('TrainCheckin #' . $this->id . ': Origin stopover not found. Created a new one.');
+            Log::error('TrainCheckin #' . $this->id . ': Origin stopover not found. Created a new one.', [
+                'stacktrace' => debug_backtrace(),
+            ]);
             $stopOver = TrainStopover::updateOrCreate(
                 [
                     "trip_id"          => $this->trip_id,
@@ -97,7 +99,9 @@ class TrainCheckin extends Model
                                                   ->first();
         if ($stopOver == null) {
             //To support legacy data, where we don't save the stopovers in the stopovers table, yet.
-            Log::error('TrainCheckin #' . $this->id . ': Destination stopover not found. Created a new one.');
+            Log::error('TrainCheckin #' . $this->id . ': Destination stopover not found. Created a new one.', [
+                'stacktrace' => debug_backtrace(),
+            ]);
             $stopOver = TrainStopover::updateOrCreate(
                 [
                     "trip_id"          => $this->trip_id,


### PR DESCRIPTION
These lines of code actually exist only to catch an old legacy case. The code should no longer be used, but according to the log it still is regularly.

I need the stack trace to find out where the error is.