### PR TITLE
:bug: Change default scopes

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -84,6 +84,7 @@ class AuthServiceProvider extends ServiceProvider {
         Passport::tokensCan(self::$scopes);
         Passport::setDefaultScope([
                                       'read-statuses',
+                                      'read-statistics',
                                       'write-statuses',
                                       'write-likes',
                                       'read-notifications',


### PR DESCRIPTION
Change default scopes to include read-statistics. Sadly this will not affect any previously accepted oauth-stuff.