### PR TITLE
💄 🐛 Change label position in edit modal

### DIFF
--- a/resources/views/includes/edit-modal.blade.php
+++ b/resources/views/includes/edit-modal.blade.php
@@ -19,7 +19,7 @@
                         </label>
                     </div>
 
-                    <div class="form-floating">
+                    <div class="form-outline">
                         <textarea class="form-control" name="body" id="status-body" maxlength="280"
                                   placeholder="{{__('modals.editStatus-label')}}"
                                   style="min-height: 130px;"></textarea>


### PR DESCRIPTION
Fixes #1469.

Moved position of label. While it's not perfect, it's a little bit better.
![image](https://user-images.githubusercontent.com/1267894/227506197-ad3b7493-308f-41c2-9481-c89a579e2e7c.png)
