### PR TITLE
:zap: Use async decoding and lazy loading for profile pictures

### DIFF
--- a/resources/views/includes/status.blade.php
+++ b/resources/views/includes/status.blade.php
@@ -24,7 +24,7 @@
     <div class="card-body row">
         <div class="col-2 image-box pe-0 d-none d-lg-flex">
             <a href="{{ route('profile', ['username' => $status->user->username]) }}">
-                <img src="{{ ProfilePictureController::getUrl($status->user) }}"
+                <img loading="lazy" decoding="async" src="{{ ProfilePictureController::getUrl($status->user) }}"
                      alt="{{ $status->user->username }}">
             </a>
         </div>

--- a/resources/views/leaderboard/month.blade.php
+++ b/resources/views/leaderboard/month.blade.php
@@ -48,7 +48,10 @@
                             <div class="image-box pe-0 d-lg-flex">
                                 <a href="{{ route('profile', ['username' => $place->user->username]) }}">
                                     <img src="{{ \App\Http\Controllers\Backend\User\ProfilePictureController::getUrl($place->user) }}"
-                                         alt="{{$place->user->username}}" style="width: 50%; max-width: 300px;">
+                                         alt="{{$place->user->username}}"
+                                         style="width: 50%; max-width: 300px;"
+                                         loading="lazy"
+                                         decoding="async">
                                 </a>
                             </div>
                             <a href="{{ route('profile', ['username' => $place->user->username]) }}"
@@ -102,7 +105,9 @@
                                             <div class="image-box pe-0 d-lg-flex" style="width: 4em; height: 4em;">
                                                 <a href="{{ route('profile', ['username' => $place->user->username]) }}">
                                                     <img src="{{ \App\Http\Controllers\Backend\User\ProfilePictureController::getUrl($place->user) }}"
-                                                         alt="{{$place->user->username}}">
+                                                         alt="{{$place->user->username}}"
+                                                         loading="lazy"
+                                                         decoding="async">
                                                 </a>
                                             </div>
                                         </td>

--- a/resources/views/search.blade.php
+++ b/resources/views/search.blade.php
@@ -18,7 +18,9 @@
                                 <a href="{{ route('profile', ['username' => $user->username]) }}">
                                     <img
                                         src="{{\App\Http\Controllers\Backend\User\ProfilePictureController::getUrl($user)}}"
-                                        alt="Profile picture"/>
+                                        alt="Profile picture"
+                                        loading="lazy"
+                                        decoding="async"/>
                                 </a>
                             </div>
 

--- a/resources/views/settings/cards/general.blade.php
+++ b/resources/views/settings/cards/general.blade.php
@@ -13,7 +13,7 @@
                         <img
                                 src="{{ \App\Http\Controllers\Backend\User\ProfilePictureController::getUrl(auth()->user()) }}"
                                 style="max-width: 96px" alt="{{__('settings.picture')}}" class="pb-2"
-                                id="theProfilePicture"
+                                id="theProfilePicture"  loading="lazy" decoding="async"
                         />
                     </div>
 

--- a/resources/views/settings/follower.blade.php
+++ b/resources/views/settings/follower.blade.php
@@ -17,7 +17,7 @@
                                             <td>
                                                 <div class="image-box pe-0 d-lg-flex" style="width: 4em; height: 4em;">
                                                     <a href="{{ route('profile', ['username' => $request->user->username]) }}">
-                                                        <img src="{{ \App\Http\Controllers\Backend\User\ProfilePictureController::getUrl($request->user) }}"
+                                                        <img loading="lazy" decoding="async" src="{{ \App\Http\Controllers\Backend\User\ProfilePictureController::getUrl($request->user) }}"
                                                              style="height: 3em;" alt="{{ $request->user->username }}"
                                                         />
                                                     </a>
@@ -88,6 +88,8 @@
                                                         <img
                                                             src="{{ \App\Http\Controllers\Backend\User\ProfilePictureController::getUrl($follower->user) }}"
                                                             style="height: 4em;"
+                                                            loading="lazy"
+                                                            decoding="async"
                                                         />
                                                     </a>
                                                 </div>
@@ -133,7 +135,10 @@
                                                 <div class="image-box pe-0 d-lg-flex" style="width: 4em; height: 4em;">
                                                     <a href="{{ route('profile', ['username' => $user->username]) }}">
                                                         <img src="{{ \App\Http\Controllers\Backend\User\ProfilePictureController::getUrl($user) }}"
-                                                             style="height: 3em;" alt="{{$user->username}}"
+                                                             style="height: 3em;"
+                                                             alt="{{$user->username}}"
+                                                             loading="lazy"
+                                                             decoding="async"
                                                         />
                                                     </a>
                                                 </div>
@@ -178,7 +183,10 @@
                                                 <div class="image-box pe-0 d-lg-flex" style="width: 4em; height: 4em;">
                                                     <a href="{{ route('profile', ['username' => $user->username]) }}">
                                                         <img src="{{ \App\Http\Controllers\Backend\User\ProfilePictureController::getUrl($user) }}"
-                                                             style="height: 3em;" alt="{{$user->username}}"
+                                                             style="height: 3em;"
+                                                             alt="{{$user->username}}"
+                                                             loading="lazy"
+                                                             decoding="async"
                                                         />
                                                     </a>
                                                 </div>


### PR DESCRIPTION
Hi,  
I just discovered this great project. I'm a web developer myself and a big fan of public transportation in general.  
Apparently this project currently does not use [lazy loading](https://caniuse.com/loading-lazy-attr) or [async decoding](https://caniuse.com/mdn-html_elements_img_decoding) for the profile pictures.  
Applying both should reduce the server load on pages with many `image-box` elements such as <https://traewelling.de/statuses/active> or the user profile pages.

Currently all images are loaded as `png` files in **parallel** from the server. By adding the `loading=lazy` html attribute the browser will load the images when needed (before they appear in the viewport). The async decoding should further speed up the rendering (please also see [here](https://css-tricks.com/newsletter/249-decoding-async-tree-rings-and-flexbox-gap/)).

Using modern media formats like [`webp`](https://caniuse.com/webp) or [`avif`](https://caniuse.com/avif) could further decrease the file sizes. Using the [default](https://traewelling.de/img/user.png) profile picture as an example the file size could be decreased from 16.4kb to 4.1kb when encoding the image as `webp`.

It's also worth mentioning that [optimizing](https://css-tricks.com/tools-for-optimizing-svg/) the `svg` icons (tram, suburban, etc.) with a tool like [SVGOMG](https://jakearchibald.github.io/svgomg/) or [svgo](https://github.com/svg/svgo) might also be feasable.

Best regards,
Alex
