### PR TITLE
🚑 🐛  Add fallback to when route deviation is greater than 15%.

### DIFF
--- a/app/Console/Commands/RecalculateStatusDistance.php
+++ b/app/Console/Commands/RecalculateStatusDistance.php
@@ -2,24 +2,29 @@
 
 namespace App\Console\Commands;
 
+use App\Exceptions\DistanceDeviationException;
 use App\Http\Controllers\Backend\Transport\TrainCheckinController;
 use App\Models\Status;
 use Illuminate\Console\Command;
 
 class RecalculateStatusDistance extends Command
 {
-    protected $signature   = 'trwl:recalculateStatusDistance {id*} {--polyline}';
+    protected $signature   = 'trwl:recalculateStatusDistance {id*}';
     protected $description = 'Recalculate distance for status id';
 
-    public function handle(): void{
-        $ids = $this->arguments()['id'];
+    public function handle(): void {
+        $ids      = $this->arguments()['id'];
         $statuses = Status::whereIn('id', $ids)->get();
         $this->info(sprintf('Found %d of %d statuses', count($ids), count($statuses)));
         $this->newLine(3);
-        foreach($statuses as $status) {
-            $oldDistance = $status->trainCheckin->distance;
-            TrainCheckinController::refreshDistanceAndPoints(status: $status, resetPolyline: true);
-            $this->info(sprintf('#%d: %d -> %d', $status->id, $oldDistance, $status->trainCheckin->distance));
+        foreach ($statuses as $status) {
+            try {
+                $oldDistance = $status->trainCheckin->distance;
+                TrainCheckinController::refreshDistanceAndPoints(status: $status, resetPolyline: true);
+                $this->info(sprintf('#%d: %d -> %d', $status->id, $oldDistance, $status->trainCheckin->distance));
+            } catch (DistanceDeviationException) {
+                $this->error(sprintf('#%d: DistanceDeviationException occurred', $status->id));
+            }
             $this->newLine();
         }
     }

--- a/app/Console/Commands/RecalculateStatusDistance.php
+++ b/app/Console/Commands/RecalculateStatusDistance.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Http\Controllers\Backend\Transport\TrainCheckinController;
+use App\Models\Status;
+use Illuminate\Console\Command;
+
+class RecalculateStatusDistance extends Command
+{
+    protected $signature   = 'trwl:recalculateStatusDistance {id*} {--polyline}';
+    protected $description = 'Recalculate distance for status id';
+
+    public function handle(): void{
+        $ids = $this->arguments()['id'];
+        $statuses = Status::whereIn('id', $ids)->get();
+        $this->info(sprintf('Found %d of %d statuses', count($ids), count($statuses)));
+        $this->newLine(3);
+        foreach($statuses as $status) {
+            $oldDistance = $status->trainCheckin->distance;
+            TrainCheckinController::refreshDistanceAndPoints(status: $status, resetPolyline: true);
+            $this->info(sprintf('#%d: %d -> %d', $status->id, $oldDistance, $status->trainCheckin->distance));
+            $this->newLine();
+        }
+    }
+}

--- a/app/Exceptions/DistanceDeviationException.php
+++ b/app/Exceptions/DistanceDeviationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class DistanceDeviationException extends Exception
+{
+    //
+}

--- a/app/Http/Controllers/Backend/Transport/TrainCheckinController.php
+++ b/app/Http/Controllers/Backend/Transport/TrainCheckinController.php
@@ -273,23 +273,22 @@ abstract class TrainCheckinController extends Controller
     /**
      * @throws DistanceDeviationException
      */
-    public static function refreshDistanceAndPoints(Status $status, bool $resetPolyline=false) {
+    public static function refreshDistanceAndPoints(Status $status, bool $resetPolyline = false): void {
         $trainCheckin = $status->trainCheckin;
         if ($resetPolyline) {
-            $trainCheckin->HafasTrip->polyline_id = null;
-            $trainCheckin->HafasTrip->update();
+            $trainCheckin->HafasTrip->update(['polyline_id' => null]);
         }
-        $firstStop    = $trainCheckin->origin_stopover;
-        $lastStop     = $trainCheckin->destination_stopover;
-        $distance     = GeoController::calculateDistance(
+        $firstStop   = $trainCheckin->origin_stopover;
+        $lastStop    = $trainCheckin->destination_stopover;
+        $distance    = GeoController::calculateDistance(
             hafasTrip:   $trainCheckin->HafasTrip,
             origin:      $firstStop,
             destination: $lastStop
         );
-        $oldPoints    = $trainCheckin->points;
-        $oldDistance  = $trainCheckin->distance;
+        $oldPoints   = $trainCheckin->points;
+        $oldDistance = $trainCheckin->distance;
 
-        if ($distance / $trainCheckin->distance >= 1.15) {
+        if ($trainCheckin->distance === 0 || $distance / $trainCheckin->distance >= 1.15) {
             Log::error(sprintf('Distance deviation for status #%d is greater than 15 percent. Original: %d, new: %d',
                                $status->id,
                                $oldDistance,

--- a/app/Http/Controllers/Backend/Transport/TrainCheckinController.php
+++ b/app/Http/Controllers/Backend/Transport/TrainCheckinController.php
@@ -273,8 +273,12 @@ abstract class TrainCheckinController extends Controller
     /**
      * @throws DistanceDeviationException
      */
-    public static function refreshDistanceAndPoints(Status $status) {
+    public static function refreshDistanceAndPoints(Status $status, bool $resetPolyline=false) {
         $trainCheckin = $status->trainCheckin;
+        if ($resetPolyline) {
+            $trainCheckin->HafasTrip->polyline_id = null;
+            $trainCheckin->HafasTrip->update();
+        }
         $firstStop    = $trainCheckin->origin_stopover;
         $lastStop     = $trainCheckin->destination_stopover;
         $distance     = GeoController::calculateDistance(


### PR DESCRIPTION
Revert new polyline when the deviation is greater than 15%. This will most likely filter out all unwanted regional, light rail, suburban, tram, subway, etc. which are calculated absolutely wrong. 