### PR TITLE
:bug: :lipstick: fix "last stations" and gps buttons

### DIFF
--- a/resources/views/includes/station-autocomplete.blade.php
+++ b/resources/views/includes/station-autocomplete.blade.php
@@ -17,7 +17,8 @@
                     />
 
                     @if($latest->count() > 0 || auth()->user()->home)
-                        <button class="btn btn-outline-dark stationSearchButton"
+                        <button type="button"
+                                class="btn btn-outline-dark stationSearchButton"
                                 data-mdb-ripple-color="dark"
                                 data-mdb-toggle="collapse"
                                 data-mdb-target="#last-stations"
@@ -27,7 +28,8 @@
                         </button>
                     @endif
 
-                    <button class="btn btn-outline-dark stationSearchButton"
+                    <button type="button"
+                            class="btn btn-outline-dark stationSearchButton"
                             id="gps-button"
                             data-mdb-ripple-color="dark"
                             title="{{__('stationboard.search-by-location')}}">


### PR DESCRIPTION
Closes #1401. Apparently, a `<button>` element submits a form unless told to _not_ submit anything.

Requesting fastline treatment as this is a popular feature in the first visible view of träwelling.de