### PR TITLE
Show the author's username and not the current user in OAuth authorization screen

### DIFF
--- a/app/Http/Controllers/Backend/Auth/AuthorizationController.php
+++ b/app/Http/Controllers/Backend/Auth/AuthorizationController.php
@@ -101,6 +101,7 @@ class AuthorizationController extends PassportAuthorizationController {
             'authToken' => $authToken,
             'webhook' => $webhook,
             'userCount' => $userCount,
+            'author' => $client->user->username,
         ]);
     }
 

--- a/resources/views/auth/authorize.blade.php
+++ b/resources/views/auth/authorize.blade.php
@@ -69,8 +69,8 @@
                 <div class="card-footer row">
                     <p class="m-0 col-md-4 text-center">{!! __("menu.oauth_authorize.application_information.author", [
                         "application" => $client->name,
-                        "user" => $user->username,
-                        "url" => route("profile", $user->username)
+                        "user" => $author,
+                        "url" => route("profile", $author)
                         ])!!}</p>
                     <p class="m-0 col-md-4 text-center">{{ __("menu.oauth_authorize.application_information.created_at", [
                         "time" => $client->created_at->diffForHumans()


### PR DESCRIPTION
The authorization screen currently always shows the username of the logged in user and not the author of the application.