### PR TITLE
:children_crossing: Remove dropdown animations

### DIFF
--- a/resources/views/includes/business-dropdown.blade.php
+++ b/resources/views/includes/business-dropdown.blade.php
@@ -2,6 +2,7 @@
     <button class="btn btn-sm btn-outline-twitter dropdown-toggle"
             type="button"
             id="businessDropdownButton"
+            data-mdb-dropdown-animation="off"
             data-mdb-toggle="dropdown"
             aria-expanded="false"
     >

--- a/resources/views/includes/visibility-dropdown.blade.php
+++ b/resources/views/includes/visibility-dropdown.blade.php
@@ -2,6 +2,7 @@
     <button class="btn btn-sm btn-outline-twitter dropdown-toggle"
             type="button"
             id="visibilityDropdownButton"
+            data-mdb-dropdown-animation="off"
             data-mdb-toggle="dropdown"
             aria-expanded="false"
     >

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -116,8 +116,8 @@
                                 </li>
                                 <li class="nav-item dropdown">
                                     <a id="navbarDropdown" href="#" class="nav-link dropdown-toggle mdb-select"
-                                       role="button" data-mdb-toggle="dropdown" aria-haspopup="true"
-                                       aria-expanded="false">
+                                       role="button" data-mdb-dropdown-animation="off" data-mdb-toggle="dropdown"
+                                       aria-haspopup="true" aria-expanded="false">
                                         {{ Auth::user()->name }}
                                         <span class="caret"></span>
                                     </a>
@@ -169,8 +169,8 @@
             <footer class="footer mt-auto py-3">
                 <div class="container">
                     <div class="btn-group dropup float-end">
-                        <button type="button" class="btn btn-primary dropdown-toggle" data-mdb-toggle="dropdown"
-                                aria-haspopup="true" aria-expanded="false">
+                        <button type="button" class="btn btn-primary dropdown-toggle" data-mdb-dropdown-animation="off"
+                                data-mdb-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             <i class="fas fa-globe-europe"></i> {{__('settings.language.set')}}
                         </button>
                         <div class="dropdown-menu">


### PR DESCRIPTION
During the fadeout animation, the dropdown items still receive click events and block interaction with the underlying elements. When for example a user tries to check-in after changing the type to `commute`, often the animation hasn't finished yet which results in the dropdown item for `business` reacting to the click event instead of the check-in button.

Other options to solve this problem could be using CSS to set `pointer-events: none` and reverting it to `auto` when the dropdown is open or perhaps increasing the animation speed. But I felt removing the animation makes the UI feel snappier.