### PR TITLE
:white_check_mark: Stabilize and mock tests

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -47,4 +47,4 @@ jobs:
         env:
           DB_CONNECTION: sqlite
           DB_DATABASE: database/database.sqlite
-        run: php artisan test --parallel --coverage --min=41.1
+        run: php artisan test --parallel --coverage --min=43 #Increase this value regularly while writing tests. Target: 80%

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -47,4 +47,4 @@ jobs:
         env:
           DB_CONNECTION: sqlite
           DB_DATABASE: database/database.sqlite
-        run: php artisan test --parallel --coverage --min=43 #Increase this value regularly while writing tests. Target: 80%
+        run: php artisan test --parallel --coverage --min=44 #Increase this value regularly while writing tests. Target: 80%

--- a/app/Http/Controllers/API/v1/UserController.php
+++ b/app/Http/Controllers/API/v1/UserController.php
@@ -7,13 +7,11 @@ use App\Exceptions\UserAlreadyBlockedException;
 use App\Exceptions\UserAlreadyMutedException;
 use App\Exceptions\UserNotBlockedException;
 use App\Exceptions\UserNotMutedException;
-use App\Http\Controllers\Backend\User\BlockController;
 use App\Http\Controllers\Backend\UserController as BackendUserBackend;
 use App\Http\Controllers\UserController as UserBackend;
 use App\Http\Resources\StatusResource;
 use App\Http\Resources\UserResource;
 use App\Models\User;
-use Error;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
@@ -65,11 +63,10 @@ class UserController extends Controller
     public function deleteAccount(Request $request): JsonResponse {
         $request->validate(['confirmation' => ['required', Rule::in([auth()->user()->username])]]);
 
-        try {
-            return $this->sendResponse(BackendUserBackend::deleteUserAccount(user: auth()->user()));
-        } catch (Error) {
-            return $this->sendError('', 409);
+        if(!BackendUserBackend::deleteUserAccount(user: auth()->user())) {
+            return $this->sendError(__('messages.exception.general'), 500);
         }
+        return $this->sendResponse(true);
     }
 
     /**

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -52,7 +52,7 @@ class LoginController extends Controller
             return redirect()->intended($this->redirectPath());
         }
 
-        return redirect()->back()
+        return redirect()->route('login')
                          ->withInput()
                          ->withErrors([
                                           'login_error' => __('error.login'),

--- a/app/Http/Controllers/Backend/UserController.php
+++ b/app/Http/Controllers/Backend/UserController.php
@@ -12,7 +12,6 @@ use App\Models\Like;
 use App\Models\User;
 use App\Models\UserBlock;
 use App\Models\UserMute;
-use Error;
 use Exception;
 use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Pagination\Paginator;
@@ -24,10 +23,9 @@ abstract class UserController extends Controller
     /**
      * @param User $user
      *
-     * @return bool
-     * @throws Error
+     * @return bool|null
      */
-    public static function deleteUserAccount(User $user): bool {
+    public static function deleteUserAccount(User $user): ?bool {
         SettingsController::deleteProfilePicture(user: $user);
 
         DatabaseNotification::where([
@@ -35,10 +33,7 @@ abstract class UserController extends Controller
                                         'notifiable_type' => get_class($user)
                                     ])->delete();
 
-        if ($user->delete()) {
-            return true;
-        }
-        throw new Error();
+        return $user->delete();
     }
 
     /**

--- a/app/Http/Controllers/Frontend/Export/ExportController.php
+++ b/app/Http/Controllers/Frontend/Export/ExportController.php
@@ -26,9 +26,9 @@ class ExportController extends Controller
                                             'filetype' => ['required', Rule::in(['json', 'csv', 'pdf'])],
                                         ]);
 
-        $from = Carbon::parse($validated['from']);
+        $from  = Carbon::parse($validated['from']);
         $until = Carbon::parse($validated['until']);
-        if($from->diffInDays($until) > 365) {
+        if ($from->diffInDays($until) > 365) {
             return back()->with('error', __('export.error.time'));
         }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -133,7 +133,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
             Route::put('password', [SettingsController::class, 'updatePassword'])
                  ->middleware(['scope:extra-write-password']);
             Route::delete('account', [UserController::class, 'deleteAccount'])
-                 ->middleware(['extra-delete'])
+                 ->middleware(['scope:extra-delete'])
                  ->withoutMiddleware('privacy-policy');
             Route::group(['middleware' => ['scope:write-settings-calendar']], static function() {
                 Route::get('ics-tokens', [IcsController::class, 'getIcsTokens']);

--- a/tests/ApiTestCase.php
+++ b/tests/ApiTestCase.php
@@ -13,7 +13,6 @@ abstract class ApiTestCase extends TestCase
         parent::setUp();
         $this->artisan('passport:install');
         $this->artisan('passport:keys', ['--no-interaction' => true]);
-        $this->artisan('db:seed');
     }
 
     protected function getTokenForTestUser(): string {

--- a/tests/Feature/APIv1/EventTest.php
+++ b/tests/Feature/APIv1/EventTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\APIv1;
 
+use App\Models\Event;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -13,6 +14,7 @@ class EventTest extends ApiTestCase
     use RefreshDatabase;
 
     public function testEventDetails(): void {
+        Event::factory()->create();
         $response = $this->get('/api/v1/events');
         $response->assertOk();
         $response->assertJsonCount(1, 'data');

--- a/tests/Feature/APIv1/StatusTest.php
+++ b/tests/Feature/APIv1/StatusTest.php
@@ -175,67 +175,34 @@ class StatusTest extends ApiTestCase
     }
 
 
-    public function testStatusUpdateWithChangedDestination() {
+    public function testStatusUpdateWithChangedDestination(): void {
         $user      = User::factory()->create();
         $userToken = $user->createToken('token', array_keys(AuthServiceProvider::$scopes))->accessToken;
 
-        $firstDeparture = Date::now()->addHour();
-        $secondArrival  = Date::now()->addHours(2);
-        $thirdArrival   = Date::now()->addHours(3);
+        $checkin = TrainCheckin::factory(['user_id' => $user->id])->create();
 
-        $firstStation  = TrainStation::factory()->create();
-        $secondStation = TrainStation::factory()->create();
-        $thirdStation  = TrainStation::factory()->create();
-
-        $status  = Status::factory([
-                                       'user_id'    => $user->id,
-                                       'visibility' => StatusVisibility::PRIVATE->value,
-                                       'business'   => Business::PRIVATE->value,
-                                   ])->create();
-        $checkin = TrainCheckin::factory([
-                                             'status_id'   => $status->id,
-                                             'user_id'     => $user->id,
-                                             'origin'      => $firstStation->ibnr,
-                                             'departure'   => $firstDeparture->toDateTimeString(),
-                                             'destination' => $secondStation->ibnr,
-                                             'arrival'     => $secondArrival->toDateTimeString(),
-                                         ])->create();
-
+        //Create a new stopover now (factory creates departure 1 hour ago and arrival in 1 hour)
+        $newStation     = TrainStation::factory()->create();
+        $thirdTimestamp = Date::now()->setSecond(0);
         TrainStopover::factory([
                                    'trip_id'           => $checkin->trip_id,
-                                   'train_station_id'  => $firstStation->id,
-                                   'arrival_planned'   => $firstDeparture,
-                                   'arrival_real'      => $firstDeparture,
-                                   'departure_planned' => $firstDeparture,
-                                   'departure_real'    => $firstDeparture,
-                               ])->create();
-        TrainStopover::factory([
-                                   'trip_id'           => $checkin->trip_id,
-                                   'train_station_id'  => $secondStation->id,
-                                   'arrival_planned'   => $secondArrival,
-                                   'arrival_real'      => $secondArrival,
-                                   'departure_planned' => $secondArrival,
-                                   'departure_real'    => $secondArrival,
-                               ])->create();
-        TrainStopover::factory([
-                                   'trip_id'           => $checkin->trip_id,
-                                   'train_station_id'  => $thirdStation->id,
-                                   'arrival_planned'   => $thirdArrival,
-                                   'arrival_real'      => $thirdArrival,
-                                   'departure_planned' => $thirdArrival,
-                                   'departure_real'    => $thirdArrival,
+                                   'train_station_id'  => $newStation->id,
+                                   'arrival_planned'   => $thirdTimestamp,
+                                   'arrival_real'      => $thirdTimestamp,
+                                   'departure_planned' => $thirdTimestamp,
+                                   'departure_real'    => $thirdTimestamp,
                                ])->create();
 
-        $this->assertEquals($checkin->originStation->id, $firstStation->id);
-        $this->assertEquals($checkin->destinationStation->id, $secondStation->id);
+        $this->assertNotEquals($checkin->originStation->id, $newStation->id);
+        $this->assertNotEquals($checkin->destinationStation->id, $newStation->id);
 
         $response = $this->put(
-            uri:     '/api/v1/statuses/' . $status->id,
+            uri:     '/api/v1/status/' . $checkin->status_id,
             data:    [
                          'visibility'                => StatusVisibility::PUBLIC->value,
                          'business'                  => Business::BUSINESS->value,
-                         'destinationId'             => $thirdStation->id,
-                         'destinationArrivalPlanned' => $thirdArrival->toDateTimeString(),
+                         'destinationId'             => $newStation->id,
+                         'destinationArrivalPlanned' => $thirdTimestamp->toDateTimeString(),
                      ],
             headers: ['Authorization' => 'Bearer ' . $userToken],
         );
@@ -243,7 +210,6 @@ class StatusTest extends ApiTestCase
 
         $checkin = $checkin->fresh();
 
-        $this->assertEquals($checkin->originStation->id, $firstStation->id);
-        $this->assertEquals($checkin->destinationStation->id, $thirdStation->id);
+        $this->assertEquals($checkin->destinationStation->id, $newStation->id);
     }
 }

--- a/tests/Feature/APIv1/StatusTest.php
+++ b/tests/Feature/APIv1/StatusTest.php
@@ -31,38 +31,18 @@ class StatusTest extends ApiTestCase
         $this->assertEquals('User doesn\'t have any checkins', $response->json('message'));
     }
 
-    public function testActiveStatusesWithActiveStatus(): void {
+    public function testActiveStatusesShowStatusesCurrentlyUnderway(): void {
         $user      = User::factory()->create();
         $userToken = $user->createToken('token', array_keys(AuthServiceProvider::$scopes))->accessToken;
 
         $departure = Date::now()->subHour();
         $arrival   = Date::now()->addHour();
 
-        $status  = Status::factory([
-                                       'user_id' => $user->id,
-                                   ])->create();
         $checkin = TrainCheckin::factory([
-                                             'status_id' => $status->id,
                                              'user_id'   => $user->id,
                                              'departure' => $departure,
                                              'arrival'   => $arrival,
                                          ])->create();
-        TrainStopover::factory([
-                                   'trip_id'           => $checkin->trip_id,
-                                   'train_station_id'  => $checkin->Origin->id,
-                                   'arrival_planned'   => $departure,
-                                   'arrival_real'      => $departure,
-                                   'departure_planned' => $departure,
-                                   'departure_real'    => $departure,
-                               ])->create();
-        TrainStopover::factory([
-                                   'trip_id'           => $checkin->trip_id,
-                                   'train_station_id'  => $checkin->Destination->id,
-                                   'arrival_planned'   => $arrival,
-                                   'arrival_real'      => $arrival,
-                                   'departure_planned' => $arrival,
-                                   'departure_real'    => $arrival,
-                               ])->create();
 
         $response = $this->get(
             uri:     '/api/v1/user/statuses/active',

--- a/tests/Feature/APIv1/StatusTest.php
+++ b/tests/Feature/APIv1/StatusTest.php
@@ -97,38 +97,18 @@ class StatusTest extends ApiTestCase
         $this->assertEquals($checkin->destinationStation->id, $response->json('data.train.destination.id'));
     }
 
-    public function testActiveStatusesWithInactiveStatus(): void {
+    public function testActiveStatusesDontShowStatusesFromTheFuture(): void {
         $user      = User::factory()->create();
         $userToken = $user->createToken('token', array_keys(AuthServiceProvider::$scopes))->accessToken;
 
         $departure = Date::now()->addHour();
         $arrival   = Date::now()->addHours(2);
 
-        $status  = Status::factory([
-                                       'user_id' => $user->id,
-                                   ])->create();
-        $checkin = TrainCheckin::factory([
-                                             'status_id' => $status->id,
-                                             'user_id'   => $user->id,
-                                             'departure' => $departure,
-                                             'arrival'   => $arrival,
-                                         ])->create();
-        TrainStopover::factory([
-                                   'trip_id'           => $checkin->trip_id,
-                                   'train_station_id'  => $checkin->Origin->id,
-                                   'arrival_planned'   => $departure,
-                                   'arrival_real'      => $departure,
-                                   'departure_planned' => $departure,
-                                   'departure_real'    => $departure,
-                               ])->create();
-        TrainStopover::factory([
-                                   'trip_id'           => $checkin->trip_id,
-                                   'train_station_id'  => $checkin->Destination->id,
-                                   'arrival_planned'   => $arrival,
-                                   'arrival_real'      => $arrival,
-                                   'departure_planned' => $arrival,
-                                   'departure_real'    => $arrival,
-                               ])->create();
+        TrainCheckin::factory([
+                                  'user_id'   => $user->id,
+                                  'departure' => $departure,
+                                  'arrival'   => $arrival,
+                              ])->create();
 
         $response = $this->get(
             uri:     '/api/v1/user/statuses/active',

--- a/tests/Feature/APIv1/UserBlockTest.php
+++ b/tests/Feature/APIv1/UserBlockTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature\APIv1;
+
+use App\Models\User;
+use App\Providers\AuthServiceProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\ApiTestCase;
+
+class UserBlockTest extends ApiTestCase
+{
+
+    use RefreshDatabase;
+
+    public function testUserCanBeBlockedOnceAndThenUnblocked(): void {
+        $alice      = User::factory()->create();
+        $aliceToken = $alice->createToken('token', array_keys(AuthServiceProvider::$scopes))->accessToken;
+        $bob        = User::factory()->create();
+
+        $this->assertDatabaseMissing('user_blocks', [
+            'user_id'    => $alice->id,
+            'blocked_id' => $bob->id,
+        ]);
+
+        $response = $this->postJson(
+            uri:     strtr('/api/v1/user/:userId/block', [':userId' => $bob->id]),
+            headers: ['Authorization' => 'Bearer ' . $aliceToken]
+        );
+        $response->assertCreated();
+
+        $this->assertDatabaseHas('user_blocks', [
+            'user_id'    => $alice->id,
+            'blocked_id' => $bob->id,
+        ]);
+
+        //Already blocked -> expect 409
+        $response = $this->postJson(
+            uri:     strtr('/api/v1/user/:userId/block', [':userId' => $bob->id]),
+            headers: ['Authorization' => 'Bearer ' . $aliceToken]
+        );
+        $response->assertConflict();
+
+        //Now unblock user
+        $response = $this->deleteJson(
+            uri:     strtr('/api/v1/user/:userId/block', [':userId' => $bob->id]),
+            headers: ['Authorization' => 'Bearer ' . $aliceToken]
+        );
+        $response->assertOk();
+
+        $this->assertDatabaseMissing('user_blocks', [
+            'user_id'    => $alice->id,
+            'blocked_id' => $bob->id,
+        ]);
+
+        //Now unblock an already unblocked user and expect 409
+        $response = $this->deleteJson(
+            uri:     strtr('/api/v1/user/:userId/block', [':userId' => $bob->id]),
+            headers: ['Authorization' => 'Bearer ' . $aliceToken]
+        );
+        $response->assertConflict();
+    }
+
+    public function testNonExistingUserCantBeBlocked(): void {
+        $alice      = User::factory()->create();
+        $aliceToken = $alice->createToken('token', array_keys(AuthServiceProvider::$scopes))->accessToken;
+
+        $response = $this->postJson(
+            uri:     strtr('/api/v1/user/:userId/block', [':userId' => 9999]),
+            headers: ['Authorization' => 'Bearer ' . $aliceToken]
+        );
+        $response->assertNotFound();
+    }
+
+    public function testNonExistingUserCantBeUnblocked(): void {
+        $alice      = User::factory()->create();
+        $aliceToken = $alice->createToken('token', array_keys(AuthServiceProvider::$scopes))->accessToken;
+
+        $response = $this->deleteJson(
+            uri:     strtr('/api/v1/user/:userId/block', [':userId' => 9999]),
+            headers: ['Authorization' => 'Bearer ' . $aliceToken]
+        );
+        $response->assertNotFound();
+    }
+}

--- a/tests/Feature/APIv1/UserDeletionTest.php
+++ b/tests/Feature/APIv1/UserDeletionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature\APIv1;
+
+use App\Models\User;
+use App\Providers\AuthServiceProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\ApiTestCase;
+
+class UserDeletionTest extends ApiTestCase
+{
+
+    use RefreshDatabase;
+
+    public function testUserAccountCanBeDeleted(): void {
+        $alice      = User::factory()->create();
+        $aliceToken = $alice->createToken('token', array_keys(AuthServiceProvider::$scopes))->accessToken;
+
+        $this->assertDatabaseHas('users', ['id' => $alice->id]);
+
+        $response = $this->deleteJson(
+            uri:     '/api/v1/settings/account',
+            data:    ['confirmation' => $alice->username],
+            headers: ['Authorization' => 'Bearer ' . $aliceToken]
+        );
+        $response->assertOk();
+
+        $this->assertDatabaseMissing('users', ['id' => $alice->id]);
+    }
+}

--- a/tests/Feature/APIv1/UserMuteTest.php
+++ b/tests/Feature/APIv1/UserMuteTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature\APIv1;
+
+use App\Models\User;
+use App\Providers\AuthServiceProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\ApiTestCase;
+
+class UserMuteTest extends ApiTestCase
+{
+
+    use RefreshDatabase;
+
+    public function testUserCanBeMutedOnceAndThenUnmuted(): void {
+        $alice      = User::factory()->create();
+        $aliceToken = $alice->createToken('token', array_keys(AuthServiceProvider::$scopes))->accessToken;
+        $bob        = User::factory()->create();
+
+        $this->assertDatabaseMissing('user_mutes', [
+            'user_id'  => $alice->id,
+            'muted_id' => $bob->id,
+        ]);
+
+        $response = $this->postJson(
+            uri:     strtr('/api/v1/user/:userId/mute', [':userId' => $bob->id]),
+            headers: ['Authorization' => 'Bearer ' . $aliceToken]
+        );
+        $response->assertCreated();
+
+        $this->assertDatabaseHas('user_mutes', [
+            'user_id'  => $alice->id,
+            'muted_id' => $bob->id,
+        ]);
+
+        //Already muted -> expect 409
+        $response = $this->postJson(
+            uri:     strtr('/api/v1/user/:userId/mute', [':userId' => $bob->id]),
+            headers: ['Authorization' => 'Bearer ' . $aliceToken]
+        );
+        $response->assertConflict();
+
+        //Now unmute user
+        $response = $this->deleteJson(
+            uri:     strtr('/api/v1/user/:userId/mute', [':userId' => $bob->id]),
+            headers: ['Authorization' => 'Bearer ' . $aliceToken]
+        );
+        $response->assertOk();
+
+        $this->assertDatabaseMissing('user_mutes', [
+            'user_id'  => $alice->id,
+            'muted_id' => $bob->id,
+        ]);
+
+        //Now unmute an already unmuted user and expect 409
+        $response = $this->deleteJson(
+            uri:     strtr('/api/v1/user/:userId/mute', [':userId' => $bob->id]),
+            headers: ['Authorization' => 'Bearer ' . $aliceToken]
+        );
+        $response->assertConflict();
+    }
+
+    public function testNonExistingUserCantBeMuted(): void {
+        $alice      = User::factory()->create();
+        $aliceToken = $alice->createToken('token', array_keys(AuthServiceProvider::$scopes))->accessToken;
+
+        $response = $this->postJson(
+            uri:     strtr('/api/v1/user/:userId/mute', [':userId' => 9999]),
+            headers: ['Authorization' => 'Bearer ' . $aliceToken]
+        );
+        $response->assertNotFound();
+    }
+
+    public function testNonExistingUserCantBeUnmuted(): void {
+        $alice      = User::factory()->create();
+        $aliceToken = $alice->createToken('token', array_keys(AuthServiceProvider::$scopes))->accessToken;
+
+        $response = $this->deleteJson(
+            uri:     strtr('/api/v1/user/:userId/mute', [':userId' => 9999]),
+            headers: ['Authorization' => 'Bearer ' . $aliceToken]
+        );
+        $response->assertNotFound();
+    }
+}

--- a/tests/Feature/CheckinTest.php
+++ b/tests/Feature/CheckinTest.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Backend\Transport\TrainCheckinController;
 use App\Http\Controllers\TransportController;
 use App\Models\HafasTrip;
 use App\Models\TrainStation;
+use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -55,7 +56,7 @@ class CheckinTest extends TestCase
      */
     public function stationboardByLocationPositiveTest(): void {
         // GIVEN: A logged-in and gdpr-acked user
-        $user = $this->createGDPRAckedUser();
+        $user = User::factory()->create();
 
         // GIVEN: A HTTP Mock
         Http::fake(["*/stops/nearby*" => Http::response([array_merge(
@@ -83,7 +84,7 @@ class CheckinTest extends TestCase
      */
     public function stationboardByLocationNegativeTest(): void {
         // GIVEN: A logged-in and gdpr-acked user
-        $user = $this->createGDPRAckedUser();
+        $user = User::factory()->create();
 
         // GIVEN: A HTTP Mock
         Http::fake(Http::response([]));
@@ -113,7 +114,7 @@ class CheckinTest extends TestCase
      */
     public function testCheckin(): void {
         // GIVEN: A logged-in and gdpr-acked user
-        $user = $this->createGDPRAckedUser();
+        $user = User::factory()->create();
 
         // WHEN: User follows Check-In Flow (checks departures, takes a look at trip information, performs check-in)
         Http::fake([
@@ -172,7 +173,7 @@ class CheckinTest extends TestCase
         TrainStation::factory()->count(4)->create();
 
         // GIVEN: A logged-in and gdpr-acked user
-        $user = $this->createGDPRAckedUser();
+        $user = User::factory()->create();
 
         /*
          * We're now generating a 'base checkin' on which we are comparing all possible collision types
@@ -306,7 +307,7 @@ class CheckinTest extends TestCase
      */
     public function testCheckinSuccessFlash(): void {
         // GIVEN: A gdpr-acked user
-        $user = $this->createGDPRAckedUser();
+        $user = User::factory()->create();
 
         // WHEN: Coming back from the checkin flow and returning to the dashboard
         $message  = [

--- a/tests/Feature/Dev/EditOAuthClientTest.php
+++ b/tests/Feature/Dev/EditOAuthClientTest.php
@@ -2,21 +2,21 @@
 
 namespace Tests\Feature\Dev;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
 use App\Repositories\OAuthClientRepository;
-use Illuminate\Support\Facades\Log;
-
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertNotEquals;
 
-class EditOAuthClientTest extends TestCase {
+class EditOAuthClientTest extends TestCase
+{
     use RefreshDatabase;
 
     public function testOAuthClientConfidentialEditToggle() {
-        $user = $this->createGDPRAckedUser();
-        $client = $this->createOAuthClient($user, true);
-        $clients = new OAuthClientRepository();
+        $user           = User::factory()->create();
+        $client         = $this->createOAuthClient($user, true);
+        $clients        = new OAuthClientRepository();
         $originalSecret = $client->secret;
 
         $clients->update(

--- a/tests/Feature/EventSuggestionTest.php
+++ b/tests/Feature/EventSuggestionTest.php
@@ -19,8 +19,8 @@ class EventSuggestionTest extends TestCase
 
     public function setUp(): void {
         parent::setUp();
-        $this->user  = $this->createGDPRAckedUser();
-        $this->admin = $this->createAdminUser();
+        $this->user  = User::factory()->create();
+        $this->admin = User::factory(['role' => 10])->create();
 
         $this->postData = [
             // For the EventSuggestion POST

--- a/tests/Feature/ExportTripsTest.php
+++ b/tests/Feature/ExportTripsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -15,7 +16,7 @@ class ExportTripsTest extends TestCase
     protected function setUp(): void {
         parent::setUp();
 
-        $this->user = $this->createGDPRAckedUser();
+        $this->user = User::factory()->create();
 
         $this->checkin('Frankfurt(M) Flughafen Fernbf', Carbon::parse("next monday 8:00"));
         $this->checkin('Hamburg Hbf', Carbon::parse("next thursday 7:45"));

--- a/tests/Feature/Frontend/AuthTest.php
+++ b/tests/Feature/Frontend/AuthTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature\Frontend;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class AuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testSuccessfulLogin(): void {
+        $user = User::factory(['password' => Hash::make('password')])->create();
+        $this->assertGuest();
+        $response = $this->followingRedirects()
+                         ->post(route('login', [
+                             'login'    => $user->username,
+                             'password' => 'password',
+                         ]));
+        $response->assertOk();
+        $response->assertViewIs('dashboard');
+        $this->assertAuthenticated();
+    }
+
+    public function testLoginWithWrongCredentials(): void {
+        $user = User::factory(['password' => Hash::make('password')])->create();
+        $this->assertGuest();
+        $response = $this->post(route('login', [
+            'login'    => $user->username,
+            'password' => 'wrong password',
+        ]));
+        $response->assertRedirectToRoute('login');
+        $this->assertGuest();
+    }
+}

--- a/tests/Feature/Frontend/AuthTest.php
+++ b/tests/Feature/Frontend/AuthTest.php
@@ -34,4 +34,20 @@ class AuthTest extends TestCase
         $response->assertRedirectToRoute('login');
         $this->assertGuest();
     }
+
+    public function testSuccessfulRegistration(): void {
+        $this->assertGuest();
+        $this->assertDatabaseMissing('users', ['username' => 'alice123']);
+        $response = $this->followingRedirects()
+                         ->post(route('register', [
+                             'username'              => 'alice123',
+                             'name'                  => 'Alice',
+                             'email'                 => 'alice@traewelling.de',
+                             'password'              => 'password',
+                             'password_confirmation' => 'password',
+                         ]));
+        $response->assertOk();
+        $response->assertViewIs('legal.privacy-interception');
+        $this->assertDatabaseHas('users', ['username' => 'alice123']);
+    }
 }

--- a/tests/Feature/Frontend/LanguageTest.php
+++ b/tests/Feature/Frontend/LanguageTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\Frontend;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LanguageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testBrowserHasValidLanguageCode(): void {
+        $this->assertGuest();
+        $response = $this->get(
+            uri:     route('login'),
+            headers: ['Accept-Language' => 'de'],
+        );
+        $response->assertOk();
+        $response->assertViewIs('auth.login');
+        $response->assertSee(__('user.forgot-password', [], 'de'));
+        $this->assertGuest();
+    }
+
+    public function testBrowserHasInvalidLanguageCode(): void {
+        $this->assertGuest();
+        $response = $this->get(
+            uri:     route('login'),
+            headers: ['Accept-Language' => 'zz'],
+        );
+        $response->assertOk();
+        $response->assertViewIs('auth.login');
+        $response->assertSee(__('user.forgot-password', [], 'en'));
+        $this->assertGuest();
+    }
+
+    public function testRequestHasValidLanguageCode(): void {
+        $this->assertGuest();
+        $response = $this->get(
+            uri: route('login', ['language' => 'de']),
+        );
+        $response->assertOk();
+        $response->assertViewIs('auth.login');
+        $response->assertSee(__('user.forgot-password', [], 'de'));
+        $this->assertGuest();
+    }
+
+    public function testRequestHasInvalidLanguageCode(): void {
+        $this->assertGuest();
+        $response = $this->get(
+            uri: route('login', ['language' => 'zz']),
+        );
+        $response->assertOk();
+        $response->assertViewIs('auth.login');
+        $this->assertGuest();
+    }
+
+    public function testRequestHasValidLanguageCodeWithLoggedInUser(): void {
+        $user     = User::factory()->create();
+        $this->assertDatabaseMissing('users', ['username' => $user->username, 'language' => 'de']);
+        $response = $this->actingAs($user)
+                         ->get(route('globaldashboard', ['language' => 'de']));
+        $response->assertOk();
+        $response->assertViewIs('dashboard');
+        $this->assertDatabaseHas('users', ['username' => $user->username, 'language' => 'de']);
+    }
+
+    public function testLoggedInUsersWithSavedLanguageInProfile(): void {
+        $user     = User::factory(['language' => 'de'])->create();
+        $response = $this->actingAs($user)
+                         ->get(route('settings'));
+        $response->assertOk();
+        $response->assertViewIs('settings.settings');
+        $response->assertSee(__('menu.settings', [], 'de'));
+    }
+}

--- a/tests/Feature/MutedProfileVisibilityTest.php
+++ b/tests/Feature/MutedProfileVisibilityTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Http\Controllers\UserController;
+use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
@@ -225,9 +226,9 @@ class MutedProfileVisibilityTest extends ApiTestCase
         $data->gertrud = new stdClass();
         $data->alice   = new stdClass();
         // Create Gertrud, Alice and Bob
-        $data->bob->user     = $this->createGDPRAckedUser(['name' => 'bob', 'privacy_ack_at' => now()]);
-        $data->gertrud->user = $this->createGDPRAckedUser(['name' => 'gertrud', 'privacy_ack_at' => now()]);
-        $data->alice->user   = $this->createGDPRAckedUser(['name' => 'alice', 'privacy_ack_at' => now()]);
+        $data->bob->user     = User::factory(['name' => 'bob'])->create();
+        $data->gertrud->user = User::factory(['name' => 'gertrud'])->create();
+        $data->alice->user   = User::factory(['name' => 'alice'])->create();
 
         // Create new CheckIn for Bob
         $timestamp          = Carbon::parse('+1 day 8:00');

--- a/tests/Feature/MutedProfileVisibilityTest.php
+++ b/tests/Feature/MutedProfileVisibilityTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Feature;
 
 use App\Http\Controllers\UserController;
+use App\Models\TrainCheckin;
 use App\Models\User;
-use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
 use stdClass;
@@ -18,8 +18,8 @@ class MutedProfileVisibilityTest extends ApiTestCase
 
     /**
      * We want to test, if a muted profile and/or status is visible to the user itself, a following user, a
-     * not-following user and a guest. Therefore we create three users: bob (muted profile), gertrud (following bob),
-     * and alice (not following bob). Also Gertrud and bob will have their own seperate check-ins.
+     * not-following user and a guest. Therefore, we create three users: bob (muted profile), gertrud (following bob),
+     * and alice (not following bob). Also, Gertrud and bob will have their own seperate check-ins.
      */
     public function setUp(): void {
         parent::setUp();
@@ -231,8 +231,7 @@ class MutedProfileVisibilityTest extends ApiTestCase
         $data->alice->user   = User::factory(['name' => 'alice'])->create();
 
         // Create new CheckIn for Bob
-        $timestamp          = Carbon::parse('+1 day 8:00');
-        $data->bob->checkin = $this->checkin("Frankfurt Hbf", $timestamp, $data->bob->user, 1);
+        $data->bob->checkin = TrainCheckin::factory(['user_id' => $data->bob->user->id])->create();
 
         // Make Gertrud follow bob and make bob's profile muted
         UserController::destroyFollow($data->alice->user, $data->bob->user);

--- a/tests/Feature/NotificationsTest.php
+++ b/tests/Feature/NotificationsTest.php
@@ -23,14 +23,14 @@ class NotificationsTest extends TestCase
     protected function setUp(): void {
         parent::setUp();
 
-        $this->user = $this->createGDPRAckedUser();
+        $this->user = User::factory()->create();
     }
 
     /** @test */
     public function following_a_user_should_spawn_a_notification(): void {
         // Given: Users Alice and Bob
         $alice = $this->user;
-        $bob   = $this->createGDPRAckedUser();
+        $bob   = User::factory()->create();
 
         // When: Alice follows Bob
         $follow = $this->actingAs($alice)->post(route('follow.create'), ['follow_id' => $bob->id]);
@@ -52,7 +52,7 @@ class NotificationsTest extends TestCase
     public function unfollowing_bob_should_remove_the_notification(): void {
         // Given: Users Alice and Bob and Alice follows Bob
         $alice  = $this->user;
-        $bob    = $this->createGDPRAckedUser();
+        $bob    = User::factory()->create();
         $follow = $this->actingAs($alice)->post(route('follow.create'), ['follow_id' => $bob->id]);
         $follow->assertStatus(201);
 
@@ -116,7 +116,7 @@ class NotificationsTest extends TestCase
      */
     public function test_bob_joining_on_alices_connection_should_not_spawn_a_notification_when_private(): void {
         // GIVEN: Alice checked-into a train.
-        $alice     = $this->createGDPRAckedUser();
+        $alice     = User::factory()->create();
         $timestamp = Carbon::now()->setHour(7)->setMinute(45);
         $this->checkin(
             stationName: "Frankfurt(Main)Hbf",
@@ -125,7 +125,7 @@ class NotificationsTest extends TestCase
         );
 
         // WHEN: Bob also checks into the train
-        $bob = $this->createGDPRAckedUser();
+        $bob = User::factory()->create();
         $this->checkin(
             stationName:      "Frankfurt(Main)Hbf",
             timestamp:        $timestamp,
@@ -143,7 +143,7 @@ class NotificationsTest extends TestCase
     /** @test */
     public function mark_notification_as_read(): void {
         // GIVEN: Alice has a notification
-        $userToFollow = $this->createGDPRAckedUser();
+        $userToFollow = User::factory()->create();
         UserBackend::createFollow($this->user, $userToFollow);
 
         // GIVEN: Alice receives the notification and it's unread
@@ -174,7 +174,7 @@ class NotificationsTest extends TestCase
     public function deleting_a_user_should_delete_its_notifications(): void {
         // Given: Users Alice and Bob
         $alice = $this->user;
-        $bob   = $this->createGDPRAckedUser();
+        $bob   = User::factory()->create();
 
         // When: Alice follows Bob
         $follow = $this->actingAs($alice)->post(route('follow.create'), ['follow_id' => $bob->id]);

--- a/tests/Feature/NotificationsTest.php
+++ b/tests/Feature/NotificationsTest.php
@@ -79,12 +79,12 @@ class NotificationsTest extends TestCase
         // WHEN: Bob also checks into the train (with same origin and destination - but not relevant)
         $bob = User::factory(['privacy_ack_at' => Carbon::now()])->create();
         TrainCheckinController::checkin(
-            user:         $bob,
-            hafasTrip:    $aliceCheckIn->HafasTrip,
-            origin:       $aliceCheckIn->originStation,
-            departure:    $aliceCheckIn->departure,
-            destination:  $aliceCheckIn->destinationStation,
-            arrival:      $aliceCheckIn->arrival,
+            user:        $bob,
+            hafasTrip:   $aliceCheckIn->HafasTrip,
+            origin:      $aliceCheckIn->originStation,
+            departure:   $aliceCheckIn->departure,
+            destination: $aliceCheckIn->destinationStation,
+            arrival:     $aliceCheckIn->arrival,
         );
 
         // THEN: Alice should see that in their notification
@@ -115,22 +115,20 @@ class NotificationsTest extends TestCase
      * @test
      */
     public function test_bob_joining_on_alices_connection_should_not_spawn_a_notification_when_private(): void {
-        // GIVEN: Alice checked-into a train.
-        $alice     = User::factory()->create();
-        $timestamp = Carbon::now()->setHour(7)->setMinute(45);
-        $this->checkin(
-            stationName: "Frankfurt(Main)Hbf",
-            timestamp:   $timestamp,
-            user:        $alice,
-        );
+        // GIVEN: A mocked checkin for Alice
+        $alice        = User::factory(['privacy_ack_at' => Carbon::now()])->create();
+        $aliceCheckIn = TrainCheckin::factory(['user_id' => $alice->id])->create();
 
-        // WHEN: Bob also checks into the train
-        $bob = User::factory()->create();
-        $this->checkin(
-            stationName:      "Frankfurt(Main)Hbf",
-            timestamp:        $timestamp,
-            user:             $bob,
-            statusVisibility: StatusVisibility::PRIVATE,
+        // WHEN: Bob also checks into the train (with same origin and destination - but not relevant)
+        $bob = User::factory(['privacy_ack_at' => Carbon::now()])->create();
+        TrainCheckinController::checkin(
+            user:        $bob,
+            hafasTrip:   $aliceCheckIn->HafasTrip,
+            origin:      $aliceCheckIn->originStation,
+            departure:   $aliceCheckIn->departure,
+            destination: $aliceCheckIn->destinationStation,
+            arrival:     $aliceCheckIn->arrival,
+            visibility:  StatusVisibility::PRIVATE // <-- important in this test
         );
 
         // THEN: Alice should NOT see that in their notification, because the Status is Private

--- a/tests/Feature/NotificationsTest.php
+++ b/tests/Feature/NotificationsTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature;
 
 use App\Enum\StatusVisibility;
+use App\Http\Controllers\Backend\Transport\TrainCheckinController;
 use App\Http\Controllers\UserController as UserBackend;
+use App\Models\TrainCheckin;
 use App\Models\User;
 use App\Notifications\UserFollowed;
 use App\Notifications\UserJoinedConnection;
@@ -70,21 +72,19 @@ class NotificationsTest extends TestCase
      * @test
      */
     public function bob_joining_on_alices_connection_should_spawn_a_notification(): void {
-        // GIVEN: Alice checked-into a train.
-        $alice     = $this->createGDPRAckedUser();
-        $timestamp = Carbon::now()->setHour(7)->setMinute(45);
-        $this->checkin(
-            stationName: "Frankfurt(Main)Hbf",
-            timestamp:   $timestamp,
-            user:        $alice,
-        );
+        // GIVEN: A mocked checkin for Alice
+        $alice        = User::factory(['privacy_ack_at' => Carbon::now()])->create();
+        $aliceCheckIn = TrainCheckin::factory(['user_id' => $alice->id])->create();
 
-        // WHEN: Bob also checks into the train
-        $bob = $this->createGDPRAckedUser();
-        $this->checkin(
-            stationName: "Frankfurt(Main)Hbf",
-            timestamp:   $timestamp,
-            user:        $bob
+        // WHEN: Bob also checks into the train (with same origin and destination - but not relevant)
+        $bob = User::factory(['privacy_ack_at' => Carbon::now()])->create();
+        TrainCheckinController::checkin(
+            user:         $bob,
+            hafasTrip:    $aliceCheckIn->HafasTrip,
+            origin:       $aliceCheckIn->originStation,
+            departure:    $aliceCheckIn->departure,
+            destination:  $aliceCheckIn->destinationStation,
+            arrival:      $aliceCheckIn->arrival,
         );
 
         // THEN: Alice should see that in their notification

--- a/tests/Feature/PrivateProfileFollowerRelationsTest.php
+++ b/tests/Feature/PrivateProfileFollowerRelationsTest.php
@@ -18,9 +18,9 @@ class PrivateProfileFollowerRelationsTest extends TestCase
 
     protected function setUp(): void {
         parent::setUp();
-        $this->user = $this->createGDPRAckedUser();
+        $this->user = User::factory()->create();
         $this->user->update(["private_profile" => true]);
-        $this->alice = $this->createGDPRAckedUser();
+        $this->alice = User::factory()->create();
     }
 
     /**

--- a/tests/Feature/PrivateProfileVisibilityTest.php
+++ b/tests/Feature/PrivateProfileVisibilityTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Http\Controllers\UserController;
+use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
@@ -244,15 +245,9 @@ class PrivateProfileVisibilityTest extends ApiTestCase
         $data->gertrud = new stdClass();
         $data->alice   = new stdClass();
         // Create Gertrud, Alice and Bob
-        $data->bob->user                     = $this->createGDPRAckedUser();
-        $data->bob->user->privacy_ack_at     = now();
-        $data->gertrud->user                 = $this->createGDPRAckedUser();
-        $data->gertrud->user->privacy_ack_at = now();
-        $data->alice->user                   = $this->createGDPRAckedUser();
-        $data->alice->user->privacy_ack_at   = now();
-        $data->bob->user->save();
-        $data->gertrud->user->save();
-        $data->alice->user->save();
+        $data->bob->user     = User::factory()->create();
+        $data->gertrud->user = User::factory()->create();
+        $data->alice->user   = User::factory()->create();
 
         // Create new CheckIn for Bob
         $timestamp          = Carbon::parse("-40min");

--- a/tests/Feature/PrivateProfileVisibilityTest.php
+++ b/tests/Feature/PrivateProfileVisibilityTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Feature;
 
 use App\Http\Controllers\UserController;
+use App\Models\TrainCheckin;
 use App\Models\User;
-use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
 use stdClass;
@@ -18,8 +18,8 @@ class PrivateProfileVisibilityTest extends ApiTestCase
 
     /**
      * We want to test, if a private profile and/or status is visible to the user itself, a following user, a
-     * not-following user and a guest. Therefore we create three users: bob (private profile), gertrud (following bob),
-     * and alice (not following bob). Also Gertrud and bob will have their own seperate check-ins.
+     * not-following user and a guest. Therefore, we create three users: bob (private profile), gertrud (following bob),
+     * and alice (not following bob). Also, Gertrud and bob will have their own seperate check-ins.
      */
     public function setUp(): void {
         parent::setUp();
@@ -29,10 +29,8 @@ class PrivateProfileVisibilityTest extends ApiTestCase
     /**
      * Watching a private profile is characterized by being able to see ones statuses on a profile page.
      * If the statuses are returned as null, you're not allowed to see the statuses.
-     *
-     * @test
      */
-    public function view_profile_of_private_user() {
+    public function test_view_profile_of_private_user() {
         $this->markTestSkipped('Test does not work properly and therefore was not executed. It must be rewritten.');
 
         // Can a guest see the profile of bob? => no
@@ -64,10 +62,7 @@ class PrivateProfileVisibilityTest extends ApiTestCase
         $this->assertNotEquals(null, $gertrud['statuses'], 'Gertrud cannot see the statuses bob!');
     }
 
-    /**
-     * @test
-     */
-    public function view_status_of_private_user() {
+    public function test_view_status_of_private_user() {
         $this->markTestSkipped('Test does not work properly and therefore was not executed. It must be rewritten.');
 
         // Can a guest see the status of bob? => no
@@ -102,9 +97,8 @@ class PrivateProfileVisibilityTest extends ApiTestCase
     /**
      * If a user is private, only authorized (not explicitly authenticated) users should be able to see their statuses
      * on the dashboard
-     * @test
      */
-    public function view_status_of_private_user_on_global_dashboard() {
+    public function test_view_status_of_private_user_on_global_dashboard() {
         $this->markTestSkipped('Test does not work properly and therefore was not executed. It must be rewritten.');
 
         // Can a guest see the statuses of bob on the dashboard? => no, because they can't access the dashboard
@@ -250,8 +244,7 @@ class PrivateProfileVisibilityTest extends ApiTestCase
         $data->alice->user   = User::factory()->create();
 
         // Create new CheckIn for Bob
-        $timestamp          = Carbon::parse("-40min");
-        $data->bob->checkin = $this->checkin("Frankfurt Hbf", $timestamp, $data->bob->user, 1);
+        $data->bob->checkin = TrainCheckin::factory(['user_id' => $data->bob->user->id])->create();
 
         // Make Gertrud follow bob and make bob's profile private
         UserController::destroyFollow($data->alice->user, $data->bob->user);

--- a/tests/Feature/Social/MastodonControllerTest.php
+++ b/tests/Feature/Social/MastodonControllerTest.php
@@ -354,7 +354,7 @@ class MastodonControllerTest extends TestCase
     }
 
     private function setupUserWithMastodonAccount(): User {
-        $user = $this->createGDPRAckedUser();
+        $user = User::factory()->create();
 
         $mastodonServer = MastodonServer
             ::create([

--- a/tests/Feature/StaticPagesThatMightHaveComputedPropertiesTest.php
+++ b/tests/Feature/StaticPagesThatMightHaveComputedPropertiesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -54,7 +55,7 @@ class StaticPagesThatMightHaveComputedPropertiesTest extends TestCase
 
     public function testProfilePageGet() {
         // GIVEN: A gdpr-acked user
-        $user = $this->createGDPRAckedUser();
+        $user = User::factory()->create();
 
         // WHEN: Someone visits the user's profile page
         $response = $this->get(route('profile', ["username" => $user->username]));

--- a/tests/Feature/Transport/BackendCheckinTest.php
+++ b/tests/Feature/Transport/BackendCheckinTest.php
@@ -174,7 +174,6 @@ class BackendCheckinTest extends TestCase
 
         // The bus runs in a 20min interval
         $departure = $trainStationboard['departures'][0];
-        self::isCorrectHafasTrip($departure, $timestamp);
 
         // Third: Get the trip information
         try {

--- a/tests/Feature/UserBlockTest.php
+++ b/tests/Feature/UserBlockTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature;
 use App\Models\Like;
 use App\Models\TrainCheckin;
 use App\Models\User;
-use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -19,11 +18,9 @@ class UserBlockTest extends TestCase
 
     protected function setUp(): void {
         parent::setUp();
-
-        $this->alice = $this->createGDPRAckedUser(['username' => 'alice']);
-        $this->bob   = $this->createGDPRAckedUser(['username' => 'bob']);
-
-        $this->checkin = $this->checkin('Frankfurt Hbf', Carbon::parse('-10min'), $this->alice);
+        $this->alice   = User::factory(['username' => 'alice', 'name' => 'Alice'])->create();
+        $this->bob     = User::factory(['username' => 'bob', 'name' => 'Bob'])->create();
+        $this->checkin = TrainCheckin::factory(['user_id' => $this->alice->id])->create();
     }
 
     private function aliceBlocksBob(): void {
@@ -35,13 +32,13 @@ class UserBlockTest extends TestCase
 
     public function testStatusesAreBlocked(): void {
         $this->actingAs($this->bob)
-             ->get('/status/' . $this->checkin['statusId'])
+             ->get('/status/' . $this->checkin->status_id)
              ->assertSee($this->alice->name);
 
         $this->aliceBlocksBob();
 
         $this->actingAs($this->bob)
-             ->get('/status/' . $this->checkin['statusId'])
+             ->get('/status/' . $this->checkin->status_id)
              ->assertForbidden();
     }
 
@@ -59,43 +56,42 @@ class UserBlockTest extends TestCase
     }
 
     public function testBobsStatusIsHiddenFromAlicesGlobalDashboard(): void {
-        $this->checkin('Frankfurt Hbf', Carbon::parse('-10min'), $this->bob);
+        TrainCheckin::factory(['user_id' => $this->bob->id])->create();
+
+        $this->actingAs($this->alice)
+             ->get(route('globaldashboard'))
+             ->assertOk()
+             ->assertSee(route('profile.picture', ['username' => $this->bob->username]))
+             ->assertSee(route('profile.picture', ['username' => $this->alice->username]));
 
         $this->aliceBlocksBob();
 
         $this->actingAs($this->alice)
              ->get(route('globaldashboard'))
              ->assertOk()
-             // Bob's name is present in the session bag due the "you successfully blocked bob' message. Instead, we
-             // check that Bob's profile picture is not there, while Alice's picture is still there (from the checkin
-             // in self::setUp).
+            // Bob's name is present in the session bag due the "you successfully blocked bob' message. Instead, we
+            // check that Bob's profile picture is not there, while Alice's picture is still there (from the checkin
+            // in self::setUp).
              ->assertDontSee(route('profile.picture', ['username' => $this->bob->username]))
              ->assertSee(route('profile.picture', ['username' => $this->alice->username]));
     }
 
     public function testAlicesStatusIsHiddenFromBobsActiveJourneys(): void {
-        $trainCheckin          = TrainCheckin::where('status_id', $this->checkin['statusId'])->firstOrFail();
-        $trainCheckin->arrival = Carbon::parse('+10min');
-        $trainCheckin->save();
-
         $this->actingAs($this->bob)
              ->get(route('statuses.active'))
              ->assertOk()
-             ->assertSee('Frankfurt');
+             ->assertSee($this->checkin->destinationStation->name);
 
         $this->aliceBlocksBob();
 
         $this->actingAs($this->bob)
              ->get(route('statuses.active'))
              ->assertOk()
-             ->assertDontSee('Frankfurt');
+             ->assertDontSee($this->checkin->destinationStation->name);
     }
 
     public function testBobsStatusIsHiddenFromAlicesActiveJourneys(): void {
-        $this->checkin         = $this->checkin('Frankfurt Hbf', Carbon::parse('-10min'), $this->bob);
-        $trainCheckin          = TrainCheckin::where('status_id', $this->checkin['statusId'])->firstOrFail();
-        $trainCheckin->arrival = Carbon::parse('+10min');
-        $trainCheckin->save();
+        TrainCheckin::factory(['user_id' => $this->bob->id])->create();
 
         $this->actingAs($this->alice)
              ->get(route('statuses.active'))
@@ -128,12 +124,12 @@ class UserBlockTest extends TestCase
 
     public function testLikesAreDeleted(): void {
         $this->actingAs($this->bob)
-             ->post(route('like.create'), ['statusId' => $this->checkin['statusId']])
+             ->post(route('like.create'), ['statusId' => $this->checkin->status_id])
              ->assertStatus(201);
 
-        $this->checkin = $this->checkin('Frankfurt Hbf', Carbon::parse('-10min'), $this->bob);
+        $this->checkin = TrainCheckin::factory(['user_id' => $this->bob->id])->create();
         $this->actingAs($this->alice)
-             ->post(route('like.create'), ['statusId' => $this->checkin['statusId']])
+             ->post(route('like.create'), ['statusId' => $this->checkin->status_id])
              ->assertStatus(201);
 
         $this->assertEquals(2, Like::all()->count());

--- a/tests/Feature/UserRedirectionTest.php
+++ b/tests/Feature/UserRedirectionTest.php
@@ -86,6 +86,9 @@ class UserRedirectionTest extends TestCase
              ->assertSee(__('privacy.we-changed'), false);
 
         // At this point, we can sign the new agreement and get redirected again:
-        $this->acceptGDPR($user);
+        $response = $this->actingAs($user)
+                         ->post('/gdpr-ack');
+        $response->assertStatus(302);
+        $response->assertRedirect('/dashboard');
     }
 }

--- a/tests/Feature/Webhooks/WebhookNotificationTest.php
+++ b/tests/Feature/Webhooks/WebhookNotificationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Webhooks;
 
 use App\Enum\WebhookEvent;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
 use Spatie\WebhookServer\CallWebhookJob;
@@ -16,8 +17,8 @@ class WebhookNotificationTest extends TestCase {
     public function testWebhookSendingOnNotification() {
         Bus::fake();
 
-        $alice = $this->createGDPRAckedUser();
-        $bob   = $this->createGDPRAckedUser();
+        $alice = User::factory()->create();
+        $bob   = User::factory()->create();
 
         $client = $this->createWebhookClient($alice);
         $this->createWebhook($bob, $client, [WebhookEvent::NOTIFICATION]);

--- a/tests/Feature/Webhooks/WebhookStatusTest.php
+++ b/tests/Feature/Webhooks/WebhookStatusTest.php
@@ -16,25 +16,25 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Http;
 use Spatie\WebhookServer\CallWebhookJob;
 use Tests\TestCase;
-
 use function PHPUnit\Framework\assertEquals;
 
-class WebhookStatusTest extends TestCase {
+class WebhookStatusTest extends TestCase
+{
     use RefreshDatabase;
 
     public function testWebhookSendingOnStatusCreation() {
         Bus::fake();
 
-        $user = $this->createGDPRAckedUser();
+        $user   = User::factory()->create();
         $client = $this->createWebhookClient($user);
         $this->createWebhook($user, $client, [WebhookEvent::CHECKIN_CREATE]);
         $status = $this->createStatus($user);
 
-        Bus::assertDispatched(function (CallWebhookJob $job) use ($status) {
+        Bus::assertDispatched(function(CallWebhookJob $job) use ($status) {
             assertEquals([
-                'event' => WebhookEvent::CHECKIN_CREATE->name(),
-                'status' => new StatusResource($status),
-            ], $job->payload);
+                             'event' => WebhookEvent::CHECKIN_CREATE->name(),
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          'status' => new StatusResource($status),
+                         ], $job->payload);
             return true;
         });
     }
@@ -42,19 +42,19 @@ class WebhookStatusTest extends TestCase {
     public function testWebhookSendingOnStatusBodyChange() {
         Bus::fake();
 
-        $user = $this->createGDPRAckedUser();
+        $user   = User::factory()->create();
         $client = $this->createWebhookClient($user);
         $this->createWebhook($user, $client, [WebhookEvent::CHECKIN_UPDATE]);
         $status = $this->createStatus($user);
         $this->actingAs($user)
-            ->post(route('status.update'), [
-                'statusId' => $status['id'],
-                'body' => 'New Example Body',
-                'business_check' => $status['business']->value,
-                'checkinVisibility' => $status['visibility']->value
-            ]);
+             ->post(route('status.update'), [
+                 'statusId'          => $status['id'],
+                 'body'              => 'New Example Body',
+                 'business_check'    => $status['business']->value,
+                 'checkinVisibility' => $status['visibility']->value
+             ]);
 
-        Bus::assertDispatched(function (CallWebhookJob $job) use ($status) {
+        Bus::assertDispatched(function(CallWebhookJob $job) use ($status) {
             assertEquals(
                 WebhookEvent::CHECKIN_UPDATE->name(),
                 $job->payload['event']
@@ -68,14 +68,14 @@ class WebhookStatusTest extends TestCase {
     public function testWebhookSendingOnLike() {
         Bus::fake();
 
-        $user = $this->createGDPRAckedUser();
+        $user   = User::factory()->create();
         $client = $this->createWebhookClient($user);
         $this->createWebhook($user, $client, [WebhookEvent::CHECKIN_UPDATE]);
         $status = $this->createStatus($user);
         StatusController::createLike($user, $status);
 
         // For self-likes, a CHECKIN_UPDATE is sent, but no notification.
-        Bus::assertDispatched(function (CallWebhookJob $job) use ($status) {
+        Bus::assertDispatched(function(CallWebhookJob $job) use ($status) {
             assertEquals(
                 WebhookEvent::CHECKIN_UPDATE->name(),
                 $job->payload['event']
@@ -89,20 +89,20 @@ class WebhookStatusTest extends TestCase {
     public function testWebhookSendingOnDestinationChange() {
         Bus::fake();
 
-        $user = $this->createGDPRAckedUser();
+        $user   = User::factory()->create();
         $client = $this->createWebhookClient($user);
         $this->createWebhook($user, $client, [WebhookEvent::CHECKIN_UPDATE]);
-        $status = $this->createStatus($user);
-        $checkin = $status->trainCheckin()->first();
+        $status    = $this->createStatus($user);
+        $checkin   = $status->trainCheckin()->first();
         $hafasTrip = TrainCheckinController::getHafasTrip(
-            tripId: self::TRIP_ID,
+            tripId:   self::TRIP_ID,
             lineName: self::ICE802['line']['name'],
-            startId: self::FRANKFURT_HBF['id']
+            startId:  self::FRANKFURT_HBF['id']
         );
-        $aachen  = $hafasTrip->stopoversNew->where('trainStation.ibnr', self::AACHEN_HBF['id'])->first();
+        $aachen    = $hafasTrip->stopoversNew->where('trainStation.ibnr', self::AACHEN_HBF['id'])->first();
         TrainCheckinController::changeDestination($checkin, $aachen);
 
-        Bus::assertDispatched(function (CallWebhookJob $job) use ($status) {
+        Bus::assertDispatched(function(CallWebhookJob $job) use ($status) {
             assertEquals(
                 WebhookEvent::CHECKIN_UPDATE->name(),
                 $job->payload['event']
@@ -118,19 +118,19 @@ class WebhookStatusTest extends TestCase {
     public function testWebhookSendingOnBusinessChange() {
         Bus::fake();
 
-        $user = $this->createGDPRAckedUser();
+        $user   = User::factory()->create();
         $client = $this->createWebhookClient($user);
         $this->createWebhook($user, $client, [WebhookEvent::CHECKIN_UPDATE]);
         $status = $this->createStatus($user);
         $this->actingAs($user)
-            ->post(route('status.update'), [
-                'statusId' => $status['id'],
-                'body' => $status['body'],
-                'business_check' => Business::BUSINESS->value,
-                'checkinVisibility' => $status['visibility']->value
-            ]);
+             ->post(route('status.update'), [
+                 'statusId'          => $status['id'],
+                 'body'              => $status['body'],
+                 'business_check'    => Business::BUSINESS->value,
+                 'checkinVisibility' => $status['visibility']->value
+             ]);
 
-        Bus::assertDispatched(function (CallWebhookJob $job) use ($status) {
+        Bus::assertDispatched(function(CallWebhookJob $job) use ($status) {
             assertEquals(
                 WebhookEvent::CHECKIN_UPDATE->name(),
                 $job->payload['event']
@@ -144,19 +144,19 @@ class WebhookStatusTest extends TestCase {
     public function testWebhookSendingOnVisibilityChange() {
         Bus::fake();
 
-        $user = $this->createGDPRAckedUser();
+        $user   = User::factory()->create();
         $client = $this->createWebhookClient($user);
         $this->createWebhook($user, $client, [WebhookEvent::CHECKIN_UPDATE]);
         $status = $this->createStatus($user);
         $this->actingAs($user)
-            ->post(route('status.update'), [
-                'statusId' => $status['id'],
-                'body' => $status['body'],
-                'business_check' => $status['business']->value,
-                'checkinVisibility' => StatusVisibility::UNLISTED->value,
-            ]);
+             ->post(route('status.update'), [
+                 'statusId'          => $status['id'],
+                 'body'              => $status['body'],
+                 'business_check'    => $status['business']->value,
+                 'checkinVisibility' => StatusVisibility::UNLISTED->value,
+             ]);
 
-        Bus::assertDispatched(function (CallWebhookJob $job) use ($status) {
+        Bus::assertDispatched(function(CallWebhookJob $job) use ($status) {
             assertEquals(
                 WebhookEvent::CHECKIN_UPDATE->name(),
                 $job->payload['event']
@@ -170,13 +170,13 @@ class WebhookStatusTest extends TestCase {
     public function testWebhookSendingOnStatusDeletion() {
         Bus::fake();
 
-        $user = $this->createGDPRAckedUser();
+        $user   = User::factory()->create();
         $client = $this->createWebhookClient($user);
         $this->createWebhook($user, $client, [WebhookEvent::CHECKIN_DELETE]);
         $status = $this->createStatus($user);
         StatusController::DeleteStatus($user, $status['id']);
 
-        Bus::assertDispatched(function (CallWebhookJob $job) use ($status) {
+        Bus::assertDispatched(function(CallWebhookJob $job) use ($status) {
             assertEquals(
                 WebhookEvent::CHECKIN_DELETE->name(),
                 $job->payload['event']
@@ -188,29 +188,29 @@ class WebhookStatusTest extends TestCase {
 
     protected function createStatus(User $user) {
         Http::fake([
-            '/locations*'                              => Http::response([self::FRANKFURT_HBF]),
-            '/trips/' . urlencode(self::TRIP_ID) . '*' => Http::response(self::TRIP_INFO),
-        ]);
+                       '/locations*'                              => Http::response([self::FRANKFURT_HBF]),
+                       '/trips/' . urlencode(self::TRIP_ID) . '*' => Http::response(self::TRIP_INFO),
+                   ]);
 
         $trip = TrainCheckinController::getHafasTrip(
-            tripId: self::TRIP_ID,
+            tripId:   self::TRIP_ID,
             lineName: self::ICE802['line']['name'],
-            startId: self::FRANKFURT_HBF['id']
+            startId:  self::FRANKFURT_HBF['id']
         );
 
-        $origin = HafasController::getTrainStation(self::FRANKFURT_HBF['id']);
+        $origin      = HafasController::getTrainStation(self::FRANKFURT_HBF['id']);
         $destination = HafasController::getTrainStation(self::HANNOVER_HBF['id']);
 
         $checkin = TrainCheckinController::checkin(
-            user: $user,
-            hafasTrip: $trip,
-            origin: $origin,
-            departure: Carbon::parse(self::DEPARTURE_TIME),
-            destination: $destination,
-            arrival: Carbon::parse(self::ARRIVAL_TIME),
+            user:         $user,
+            hafasTrip:    $trip,
+            origin:       $origin,
+            departure:    Carbon::parse(self::DEPARTURE_TIME),
+            destination:  $destination,
+            arrival:      Carbon::parse(self::ARRIVAL_TIME),
             travelReason: Business::PRIVATE,
-            visibility: StatusVisibility::PUBLIC,
-            body: self::EXAMPLE_BODY
+            visibility:   StatusVisibility::PUBLIC,
+            body:         self::EXAMPLE_BODY
         );
         return $checkin['status'];
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -252,7 +252,10 @@ abstract class TestCase extends BaseTestCase
      * @param StatusVisibility $statusVisibility
      *
      * @return array|null
-     * @throws TrainCheckinAlreadyExistException|NotConnectedException|AlreadyCheckedInException
+     * @throws TrainCheckinAlreadyExistException|NotConnectedException|AlreadyCheckedInException|StationNotOnTripException
+     *
+     * @deprecated Please do not use this function (unless you really want to test DB-Rest!).
+     *             Please use the factories instead. For a TrainCheckin e.g. TrainCheckin::factory()->create();
      */
     #[ArrayShape([
         'success'              => "bool",

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -242,14 +242,6 @@ abstract class TestCase extends BaseTestCase
         return $ret;
     }
 
-    public function acceptGDPR(User $user): void {
-        $response = $this->actingAs($user)
-                         ->post('/gdpr-ack');
-        $response->assertStatus(302);
-        $response->assertRedirect('/dashboard');
-    }
-
-
     /**
      * This is mostly copied from Checkin Test and exactly copied from ExportTripsTest.
      *

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -157,21 +157,6 @@ abstract class TestCase extends BaseTestCase
         $this->artisan('db:seed --class=Database\\\\Seeders\\\\PrivacyAgreementSeeder');
     }
 
-    public function createGDPRAckedUser(array $defaultValues = []): User {
-        $user = User::factory($defaultValues)->create();
-        $this->acceptGDPR($user);
-
-        return $user;
-    }
-
-    protected function createAdminUser(): User {
-        $admin       = $this->createGDPRAckedUser();
-        $admin->role = 10;
-        $admin->update();
-
-        return $admin;
-    }
-
     public function createWebhookClient(User $user): OAuthClient {
         $clients = new OAuthClientRepository();
         return $clients->create(

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,8 +7,6 @@ use App\Models\OAuthClient;
 use App\Models\User;
 use App\Models\Webhook;
 use App\Repositories\OAuthClientRepository;
-use Carbon\Carbon;
-use Exception;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
@@ -142,8 +140,7 @@ abstract class TestCase extends BaseTestCase
     }
 
     public function createWebhookClient(User $user): OAuthClient {
-        $clients = new OAuthClientRepository();
-        return $clients->create(
+        return (new OAuthClientRepository())->create(
             $user->id,
             "TRWL Webhook Testing Application",
             "https://example.com",
@@ -158,8 +155,7 @@ abstract class TestCase extends BaseTestCase
     }
 
     public function createOAuthClient(User $user, bool $confidential): OAuthClient {
-        $clients = new OAuthClientRepository();
-        return $clients->create(
+        return (new OAuthClientRepository())->create(
             $user->id,
             "TRWL OAuth Testing Application",
             "https://example.com",
@@ -180,49 +176,5 @@ abstract class TestCase extends BaseTestCase
         }
         $request = WebhookController::createWebhookRequest($user, $client, 'stub', "https://example.com", $bitflag);
         return WebhookController::createWebhook($request);
-    }
-
-    /**
-     * @var string Hafas is weird and it's trip ids are shorter the first 9 days of the month.
-     */
-    private static $HAFAS_ID_DATE = 'jmY';
-
-    /**
-     * Check if the given Hafas Trip was correct. Can be used from several test functions.
-     * Currently checking if the hafas tripId contains four pipe characters and if it contains the
-     * date of the request. If the test runs between 23:45 and midnight, the stationboard response
-     * may contain trains starting the next day. If the test runs after midnight it might contain
-     * some trains that started the day before.
-     *
-     * Trips where the first station is a day before the requestDate can be even one day more earlier.
-     * e.g. Train starts at 01.01. but out request is on the same train which departs on 02.01 at 00:01
-     * at the second station -> in the trip is is still the 01.01.
-     *
-     * @return Boolean If all checks were resolved positively. Assertions to be made on the caller
-     * side to provide a coherent amount of assertions.
-     * @throws Exception
-     */
-    public static function isCorrectHafasTrip($hafastrip, Carbon $requestDate): bool {
-        $requestDateMinusMinusOneDay = $requestDate->clone()->subDays(2)->format(self::$HAFAS_ID_DATE);
-        $requestDateMinusOneDay      = $requestDate->clone()->subDay()->format(self::$HAFAS_ID_DATE);
-        $requestDatePlusOneDay       = $requestDate->clone()->addDay()->format(self::$HAFAS_ID_DATE);
-        $requestDate                 = $requestDate->format(self::$HAFAS_ID_DATE);
-
-        // All Hafas Trips should have four pipe characters
-        $fourPipes = 4 == substr_count($hafastrip->tripId, '|');
-
-        $rightDate = in_array(1, [
-            substr_count($hafastrip->tripId, $requestDateMinusMinusOneDay),
-            substr_count($hafastrip->tripId, $requestDateMinusOneDay),
-            substr_count($hafastrip->tripId, $requestDate),
-            substr_count($hafastrip->tripId, $requestDatePlusOneDay)
-        ]);
-
-        $ret = $fourPipes && $rightDate;
-        if (!$ret) {
-            echo "The following Hafas Trip did not match our expectations:";
-            dd($hafastrip);
-        }
-        return $ret;
     }
 }


### PR DESCRIPTION
fixes #1591

The `bob_joining_on_alices_connection_should_spawn_a_notification` test regularly failed. I have now rewritten it to the point where the data is fully mocked and we are not dependent on any external resource.