### PR TITLE
:art: improve layout of status footer

### DIFF
--- a/resources/sass/components/status.scss
+++ b/resources/sass/components/status.scss
@@ -31,11 +31,59 @@
         max-width: 100%;
     }
 
+    .interaction {
+        align-items: center;
+        display: flex;
+        height: 3.5rem;
+        justify-content: space-between;
+        padding-block: 0;
+    }
+
+    .metadata-list {
+        align-items: center;
+        display: flex;
+    }
+
+    .interaction-list {
+        margin: 0;
+        margin-right: -0.75rem;
+        padding: 0;
+    }
+
+    .interaction-list-item {
+        align-items: center;
+        display: flex;
+    }
+
+    .interaction-button {
+        align-items: center;
+        appearance: none;
+        background: none;
+        border: none;
+        box-shadow: none;
+        color: inherit;
+        cursor: pointer;
+        display: flex;
+        gap: 0.25rem;
+        height: 2.75rem;
+        justify-content: center;
+        min-width: 2.75rem;
+        padding: 0 0.75rem;
+
+        &[data-mdb-toggle] {
+            color: var(--mdb-link-color);
+        }
+
+        span {
+            margin-top: 1px;
+        }
+    }
+
     .list-inline {
         margin-bottom: 0;
 
         .list-inline-item:not(:last-child) {
-            margin-right: 0.5rem;
+            margin-right: 0.25rem;
         }
     }
 
@@ -43,9 +91,8 @@
         line-height: 2em;
     }
 
-    .like {
+    .like-color {
         color: #f5a530;
-        cursor: pointer;
     }
 
     .visibility-icon {

--- a/resources/sass/components/status.scss
+++ b/resources/sass/components/status.scss
@@ -83,7 +83,7 @@
         margin-bottom: 0;
 
         .list-inline-item:not(:last-child) {
-            margin-right: 0.25rem;
+            margin-right: 0.5rem;
         }
     }
 

--- a/resources/views/includes/status.blade.php
+++ b/resources/views/includes/status.blade.php
@@ -151,30 +151,62 @@
             ></div>
         </div>
         <div class="card-footer text-muted interaction px-3 px-md-4">
-            <ul class="list-inline float-end">
-                <li class="like-text list-inline-item me-0">
-                    <a href="{{ auth()->user() ? '#' : route('login') }}"
-                       class="like {{ auth()->user() && $status->likes->where('user_id', auth()->user()->id)->first() !== null ? 'fas fa-star' : 'far fa-star'}}"
-                       data-trwl-status-id="{{ $status->id }}"></a>
+            <ul class="list-inline metadata-list">
+                <li id="avatar-small-{{ $status->id }}" class="d-lg-none list-inline-item">
+                    <a href="{{ route('profile', ['username' => $status->user->username]) }}">
+                        <img
+                        src="{{ ProfilePictureController::getUrl($status->user) }}"
+                        class="profile-image" alt="{{__('settings.picture')}}">
+                    </a>
                 </li>
-                <li class="like-text list-inline-item">
-                <span class="pl-1 @if($status->likes->count() == 0) d-none @endif"
-                      id="like-count-{{ $status->id }}">{{ $status->likes->count() }}
-                </span>
+                <li class="list-inline-item">
+                    <a href="{{ route('profile', ['username' => $status->user->username]) }}">
+                        @if(auth()?->user()?->id == $status->user_id)
+                        {{__('user.you')}}
+                        @else
+                        {{ $status->user->username }}
+                        @endif
+                    </a>
+                    {{__('dates.-on-')}}
+                    <a href="{{ route('statuses.get', ['id' => $status->id]) }}">
+                        {{ $status->created_at->isoFormat(__('time-format')) }}
+                    </a>
                 </li>
-                <li class="like-text list-inline-item">
+            </ul>
+
+            <ul class="interaction-list">
+                <li class="interaction-list-item">
+                    @if(auth()->user())
+                        <button class="interaction-button like"
+                                type="button"
+                                data-trwl-status-id="{{ $status->id }}">
+                            <i class="like-color {{ auth()->user() && $status->likes->where('user_id', auth()->user()->id)->first() !== null ? 'fas fa-star' : 'far fa-star'}}"></i>
+                            <span class="@if($status->likes->count() == 0) d-none @endif"
+                                id="like-count-{{ $status->id }}">{{ $status->likes->count() }}
+                            </span>
+                        </button>
+                    @else
+                        <a href="{{ route('login') }}"
+                           class="interaction-button like"
+                           data-trwl-status-id="{{ $status->id }}">
+                            <i class="like-color {{ auth()->user() && $status->likes->where('user_id', auth()->user()->id)->first() !== null ? 'fas fa-star' : 'far fa-star'}}"></i>
+                            <span class="@if($status->likes->count() == 0) d-none @endif"
+                                id="like-count-{{ $status->id }}">{{ $status->likes->count() }}
+                            </span>
+                        </a>
+                    @endif
+                </li>
+                <li class="interaction-list-item">
                     <i class="fas {{$status->visibility->faIcon()}} visibility-icon text-small"
                        aria-hidden="true" title="{{$status->visibility->title()}}"
                        data-mdb-toggle="tooltip"
                        data-mdb-placement="top"></i>
                 </li>
-                <li class="like-text list-inline-item">
+                <li class="interaction-list-item">
                     <div class="dropdown">
-                        <a href="#" data-mdb-toggle="dropdown" aria-expanded="false">
-                            &nbsp;
+                        <button class="interaction-button" type="button" data-mdb-toggle="dropdown" aria-expanded="false">
                             <i class="fa fa-ellipsis-vertical" aria-hidden="true"></i>
-                            &nbsp;
-                        </a>
+                        </button>
                         <ul class="dropdown-menu">
                             <li>
                                 <a class="dropdown-item trwl-share"
@@ -236,29 +268,6 @@
                             @endauth
                         </ul>
                     </div>
-                </li>
-            </ul>
-
-            <ul class="list-inline">
-                <li id="avatar-small-{{ $status->id }}" class="d-lg-none list-inline-item">
-                    <a href="{{ route('profile', ['username' => $status->user->username]) }}">
-                        <img
-                                src="{{ ProfilePictureController::getUrl($status->user) }}"
-                                class="profile-image" alt="{{__('settings.picture')}}">
-                    </a>
-                </li>
-                <li class="list-inline-item">
-                    <a href="{{ route('profile', ['username' => $status->user->username]) }}">
-                        @if(auth()?->user()?->id == $status->user_id)
-                            {{__('user.you')}}
-                        @else
-                            {{ $status->user->username }}
-                        @endif
-                    </a>
-                    {{__('dates.-on-')}}
-                    <a href="{{ route('statuses.get', ['id' => $status->id]) }}">
-                        {{ $status->created_at->isoFormat(__('time-format')) }}
-                    </a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
Tapping the star on mobile was hard because of the small hitbox, so I increased the size of it and the new dropdown trigger to the [recommended minimum size for interactable elements (44x44)](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html).

**Before**, the click was only registered when the user hits exactly the star or the dots

![grafik](https://user-images.githubusercontent.com/11841072/227747565-e4e99bd4-fa10-43f0-94e8-1f79b8e2ae59.png)

**Now**, the hit area includes the like counter and is generally increased around the icons

![grafik](https://user-images.githubusercontent.com/11841072/227747596-53e3370b-bf13-4ca0-961a-be8c40ae9aa3.png)

As a bonus, the user avatar and the text next to it are now vertically centered:

![grafik](https://user-images.githubusercontent.com/11841072/227747700-98cb4635-bc23-4192-8811-1f6262b1189d.png)
![grafik](https://user-images.githubusercontent.com/11841072/227747718-274e5671-5b92-439f-a596-a5ffdda36466.png)

