### PR TITLE
:children_crossing: Show only allowed users in leaderboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ Homestead.json
 .idea/**/contentModel.xml
 .idea/commandlinetools/
 .idea/laravel-idea.xml
+.idea/sonarlint.xml
 
 # Sensitive or high-churn files
 .idea/dataSources.xml

--- a/app/Http/Controllers/Frontend/LeaderboardController.php
+++ b/app/Http/Controllers/Frontend/LeaderboardController.php
@@ -20,8 +20,10 @@ class LeaderboardController extends Controller
         $leaderboard = Cache::remember(
             CacheKey::LeaderboardMonth . '-for-' . $date->toISOString(),
             config(self::$cacheRetentionConfigKey),
-            fn() => LeaderboardBackend::getMonthlyLeaderboard($date)
-        );
+            static fn() => LeaderboardBackend::getMonthlyLeaderboard($date)
+        )->filter(function(\stdClass $row) {
+            return Gate::allows('view', $row->user);
+        });
 
         return view('leaderboard.month', [
             'leaderboard' => $leaderboard,

--- a/app/Http/Controllers/Frontend/LeaderboardController.php
+++ b/app/Http/Controllers/Frontend/LeaderboardController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use Carbon\Carbon;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Gate;
 
 class LeaderboardController extends Controller
 {
@@ -35,13 +36,17 @@ class LeaderboardController extends Controller
             CacheKey::LeaderboardGlobalPoints,
             $ttl,
             static fn() => LeaderboardBackend::getLeaderboard()
-        );
+        )->filter(function(\stdClass $row) {
+            return Gate::allows('view', $row->user);
+        });
 
         $distanceLeaderboard = Cache::remember(
             CacheKey::LeaderboardGlobalDistance,
             $ttl,
             static fn() => LeaderboardBackend::getLeaderboard(orderBy: 'distance')
-        );
+        )->filter(function(\stdClass $row) {
+            return Gate::allows('view', $row->user);
+        });
 
         $friendsLeaderboard = auth()->check()
             ? Cache::remember(


### PR DESCRIPTION
fixes #1517 

As the global leaderboard tabs are cached, this PR checks every user shown for the ability if the current user (or guest) can view the profile. This checks if the current user is blocked or the shown user is muted by current user.