### PR TITLE
✨ display newlines in status body

### DIFF
--- a/resources/views/includes/status.blade.php
+++ b/resources/views/includes/status.blade.php
@@ -96,7 +96,7 @@
                     </p>
 
                     @if(!empty($status->body))
-                        <p class="status-body"><i class="fas fa-quote-right" aria-hidden="true"></i> {{ $status->body }}
+                        <p class="status-body"><i class="fas fa-quote-right" aria-hidden="true"></i> {!! nl2br(e($status->body)) !!}
                         </p>
                     @endif
 

--- a/resources/views/includes/status.blade.php
+++ b/resources/views/includes/status.blade.php
@@ -96,7 +96,8 @@
                     </p>
 
                     @if(!empty($status->body))
-                        <p class="status-body"><i class="fas fa-quote-right" aria-hidden="true"></i> {!! nl2br(e($status->body)) !!}
+                        <p class="status-body"><i class="fas fa-quote-right" aria-hidden="true"></i>
+                            {!! nl2br(e(preg_replace('~(\R{2})\R+~', '$1', $status->body))) !!}
                         </p>
                     @endif
 

--- a/tests/Feature/Status/StatusBodyTest.php
+++ b/tests/Feature/Status/StatusBodyTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature\Status;
+
+use App\Models\TrainCheckin;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StatusBodyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @dataProvider statusBodyProvider
+     */
+    public function testStatusBodySanitizesHtml($body, $htmlSanitized) {
+        $status       = TrainCheckin::factory()->create()->status;
+        $status->body = $body;
+        $status->update();
+
+        $this->get(route('statuses.get', $status))
+             ->assertSee($htmlSanitized, escape: false);
+    }
+
+    public function statusBodyProvider() {
+        return [
+            [
+                'ab' . PHP_EOL . 'cd',
+                'ab<br />' . PHP_EOL . 'cd'
+            ],
+            [
+                '<script>alert(1)</script>',
+                '&lt;script&gt;alert(1)&lt;/script&gt;'
+            ],
+        ];
+    }
+}

--- a/tests/Feature/Status/StatusBodyTest.php
+++ b/tests/Feature/Status/StatusBodyTest.php
@@ -32,6 +32,14 @@ class StatusBodyTest extends TestCase
                 '<script>alert(1)</script>',
                 '&lt;script&gt;alert(1)&lt;/script&gt;'
             ],
+            [
+                'ab' . PHP_EOL . PHP_EOL . PHP_EOL . PHP_EOL . PHP_EOL . PHP_EOL . PHP_EOL . 'cd',
+                'ab<br />' . PHP_EOL . '<br />' . PHP_EOL . 'cd'
+            ],
+            [
+                'ab' . PHP_EOL . PHP_EOL . PHP_EOL . 'cd' . PHP_EOL . PHP_EOL . PHP_EOL . 'ef',
+                'ab<br />' . PHP_EOL . '<br />' . PHP_EOL . 'cd<br />' . PHP_EOL . '<br />' . PHP_EOL . 'ef'
+            ],
         ];
     }
 }


### PR DESCRIPTION
This fixes #1349. Ive moved to a PHP solution rather than a CSS solution since anything `pre` can cause weird ui bugs.

Since we have to use `{!!` in this case, I've added some more tests that HTML is properly sanitized.

In addition, a "only ever allow two linebreaks at a time" rule has been implemented in the UI, following [this stack exchange answer](https://stackoverflow.com/a/40084137):

<img width="765" alt="image" src="https://user-images.githubusercontent.com/2796271/222096707-ab412ed4-24b1-4f33-8aec-785d3cf098a3.png">
