### PR TITLE
:bug: Fix display of unlisted statuses

### DIFF
--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -72,7 +72,7 @@ class StatusController extends Controller
                           })
                           ->get()
                           ->filter(function(Status $status) {
-                              return Gate::allows('view', $status) && !$status->user->shadow_banned;
+                              return Gate::allows('view', $status) && !$status->user->shadow_banned && $status->visibility !== StatusVisibility::UNLISTED;
                           })
                           ->sortByDesc(function(Status $status) {
                               return $status->trainCheckin->departure;

--- a/app/Policies/StatusPolicy.php
+++ b/app/Policies/StatusPolicy.php
@@ -58,7 +58,11 @@ class StatusPolicy
         }
 
         // Case 6: Status is unlisted
-        // This isn't checked here. This is done in the query from the (global/private) dashboard.
+        if ($status->visibility === StatusVisibility::UNLISTED) {
+            //This isn't checked here. This is done in the query from the (global/private) dashboard.
+            //But in general, unlisted statuses are visible to everyone.
+            return Response::allow();
+        }
 
         // Case 7: Status is public or authenticated
         if ($status->visibility === StatusVisibility::PUBLIC || $status->visibility === StatusVisibility::AUTHENTICATED) {


### PR DESCRIPTION
In the past, users could not directly open unlisted statuses, although direct access should be possible. Only the display in the dashboard and on the underway map should be disabled.

Thanks @marhei for reporting this issue to me.