### PR TITLE
:globe_with_meridians: Use local spelling of Dutch for consistency

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -91,7 +91,7 @@ return [
         'en'     => 'English',
         'it'     => 'Italiano',
         'fr'     => 'Français',
-        'nl'     => 'Dutch',
+        'nl'     => 'Nederlands',
         'sv'     => 'Svenska',
         'pl'     => 'Polski',
     ],


### PR DESCRIPTION
as all other languages use their local spelling