### PR TITLE
:bug: fix toot chaining bug for custom thread entries

### DIFF
--- a/app/Http/Controllers/Backend/Social/MastodonController.php
+++ b/app/Http/Controllers/Backend/Social/MastodonController.php
@@ -190,7 +190,8 @@ abstract class MastodonController extends Controller
             return null;
         }
 
-        $mastodonUserId = $user->socialProfile->mastodon_id;
+        // Mastodon transmits ids as strings, and since we want to use === whenever possible, we convert the mastodon_id to a string.
+        $mastodonUserId = (string) $user->socialProfile->mastodon_id;
         $onlyThread     = array_filter($context['descendants'], function($toot) use ($mastodonUserId): bool {
             return
                 // We never want to interact with any direct messages

--- a/tests/Feature/Social/MastodonControllerTest.php
+++ b/tests/Feature/Social/MastodonControllerTest.php
@@ -19,12 +19,12 @@ class MastodonControllerTest extends TestCase
 {
     use RefreshDatabase;
 
-    const USERID_OP       = 2342;
-    const USERID_ANSWER   = 2343;
-    const TOOTID_OP       = 1337;
-    const TOOTID_ANSWER   = 1338;
-    const TOOTID_ANSWER_2 = 1339;
-    const TOOTID_ANSWER_3 = 1340;
+    const USERID_OP       = "2342";
+    const USERID_ANSWER   = "2343";
+    const TOOTID_OP       = "1337";
+    const TOOTID_ANSWER   = "1338";
+    const TOOTID_ANSWER_2 = "1339";
+    const TOOTID_ANSWER_3 = "1340";
     const OP_CONTEXT_URL  = '/statuses/' . self::TOOTID_OP . '/context';
 
     /**
@@ -366,7 +366,7 @@ class MastodonControllerTest extends TestCase
             ->socialProfiles()
             ->create([
                          'user_id'         => $user->id,
-                         'mastodon_id'     => self::USERID_OP,
+                         'mastodon_id'     => (int) self::USERID_OP,
                          'mastodon_server' => $mastodonServer->id,
                          'mastodon_token'  => 'my_mastodon_token'
                      ]);


### PR DESCRIPTION
It turns out that it never really worked! Mastodon sends its ids as strings, but in the test we always used ints for all ids. The database holds the social-profile/user-id as a _number_ and the thread tail id as a _string_, so some functionality remained.

This caused the "is the reply from me and thus part of the thread" filter to fail, and create issues for travel logs that also contain non-trwl toots. For trwl-only threads, we always save the tail of the thread in our db, so those threads worked fine.

This PR fixes the issue and changes the tests to reflect actual reality. #tdd