### PR TITLE
✨ Use Brouter route where no real route is supplied by Hafas

### DIFF
--- a/app/Dto/Coordinate.php
+++ b/app/Dto/Coordinate.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Dto;
+
+class Coordinate
+{
+
+    public float $latitude;
+    public float $longitude;
+
+    public function __construct(float $latitude, float $longitude) {
+        $this->latitude  = $latitude;
+        $this->longitude = $longitude;
+    }
+
+}

--- a/app/Dto/Coordinate.php
+++ b/app/Dto/Coordinate.php
@@ -12,6 +12,7 @@ class Coordinate
     public function __construct(float $latitude, float $longitude) {
         $this->latitude  = $latitude;
         $this->longitude = $longitude;
+        \Log::debug("$latitude, $longitude");
     }
 
 }

--- a/app/Dto/Coordinate.php
+++ b/app/Dto/Coordinate.php
@@ -12,7 +12,6 @@ class Coordinate
     public function __construct(float $latitude, float $longitude) {
         $this->latitude  = $latitude;
         $this->longitude = $longitude;
-        \Log::debug("$latitude, $longitude");
     }
 
 }

--- a/app/Enum/BrouterProfile.php
+++ b/app/Enum/BrouterProfile.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Enum;
+
+/**
+ *
+ */
+enum BrouterProfile: string
+{
+    case RAIL = 'rail';
+    case CAR_FAST = 'car-fast';
+    case CAR_SHORTEST = 'car-shortest';
+}

--- a/app/Enum/HafasTravelType.php
+++ b/app/Enum/HafasTravelType.php
@@ -29,4 +29,11 @@ enum HafasTravelType: string
             default                       => '',
         };
     }
+
+    public function onRails(): bool {
+        return match ($this) {
+            static::BUS, static::FERRY, static::TAXI => false,
+            default                                  => true,
+        };
+    }
 }

--- a/app/Http/Controllers/Backend/BrouterController.php
+++ b/app/Http/Controllers/Backend/BrouterController.php
@@ -27,7 +27,7 @@ abstract class BrouterController extends Controller
         Log::debug('Brouter URL is '.$response->effectiveUri());
         if (!$response->ok()) return null;
 
-        return json_decode($response->body());
+        return json_decode($response->body(), false, 512, JSON_THROW_ON_ERROR);
     }
 }
 ?>

--- a/app/Http/Controllers/Backend/BrouterController.php
+++ b/app/Http/Controllers/Backend/BrouterController.php
@@ -4,11 +4,13 @@ namespace App\Http\Controllers\Backend;
 
 use App\Dto\Coordinate;
 use App\Enum\BrouterProfile;
+use App\Http\Controllers\Backend\Transport\TrainCheckinController;
 use App\Http\Controllers\Controller;
 use App\Jobs\PostStatusOnMastodon;
 use App\Jobs\RefreshPolyline;
 use App\Models\HafasTrip;
 use App\Models\PolyLine;
+use App\Models\TrainCheckin;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
@@ -134,6 +136,12 @@ abstract class BrouterController extends Controller
                                          'source'   => 'brouter',
                                      ]);
         $trip->update(['polyline_id' => $polyline->id]);
+
+        //Refresh distance and points of trips
+        $trainCheckinToRecalc = TrainCheckin::with(['status'])->where('trip_id', $trip->trip_id)->get();
+        foreach ($trainCheckinToRecalc as $trainCheckin) {
+            TrainCheckinController::refreshDistanceAndPoints($trainCheckin->status);
+        }
     }
 
     /**

--- a/app/Http/Controllers/Backend/BrouterController.php
+++ b/app/Http/Controllers/Backend/BrouterController.php
@@ -12,6 +12,7 @@ use App\Models\HafasTrip;
 use App\Models\PolyLine;
 use App\Models\TrainCheckin;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -68,6 +69,9 @@ abstract class BrouterController extends Controller
      * @throws JsonException
      */
     public static function reroutePolyline(HafasTrip $trip): void {
+        if (App::runningUnitTests()) {
+            return;
+        }
         //1. Prepare coordinates from stations
         $coordinates = [];
         foreach ($trip->stopoversNEW as $stopover) {

--- a/app/Http/Controllers/Backend/BrouterController.php
+++ b/app/Http/Controllers/Backend/BrouterController.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use JsonException;
+use stdClass;
 
 abstract class BrouterController extends Controller
 {
@@ -30,7 +31,7 @@ abstract class BrouterController extends Controller
     public static function getGeoJSONForRoute(
         array          $coordinates,
         BrouterProfile $profile = BrouterProfile::RAIL //Maybe extend this for other travel types later
-    ): mixed {
+    ): ?stdClass {
         $lonlats = [];
         foreach ($coordinates as $coords) {
             $lonlats[] = implode(',', array_reverse($coords)); //brouter needs order lon,lat

--- a/app/Http/Controllers/Backend/BrouterController.php
+++ b/app/Http/Controllers/Backend/BrouterController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Backend;
 
+use App\Enum\BrouterProfile;
 use App\Http\Controllers\Controller;
 use App\Models\HafasTrip;
 use App\Models\PolyLine;
@@ -25,8 +26,8 @@ abstract class BrouterController extends Controller
      * @throws \JsonException
      */
     public static function getGeoJSONForRoute(
-        array  $coordinates,
-        string $profile = 'rail' //Maybe extend this for other travel types later
+        array          $coordinates,
+        BrouterProfile $profile = BrouterProfile::RAIL //Maybe extend this for other travel types later
     ): mixed {
         $coordinateString = 'brouter?lonlats=';
         foreach ($coordinates as $coords) {
@@ -38,7 +39,7 @@ abstract class BrouterController extends Controller
         $response = self::getHttpClient()
                         ->get(strtr('brouter?lonlats=:coords&profile=:profile&alternativeidx=0&format=geojson', [
                             ':coords'  => $coordinateString,
-                            ':profile' => $profile,
+                            ':profile' => $profile->value,
                         ]));
         Log::debug('Brouter URL is ' . $response->effectiveUri());
         if (!$response->ok()) {

--- a/app/Http/Controllers/Backend/BrouterController.php
+++ b/app/Http/Controllers/Backend/BrouterController.php
@@ -2,8 +2,11 @@
 namespace App\Http\Controllers\Backend;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Exception;
+use stdClass;
 
 abstract class BrouterController extends Controller
 {
@@ -17,9 +20,12 @@ abstract class BrouterController extends Controller
         float $longitudeA,
         float $latitudeB,
         float $longitudeB
-    ): stdClass {
+    ): ?stdClass {
+        https://brouter.de/brouter?lonlats=49.214089,6.944311|48.876976,2.35912&profile=rail&alternativeidx=0&format=geojson
         $response = self::getHttpClient()
-            ->get('?lonlats='.$latitudeA.','.$longitudeA.'|'.$latitudeB.','.$longitudeB.'&profile=rail&alternativeidx=0&format=geojson');
+            ->get('brouter?lonlats='.$longitudeA.','.$latitudeA.'|'.$longitudeB.','.$latitudeB.'&profile=rail&alternativeidx=0&format=geojson');
+        Log::debug('Brouter URL is '.$response->effectiveUri());
+        if (!$response->ok()) return null;
 
         return json_decode($response->body());
     }

--- a/app/Http/Controllers/Backend/BrouterController.php
+++ b/app/Http/Controllers/Backend/BrouterController.php
@@ -28,7 +28,7 @@ abstract class BrouterController extends Controller
     }
 
     /**
-     * @param array          $coordinates Array of App/Dto/Coordinate objects
+     * @param array          $coordinates Array of App\Dto\Coordinate objects
      * @param BrouterProfile $profile
      *
      * @return null|stdClass

--- a/app/Http/Controllers/Backend/BrouterController.php
+++ b/app/Http/Controllers/Backend/BrouterController.php
@@ -55,7 +55,10 @@ abstract class BrouterController extends Controller
             return null;
         }
 
-        return json_decode($response->body(), false, 512, JSON_THROW_ON_ERROR);
+        $geoJson = json_decode($response->body(), false, 512, JSON_THROW_ON_ERROR);
+        //remove unnecessary data
+        unset($geoJson->features[0]->properties->messages, $geoJson->features[0]->properties->times);
+        return $geoJson;
     }
 
     /**
@@ -80,8 +83,6 @@ abstract class BrouterController extends Controller
 
         //2. Request route at brouter
         $brouterGeoJSON = self::getGeoJSONForRoute($coordinates);
-        //remove unnecessary data
-        unset($brouterGeoJSON->features[0]->properties->messages, $brouterGeoJSON->features[0]->properties->times);
 
         //3. Create "new" GeoJSON splitted by stations (as features)
         $geoJson = ['type' => 'FeatureCollection', 'features' => []];

--- a/app/Http/Controllers/Backend/BrouterController.php
+++ b/app/Http/Controllers/Backend/BrouterController.php
@@ -1,0 +1,27 @@
+<?php
+namespace App\Http\Controllers\Backend;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Http;
+use Exception;
+
+abstract class BrouterController extends Controller
+{
+    public static function getHttpClient(): PendingRequest {
+        return Http::baseUrl(config('trwl.brouter_url'))
+                   ->timeout(config('trwl.brouter_timeout'));
+    }
+
+    public static function getGeoJSON(
+        float $latitudeA,
+        float $longitudeA,
+        float $latitudeB,
+        float $longitudeB
+    ): stdClass {
+        $response = self::getHttpClient()
+            ->get('?lonlats='.$latitudeA.','.$longitudeA.'|'.$latitudeB.','.$longitudeB.'&profile=rail&alternativeidx=0&format=geojson');
+
+        return json_decode($response->body());
+    }
+}
+?>

--- a/app/Http/Controllers/Backend/BrouterController.php
+++ b/app/Http/Controllers/Backend/BrouterController.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use JsonException;
 use stdClass;
+use Str;
 
 abstract class BrouterController extends Controller
 {
@@ -131,7 +132,7 @@ abstract class BrouterController extends Controller
         }
 
         $polyline = PolyLine::create([
-                                         'hash'     => DB::raw('UUID()'), //In this case a non required unique key
+                                         'hash'     => Str::uuid(), //In this case a non required unique key
                                          'polyline' => json_encode($geoJson),
                                          'source'   => 'brouter',
                                      ]);

--- a/app/Http/Controllers/Backend/BrouterController.php
+++ b/app/Http/Controllers/Backend/BrouterController.php
@@ -21,7 +21,6 @@ abstract class BrouterController extends Controller
         float $latitudeB,
         float $longitudeB
     ): ?stdClass {
-        https://brouter.de/brouter?lonlats=49.214089,6.944311|48.876976,2.35912&profile=rail&alternativeidx=0&format=geojson
         $response = self::getHttpClient()
             ->get('brouter?lonlats='.$longitudeA.','.$latitudeA.'|'.$longitudeB.','.$latitudeB.'&profile=rail&alternativeidx=0&format=geojson');
         Log::debug('Brouter URL is '.$response->effectiveUri());

--- a/app/Http/Controllers/Backend/BrouterController.php
+++ b/app/Http/Controllers/Backend/BrouterController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Backend;
 
+use App\Dto\Coordinate;
 use App\Enum\BrouterProfile;
 use App\Http\Controllers\Controller;
 use App\Models\HafasTrip;
@@ -21,11 +22,10 @@ abstract class BrouterController extends Controller
     }
 
     /**
-     * @param array          $coordinates Array with Sub-Array containing the coordinates in order lat, lon (use
-     *                                    floats!)
+     * @param array          $coordinates Array of App/Dto/Coordinate objects
      * @param BrouterProfile $profile
      *
-     * @return mixed|null
+     * @return null|stdClass
      * @throws JsonException
      */
     public static function getGeoJSONForRoute(
@@ -33,8 +33,8 @@ abstract class BrouterController extends Controller
         BrouterProfile $profile = BrouterProfile::RAIL //Maybe extend this for other travel types later
     ): ?stdClass {
         $lonlats = [];
-        foreach ($coordinates as $coords) {
-            $lonlats[] = implode(',', array_reverse($coords)); //brouter needs order lon,lat
+        foreach ($coordinates as $coord) {
+            $lonlats[] = $coord->longitude . ',' . $coord->latitude; //brouter needs order lon,lat
         }
         $coordinateString = implode('|', $lonlats);
 
@@ -66,10 +66,7 @@ abstract class BrouterController extends Controller
         //1. Prepare coordinates from stations
         $coordinates = [];
         foreach ($trip->stopoversNEW as $stopover) {
-            $coordinates[] = [
-                $stopover->trainStation->latitude,
-                $stopover->trainStation->longitude,
-            ];
+            $coordinates[] = new Coordinate($stopover->trainStation->latitude, $stopover->trainStation->longitude);
         }
 
         //2. Request route at brouter

--- a/app/Http/Controllers/Backend/BrouterController.php
+++ b/app/Http/Controllers/Backend/BrouterController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Http\Controllers\Backend;
 
 use App\Http\Controllers\Controller;
@@ -22,11 +23,13 @@ abstract class BrouterController extends Controller
         float $longitudeB
     ): ?stdClass {
         $response = self::getHttpClient()
-            ->get('brouter?lonlats='.$longitudeA.','.$latitudeA.'|'.$longitudeB.','.$latitudeB.'&profile=rail&alternativeidx=0&format=geojson');
-        Log::debug('Brouter URL is '.$response->effectiveUri());
-        if (!$response->ok()) return null;
+                        ->get('brouter?lonlats=' . $longitudeA . ',' . $latitudeA . '|' . $longitudeB . ',' . $latitudeB . '&profile=rail&alternativeidx=0&format=geojson');
+        Log::debug('Brouter URL is ' . $response->effectiveUri());
+        if (!$response->ok()) {
+            Log::debug('Brouter response was not okay.', ['body' => $response->body()]);
+            return null;
+        }
 
         return json_decode($response->body(), false, 512, JSON_THROW_ON_ERROR);
     }
 }
-?>

--- a/app/Http/Controllers/Backend/BrouterController.php
+++ b/app/Http/Controllers/Backend/BrouterController.php
@@ -3,11 +3,12 @@
 namespace App\Http\Controllers\Backend;
 
 use App\Http\Controllers\Controller;
+use App\Models\HafasTrip;
+use App\Models\PolyLine;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
-use Exception;
-use stdClass;
 
 abstract class BrouterController extends Controller
 {
@@ -16,14 +17,29 @@ abstract class BrouterController extends Controller
                    ->timeout(config('trwl.brouter_timeout'));
     }
 
-    public static function getGeoJSON(
-        float $latitudeA,
-        float $longitudeA,
-        float $latitudeB,
-        float $longitudeB
-    ): ?stdClass {
+    /**
+     * @param array  $coordinates Array with Sub-Array containing the coordinates in order lat, lon (use floats!)
+     * @param string $profile
+     *
+     * @return mixed|null
+     * @throws \JsonException
+     */
+    public static function getGeoJSONForRoute(
+        array  $coordinates,
+        string $profile = 'rail' //Maybe extend this for other travel types later
+    ): mixed {
+        $coordinateString = 'brouter?lonlats=';
+        foreach ($coordinates as $coords) {
+            $lonlat           = implode(',', array_reverse($coords)); //brouter needs order lon,lat
+            $coordinateString .= $lonlat . '|';
+        }
+        $coordinateString = rtrim($coordinateString, '|'); // Remove last "|"
+
         $response = self::getHttpClient()
-                        ->get('brouter?lonlats=' . $longitudeA . ',' . $latitudeA . '|' . $longitudeB . ',' . $latitudeB . '&profile=rail&alternativeidx=0&format=geojson');
+                        ->get(strtr('brouter?lonlats=:coords&profile=:profile&alternativeidx=0&format=geojson', [
+                            ':coords'  => $coordinateString,
+                            ':profile' => $profile,
+                        ]));
         Log::debug('Brouter URL is ' . $response->effectiveUri());
         if (!$response->ok()) {
             Log::debug('Brouter response was not okay.', ['body' => $response->body()]);
@@ -31,5 +47,84 @@ abstract class BrouterController extends Controller
         }
 
         return json_decode($response->body(), false, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * 1. Fetch route for all stations of a trip at brouter
+     * 2. split the route by stations (we need the GeoJSON splitted!)
+     * 3. Create features for every station and route between
+     *
+     * @param HafasTrip $trip
+     *
+     * @return void
+     * @throws \JsonException
+     */
+    public static function reroutePolyline(HafasTrip $trip) {
+        //1. Prepare coordinates from stations
+        $coordinates = [];
+        foreach ($trip->stopoversNEW as $stopover) {
+            $coordinates[] = [
+                $stopover->trainStation->latitude,
+                $stopover->trainStation->longitude,
+            ];
+        }
+
+        //2. Request route at brouter
+        $brouterGeoJSON = self::getGeoJSONForRoute($coordinates);
+        //remove unnecessary data
+        unset($brouterGeoJSON->features[0]->properties->messages, $brouterGeoJSON->features[0]->properties->times);
+
+        //3. Create "new" GeoJSON splitted by stations (as features)
+        $geoJson = ['type' => 'FeatureCollection', 'features' => []];
+
+        foreach ($brouterGeoJSON?->features[0]?->geometry?->coordinates ?? [] as $coordinate) {
+            $geoJson['features'][] = [
+                'type'       => 'feature',
+                'properties' => [],
+                'geometry'   => [
+                    'type'        => 'Point',
+                    'coordinates' => [
+                        $coordinate[0],
+                        $coordinate[1],
+                    ]
+                ]
+            ];
+        }
+
+        //4. Try to map stations to GeoJSON
+        foreach ($trip->stopoversNEW as $stopover) {
+            $properties = [
+                'id'                => $stopover->trainStation->ibnr,
+                'name'              => $stopover->trainStation->name,
+                'departure_planned' => $stopover->departure_planned,
+                'arrival_planned'   => $stopover->arrival_planned,
+            ];
+
+            //Get feature with the lowest distance to station
+            $minDistance    = null;
+            $closestFeatureKey = null;
+            foreach ($geoJson['features'] as $key => $feature) {
+                $distance = GeoController::calculateDistanceBetweenCoordinates(
+                    latitudeA:  $feature['geometry']['coordinates'][1],
+                    longitudeA: $feature['geometry']['coordinates'][1],
+                    latitudeB:  $stopover->trainStation->latitude,
+                    longitudeB: $stopover->trainStation->longitude,
+                );
+                if ($minDistance === null || $distance < $minDistance) {
+                    $minDistance    = $distance;
+                    $closestFeatureKey = $key;
+                }
+            }
+
+            $geoJson['features'][$closestFeatureKey]['properties'] = $properties;
+        }
+
+        $polyline = PolyLine::create([
+                                         'hash'     => DB::raw('UUID()'), //In this case a non required unique key
+                                         'polyline' => json_encode($geoJson),
+                                     ]);
+        $trip->update(['polyline_id' => $polyline->id]);
+
+        dd(json_encode($geoJson, JSON_PRETTY_PRINT));
     }
 }

--- a/app/Http/Controllers/Backend/GeoController.php
+++ b/app/Http/Controllers/Backend/GeoController.php
@@ -138,6 +138,8 @@ abstract class GeoController extends Controller
                         Log::debug('Route found via Brouter: ' . json_encode($coordinates));
                         // Save new points for later
                         $additionalRoutes[$key] = $coordinates;
+                    } else {
+                        Log::debug('No route found via Brouter! :(');
                     }
                 }
 

--- a/app/Http/Controllers/Backend/GeoController.php
+++ b/app/Http/Controllers/Backend/GeoController.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Controllers\Backend;
 
-use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use App\Models\HafasTrip;
 use App\Models\TrainCheckin;
 use App\Models\TrainStopover;
 use Exception;
+use Illuminate\Support\Facades\Log;
 use JsonException;
 use stdClass;
 
@@ -123,13 +123,13 @@ abstract class GeoController extends Controller
                 if (!is_null($lastStopOver) && $hafasTrip?->category?->onRails()) { // A real route is missing -> request route via Brouter
                     Log::debug('Missing route found between ' . ($lastStopOver->properties->name ?? 'unknown') . ' and ' . ($data->properties->name ?? 'unknown'));
 
+                    $stationCoordinates = [
+                        [$lastStopOver->properties->location->latitude, $lastStopOver->properties->location->longitude],
+                        [$data->properties->location->latitude, $data->properties->location->longitude,]
+                    ];
+
                     // Demande real route from BrouterController
-                    $response = BrouterController::getGeoJSON(
-                        $lastStopOver->properties->location->latitude,
-                        $lastStopOver->properties->location->longitude,
-                        $data->properties->location->latitude,
-                        $data->properties->location->longitude,
-                    );
+                    $response = BrouterController::getGeoJSONForRoute($stationCoordinates);
 
                     if ($response !== null) {
                         // Create new points for polyline

--- a/app/Http/Controllers/Backend/GeoController.php
+++ b/app/Http/Controllers/Backend/GeoController.php
@@ -140,7 +140,7 @@ abstract class GeoController extends Controller
         if (count($additionalRoutes)) {
             $updatedFeatures = [];
             foreach ($slicedFeatures as $key => $data) {
-                if (isset($additionalRoutes[$key]) && $key != $originIndex) { // There is a route but the we're at the origin?
+                if (isset($additionalRoutes[$key]) && $key != $originIndex) { // There is a route but we're at the origin?
                     $updatedFeatures = [...$updatedFeatures, ...$additionalRoutes[$key]];
                 }
                 $updatedFeatures[] = $data;

--- a/app/Http/Controllers/Backend/GeoController.php
+++ b/app/Http/Controllers/Backend/GeoController.php
@@ -113,25 +113,11 @@ abstract class GeoController extends Controller
 
         $originIndex      = null;
         $destinationIndex = null;
-        $lastStopOver     = null; // To detect whether as the crow flies or real routing
         $additionalRoutes = [];
         foreach ($features as $key => $data) {
             if (!isset($data->properties->id)) {
-                $lastStopOver = null;
                 continue;
             }
-
-            $partOfRouteMissing = false;
-            if (!is_null($lastStopOver) && $hafasTrip?->category?->onRails()) { // A real route is missing -> request route via Brouter
-                Log::debug('Missing route found between ' . ($lastStopOver->properties->name ?? 'unknown') . ' and ' . ($data->properties->name ?? 'unknown'));
-                $partOfRouteMissing = true;
-            }
-
-            if($partOfRouteMissing) {
-                //ToDo: Fetch new Polyline
-            }
-
-            $lastStopOver = $data;
 
             if ($originIndex === null
                 && $origin->trainStation->ibnr === (int) $data->properties->id

--- a/app/Http/Controllers/Backend/GeoController.php
+++ b/app/Http/Controllers/Backend/GeoController.php
@@ -120,7 +120,7 @@ abstract class GeoController extends Controller
                 $lastStopOver = null;
                 continue;
             } else {
-                if (!is_null($lastStopOver)) { // A real route is missing -> request route via Brouter
+                if (!is_null($lastStopOver) && $hafasTrip?->category?->onRails()) { // A real route is missing -> request route via Brouter
                     Log::debug('Missing route found between ' . ($lastStopOver->properties->name ?? 'unknown') . ' and ' . ($data->properties->name ?? 'unknown'));
 
                     // Demande real route from BrouterController

--- a/app/Http/Controllers/Backend/GeoController.php
+++ b/app/Http/Controllers/Backend/GeoController.php
@@ -165,7 +165,9 @@ abstract class GeoController extends Controller
         if (count($additionalRoutes)) {
             $updatedFeatures = [];
             foreach ($slicedFeatures as $key => $data) {
-                if (isset($additionalRoutes[$key])) $updatedFeatures = [...$updatedFeatures, ...$additionalRoutes[$key]];
+                if (isset($additionalRoutes[$key]) && $key != $originIndex) { // There is a route but the we're at the origin?
+                    $updatedFeatures = [...$updatedFeatures, ...$additionalRoutes[$key]];
+                }
                 $updatedFeatures[] = $data;
             }
             $slicedFeatures = $updatedFeatures;

--- a/app/Http/Controllers/Backend/GeoController.php
+++ b/app/Http/Controllers/Backend/GeoController.php
@@ -119,32 +119,19 @@ abstract class GeoController extends Controller
             if (!isset($data->properties->id)) {
                 $lastStopOver = null;
                 continue;
-            } else {
-                if (!is_null($lastStopOver) && $hafasTrip?->category?->onRails()) { // A real route is missing -> request route via Brouter
-                    Log::debug('Missing route found between ' . ($lastStopOver->properties->name ?? 'unknown') . ' and ' . ($data->properties->name ?? 'unknown'));
-
-                    $stationCoordinates = [
-                        [$lastStopOver->properties->location->latitude, $lastStopOver->properties->location->longitude],
-                        [$data->properties->location->latitude, $data->properties->location->longitude,]
-                    ];
-
-                    // Demande real route from BrouterController
-                    $response = BrouterController::getGeoJSONForRoute($stationCoordinates);
-
-                    if ($response !== null) {
-                        // Create new points for polyline
-                        $coordinates = $response?->features[0]?->geometry?->coordinates ?? [];
-                        $coordinates = array_map(fn($c) => (object) ['type' => 'Feature', 'geometry' => (object) ['type' => 'Point', 'coordinates' => array_slice($c, 0, 2)]], $coordinates);
-                        Log::debug('Route found via Brouter: ' . json_encode($coordinates));
-                        // Save new points for later
-                        $additionalRoutes[$key] = $coordinates;
-                    } else {
-                        Log::debug('No route found via Brouter! :(');
-                    }
-                }
-
-                $lastStopOver = $data;
             }
+
+            $partOfRouteMissing = false;
+            if (!is_null($lastStopOver) && $hafasTrip?->category?->onRails()) { // A real route is missing -> request route via Brouter
+                Log::debug('Missing route found between ' . ($lastStopOver->properties->name ?? 'unknown') . ' and ' . ($data->properties->name ?? 'unknown'));
+                $partOfRouteMissing = true;
+            }
+
+            if($partOfRouteMissing) {
+                //ToDo: Fetch new Polyline
+            }
+
+            $lastStopOver = $data;
 
             if ($originIndex === null
                 && $origin->trainStation->ibnr === (int) $data->properties->id

--- a/app/Http/Controllers/FrontendStatusController.php
+++ b/app/Http/Controllers/FrontendStatusController.php
@@ -134,8 +134,6 @@ class FrontendStatusController extends Controller
     public function getStatus($statusId): Renderable {
         $status = StatusBackend::getStatus($statusId);
 
-        BrouterController::reroutePolyline($status->trainCheckin->HafasTrip);
-
         try {
             $this->authorize('view', $status);
         } catch (AuthorizationException) {

--- a/app/Http/Controllers/FrontendStatusController.php
+++ b/app/Http/Controllers/FrontendStatusController.php
@@ -4,14 +4,12 @@ namespace App\Http\Controllers;
 
 use App\Exceptions\PermissionException;
 use App\Exceptions\StatusAlreadyLikedException;
-use App\Http\Controllers\Backend\BrouterController;
 use App\Http\Controllers\Backend\EventController as EventBackend;
 use App\Http\Controllers\Backend\GeoController;
 use App\Http\Controllers\Backend\User\DashboardController;
 use App\Http\Controllers\Backend\User\ProfilePictureController;
 use App\Http\Controllers\StatusController as StatusBackend;
 use App\Models\Status;
-use App\Models\TrainStation;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Database\Eloquent\ModelNotFoundException;

--- a/app/Http/Controllers/FrontendStatusController.php
+++ b/app/Http/Controllers/FrontendStatusController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Exceptions\PermissionException;
 use App\Exceptions\StatusAlreadyLikedException;
+use App\Http\Controllers\Backend\BrouterController;
 use App\Http\Controllers\Backend\EventController as EventBackend;
 use App\Http\Controllers\Backend\GeoController;
 use App\Http\Controllers\Backend\User\DashboardController;
@@ -132,6 +133,8 @@ class FrontendStatusController extends Controller
 
     public function getStatus($statusId): Renderable {
         $status = StatusBackend::getStatus($statusId);
+
+        BrouterController::reroutePolyline($status->trainCheckin->HafasTrip);
 
         try {
             $this->authorize('view', $status);

--- a/app/Jobs/RefreshPolyline.php
+++ b/app/Jobs/RefreshPolyline.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Http\Controllers\Backend\BrouterController;
+use App\Models\HafasTrip;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use romanzipp\QueueMonitor\Traits\IsMonitored;
+
+class RefreshPolyline implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, IsMonitored, Queueable, SerializesModels;
+
+    protected HafasTrip $hafasTrip;
+
+    public function __construct(HafasTrip $hafasTrip) {
+        $this->hafasTrip = $hafasTrip;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function handle(): void {
+        \Log::debug('running job');
+        BrouterController::reroutePolyline($this->hafasTrip);
+    }
+}

--- a/app/Jobs/RefreshPolyline.php
+++ b/app/Jobs/RefreshPolyline.php
@@ -28,7 +28,6 @@ class RefreshPolyline implements ShouldQueue
      * @throws \Exception
      */
     public function handle(): void {
-        \Log::debug('running job');
         BrouterController::reroutePolyline($this->hafasTrip);
     }
 }

--- a/app/Listeners/StatusCreateCheckPolylineListener.php
+++ b/app/Listeners/StatusCreateCheckPolylineListener.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Enum\WebhookEvent;
+use App\Events\UserCheckedIn;
+use App\Http\Controllers\Backend\BrouterController;
+use App\Http\Controllers\Backend\WebhookController;
+
+class StatusCreateCheckPolylineListener
+{
+    public function handle(UserCheckedIn $event): void {
+        BrouterController::checkPolyline($event->status->trainCheckin->HafasTrip);
+    }
+}

--- a/app/Models/PolyLine.php
+++ b/app/Models/PolyLine.php
@@ -8,9 +8,10 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class PolyLine extends Model
 {
 
-    protected $fillable = ['hash', 'polyline'];
+    protected $fillable = ['hash', 'polyline', 'source'];
     protected $casts    = [
-        'id' => 'integer',
+        'id'     => 'integer',
+        'source' => 'string', //enum['hafas', 'brouter'] in database
     ];
 
     public function trips(): HasMany {

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -7,6 +7,7 @@ use App\Events\StatusUpdateEvent;
 use App\Events\UserCheckedIn;
 use App\Jobs\PostStatusOnMastodon;
 use App\Listeners\NotificationSentWebhookListener;
+use App\Listeners\StatusCreateCheckPolylineListener;
 use App\Listeners\StatusCreateWebhookListener;
 use App\Listeners\StatusDeleteWebhookListener;
 use App\Listeners\StatusUpdateWebhookListener;
@@ -17,7 +18,8 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Spatie\WebhookServer\Events\WebhookCallFailedEvent;
 
-class EventServiceProvider extends ServiceProvider {
+class EventServiceProvider extends ServiceProvider
+{
     /**
      * The event listener mappings for the application.
      *
@@ -28,7 +30,8 @@ class EventServiceProvider extends ServiceProvider {
             //SendEmailVerificationNotification::class,
         ],
         UserCheckedIn::class     => [
-            StatusCreateWebhookListener::class
+            StatusCreateWebhookListener::class,
+            StatusCreateCheckPolylineListener::class,
         ],
         StatusUpdateEvent::class => [
             StatusUpdateWebhookListener::class
@@ -36,7 +39,7 @@ class EventServiceProvider extends ServiceProvider {
         StatusDeleteEvent::class => [
             StatusDeleteWebhookListener::class
         ],
-        NotificationSent::class => [
+        NotificationSent::class  => [
             NotificationSentWebhookListener::class
         ]
     ];
@@ -50,8 +53,7 @@ class EventServiceProvider extends ServiceProvider {
         parent::boot();
 
         // Dispatch Jobs from Events
-        Event::listen(fn (UserCheckedIn $event)
-        => PostStatusOnMastodon::dispatchIf($event->shouldPostOnMastodon, $event->status, $event->shouldChain));
-        Event::listen(fn (WebhookCallFailedEvent $event) => Log::error("Webhook call failed", ['event' => $event]));
+        Event::listen(fn(UserCheckedIn $event) => PostStatusOnMastodon::dispatchIf($event->shouldPostOnMastodon, $event->status, $event->shouldChain));
+        Event::listen(fn(WebhookCallFailedEvent $event) => Log::error("Webhook call failed", ['event' => $event]));
     }
 }

--- a/config/trwl.php
+++ b/config/trwl.php
@@ -19,7 +19,7 @@ return [
 
     # Brouter
     'brouter_url'           => env('BROUTER_URL', 'https://brouter.de/'),
-    'brouter_timeout'       => env('BROUTER_TIMEOUT', 3),
+    'brouter_timeout'       => env('BROUTER_TIMEOUT', 10),
 
     # DB_REST
     'db_rest'               => env('DB_REST', 'https://v5.db.transport.rest/'),

--- a/config/trwl.php
+++ b/config/trwl.php
@@ -19,7 +19,7 @@ return [
 
     # Brouter
     'brouter_url'           => env('BROUTER_URL', 'https://brouter.de/'),
-    'brouter_timeout'       => env('BROUTER_TIMEOUT', 10),
+    'brouter_timeout'       => env('BROUTER_TIMEOUT', 3),
 
     # DB_REST
     'db_rest'               => env('DB_REST', 'https://v5.db.transport.rest/'),

--- a/config/trwl.php
+++ b/config/trwl.php
@@ -17,6 +17,10 @@ return [
     'mastodon_redirect'     => env('MASTODON_REDIRECT'),
     'mastodon_appname'      => env('MASTODON_APPNAME'),
 
+    # Brouter
+    'brouter_url'           => env('BROUTER_URL', 'https://brouter.de/brouter'),
+    'brouter_timeout'   => env('BROUTER_TIMEOUT', 10),
+
     # DB_REST
     'db_rest'               => env('DB_REST', 'https://v5.db.transport.rest/'),
     'db_rest_timeout'       => env('DB_REST_TIMEOUT', 10),

--- a/config/trwl.php
+++ b/config/trwl.php
@@ -18,8 +18,8 @@ return [
     'mastodon_appname'      => env('MASTODON_APPNAME'),
 
     # Brouter
-    'brouter_url'           => env('BROUTER_URL', 'https://brouter.de/brouter'),
-    'brouter_timeout'   => env('BROUTER_TIMEOUT', 10),
+    'brouter_url'           => env('BROUTER_URL', 'https://brouter.de/'),
+    'brouter_timeout'       => env('BROUTER_TIMEOUT', 10),
 
     # DB_REST
     'db_rest'               => env('DB_REST', 'https://v5.db.transport.rest/'),

--- a/database/migrations/2023_04_25_000000_add_source_to_poly_lines.php
+++ b/database/migrations/2023_04_25_000000_add_source_to_poly_lines.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void {
+        Schema::table('poly_lines', static function(Blueprint $table) {
+            $table->enum('source', ['hafas', 'brouter'])
+                  ->default('hafas')
+                  ->after('polyline');
+        });
+    }
+
+    public function down(): void {
+        Schema::table('poly_lines', static function(Blueprint $table) {
+            $table->dropColumn(['source']);
+        });
+    }
+};


### PR DESCRIPTION
In this PR, the `GeoController::getPolylineBetween()` method will be extended with a connection to Brouter, which will automatically find the most direct railroad line between two stations in case of missing real line in the Hafas data.

Potential problems: The route is currently searched during check-in, which may result in longer loading times sometimes even timeouts. Possibly this process should be executed in the background afterwards.