### PR TITLE
:construction_worker: Split node vulnerability workflow

### DIFF
--- a/.github/workflows/nodejs-audit.yml
+++ b/.github/workflows/nodejs-audit.yml
@@ -1,4 +1,4 @@
-name: Resources build with `prod`
+name: Check for node vulnerabilities
 
 on: [ push, pull_request ]
 
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 18.x, 19.x ]
+        node-version: [ 19.x ]
 
     steps:
       - uses: actions/checkout@v3
@@ -17,10 +17,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install dependencies
-        run: npm install
-      - name: Run production build
-        run: npm run production
+      - name: Check for vulnerabilities
+        run: npm audit
 
         env:
           CI: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -2151,6 +2151,12 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==",
+            "dev": true
+        },
         "node_modules/@types/http-proxy": {
             "version": "1.17.11",
             "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.11.tgz",
@@ -2225,9 +2231,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.3.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-            "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
+            "version": "20.3.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.2.tgz",
+            "integrity": "sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw==",
             "dev": true
         },
         "node_modules/@types/parse-json": {
@@ -2274,11 +2280,12 @@
             }
         },
         "node_modules/@types/serve-static": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
-            "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.2.tgz",
+            "integrity": "sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==",
             "dev": true,
             "dependencies": {
+                "@types/http-errors": "*",
                 "@types/mime": "*",
                 "@types/node": "*"
             }
@@ -3108,9 +3115,9 @@
             }
         },
         "node_modules/bootstrap-cookie-alert": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/bootstrap-cookie-alert/-/bootstrap-cookie-alert-1.2.1.tgz",
-            "integrity": "sha512-T4nzcJkrCJCfxbw9eRM93EwO3/seSL/wbjsDLLOdLIhhksb07zhj4NOgNJUwtLc7dkI28ef1KZU9yYzHZMUXvQ=="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/bootstrap-cookie-alert/-/bootstrap-cookie-alert-1.2.2.tgz",
+            "integrity": "sha512-jmb3vKoq9rRGRynlLgLJ0fgTk6yICxLoc9GTxUeaHsrOzjqK1cg3HwvkvYspg6tU+LHxyGRQjs4EHkuz4smidQ=="
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -3342,9 +3349,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001505",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001505.tgz",
-            "integrity": "sha512-jaAOR5zVtxHfL0NjZyflVTtXm3D3J9P15zSJ7HmQF8dSKGA6tqzQq+0ZI3xkjyQj46I4/M0K2GbMpcAFOcbr3A==",
+            "version": "1.0.30001509",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001509.tgz",
+            "integrity": "sha512-2uDDk+TRiTX5hMcUYT/7CSyzMZxjfGu0vAUjS2g0LSD8UoXOv0LtpH4LxGMemsiPq6LCVIUjNwVM0erkOkGCDA==",
             "dev": true,
             "funding": [
                 {
@@ -4305,9 +4312,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.434",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.434.tgz",
-            "integrity": "sha512-5Gvm09UZTQRaWrimRtWRO5rvaX6Kpk5WHAPKDa7A4Gj6NIPuJ8w8WNpnxCXdd+CJJt6RBU6tUw0KyULoW6XuHw==",
+            "version": "1.4.442",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.442.tgz",
+            "integrity": "sha512-RkrZF//Ya+0aJq2NM3OdisNh5ZodZq1rdXOS96G8DdDgpDKqKE81yTbbQ3F/4CKm1JBPsGu1Lp/akkna2xO06Q==",
             "dev": true
         },
         "node_modules/elliptic": {
@@ -4378,9 +4385,9 @@
             }
         },
         "node_modules/envinfo": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.9.0.tgz",
-            "integrity": "sha512-RODB4txU+xImYDemN5DqaKC0CHk05XSVkOX4pq0hK26Qx+1LChkuOyUDlGEjYb3ACr0n9qBhFjg37hQuJvpkRQ==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.10.0.tgz",
+            "integrity": "sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==",
             "dev": true,
             "bin": {
                 "envinfo": "dist/cli.js"
@@ -5148,9 +5155,9 @@
             }
         },
         "node_modules/html-entities": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.6.tgz",
-            "integrity": "sha512-9o0+dcpIw2/HxkNuYKxSJUF/MMRZQECK4GnF+oQOmJ83yCVHTWgCH5aOXxK5bozNRmM8wtgryjHD3uloPBDEGw==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.4.0.tgz",
+            "integrity": "sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==",
             "dev": true,
             "funding": [
                 {
@@ -7847,9 +7854,9 @@
             "dev": true
         },
         "node_modules/sass": {
-            "version": "1.63.4",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.4.tgz",
-            "integrity": "sha512-Sx/+weUmK+oiIlI+9sdD0wZHsqpbgQg8wSwSnGBjwb5GwqFhYNwwnI+UWZtLjKvKyFlKkatRK235qQ3mokyPoQ==",
+            "version": "1.63.6",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.6.tgz",
+            "integrity": "sha512-MJuxGMHzaOW7ipp+1KdELtqKbfAWbH7OLIdoSMnVe3EXPMTmxTmlaZDCTsgIpPCs3w99lLo9/zDKkOrJuT5byw==",
             "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -7937,9 +7944,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-            "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+            "version": "7.5.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+            "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -8587,9 +8594,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.18.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.1.tgz",
-            "integrity": "sha512-j1n0Ao919h/Ai5r43VAnfV/7azUYW43GPxK7qSATzrsERfW7+y2QW9Cp9ufnRF5CQUWbnLSo7UJokSWCqg4tsQ==",
+            "version": "5.18.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.2.tgz",
+            "integrity": "sha512-Ah19JS86ypbJzTzvUCX7KOsEIhDaRONungA4aYBjEP3JZRf4ocuDzTg4QWZnPn9DEMiMYGJPiSOy7aykoCc70w==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
@@ -8717,9 +8724,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
             "dev": true
         },
         "node_modules/tty-browserify": {
@@ -9002,9 +9009,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.87.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.87.0.tgz",
-            "integrity": "sha512-GOu1tNbQ7p1bDEoFRs2YPcfyGs8xq52yyPBZ3m2VGnXGtV9MxjrkABHm4V9Ia280OefsSLzvbVoXcfLxjKY/Iw==",
+            "version": "5.88.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
+            "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",


### PR DESCRIPTION
In this PR, I have split the testing for vulnerable node packages into a separate workflow. Currently our node testing is failing because of some vulnerabilities in semver / babel (https://github.com/babel/babel/issues/15720). These vulnerabilities do not affect us, but we cannot fix them at this time.
After this PR, we can see if webpack builds successfully.