### PR TITLE
:sparkles: Add daily statistics API endpoint

### DIFF
--- a/app/Http/Controllers/API/v1/StatusController.php
+++ b/app/Http/Controllers/API/v1/StatusController.php
@@ -447,21 +447,9 @@ class StatusController extends Controller
                                      return true;
                                  })
                                  ->map(function($status) {
-                                     return [
-                                         'type'       => 'Feature',
-                                         'geometry'   => [
-                                             'type'        => 'LineString',
-                                             'coordinates' => GeoController::getMapLinesForCheckin($status->trainCheckin)
-                                         ],
-                                         'properties' => [
-                                             'statusId' => $status->id
-                                         ]
-                                     ];
+                                     return GeoController::getGeoJsonFeatureForStatus($status);
                                  });
-        $geoJson         = [
-            'type'     => 'FeatureCollection',
-            'features' => $geoJsonFeatures
-        ];
+        $geoJson = GeoController::getGeoJsonFeatureCollection($geoJsonFeatures);
         return $ids ? $this->sendResponse($geoJson) : $this->sendError("");
     }
 

--- a/app/Http/Controllers/Backend/GeoController.php
+++ b/app/Http/Controllers/Backend/GeoController.php
@@ -4,9 +4,11 @@ namespace App\Http\Controllers\Backend;
 
 use App\Http\Controllers\Controller;
 use App\Models\HafasTrip;
+use App\Models\Status;
 use App\Models\TrainCheckin;
 use App\Models\TrainStopover;
 use Exception;
+use Illuminate\Support\Collection;
 use JsonException;
 use stdClass;
 
@@ -211,5 +213,25 @@ abstract class GeoController extends Controller
                 [$checkin->destinationStation->latitude, $checkin->destinationStation->longitude]
             ];
         }
+    }
+
+    public static function getGeoJsonFeatureForStatus(Status $status): array {
+        return [
+            'type'       => 'Feature',
+            'geometry'   => [
+                'type'        => 'LineString',
+                'coordinates' => self::getMapLinesForCheckin($status->trainCheckin)
+            ],
+            'properties' => [
+                'statusId' => $status->id
+            ]
+        ];
+    }
+
+    public static function getGeoJsonFeatureCollection(Collection $features): array {
+        return [
+            'type'     => 'FeatureCollection',
+            'features' => $features
+        ];
     }
 }

--- a/database/factories/HafasTripFactory.php
+++ b/database/factories/HafasTripFactory.php
@@ -8,7 +8,6 @@ use App\Models\HafasOperator;
 use App\Models\HafasTrip;
 use App\Models\TrainStation;
 use App\Models\TrainStopover;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class HafasTripFactory extends Factory
@@ -23,7 +22,7 @@ class HafasTripFactory extends Factory
         }
 
         return [
-            'trip_id'        => $this->faker->unique()->numerify('1|######|##|##|') . Carbon::now()->format('dmY'),
+            'trip_id'        => $this->faker->unique()->numerify('1|######|##|##|') . now()->format('dmY'),
             'category'       => $this->faker->randomElement(HafasTravelType::cases())->value,
             'number'         => $this->faker->bothify('??-##'),
             'linename'       => $this->faker->bothify('?? ##'),
@@ -32,8 +31,8 @@ class HafasTripFactory extends Factory
             'origin'         => $origin->ibnr,
             'destination'    => $destination->ibnr,
             'polyline_id'    => null, //Will be set in the configure function
-            'departure'      => Carbon::now()->subMinutes(15)->format('c'),
-            'arrival'        => Carbon::now()->addMinutes(80)->format('c'),
+            'departure'      => now()->subMinutes(15)->format('c'),
+            'arrival'        => now()->addMinutes(80)->format('c'),
             'delay'          => 0, //TODO: is deprecated? used?
         ];
     }
@@ -85,7 +84,7 @@ class HafasTripFactory extends Factory
     }
 
     public static function createPolyline(HafasTrip $hafasTrip) {
-        $time     = Carbon::now()->subMinutes(15);
+        $time     = now()->subMinutes(15);
         $features = [];
         foreach ($hafasTrip->stopovers as $stopover) {
             $products = [];

--- a/routes/api.php
+++ b/routes/api.php
@@ -93,8 +93,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
             Route::get('/global', [StatisticsController::class, 'getGlobalStatistics']);
             Route::post('export', [StatisticsController::class, 'generateTravelExport'])
                  ->middleware(['scope:write-exports'])->withoutMiddleware(['scope:read-statistics']);
-            Route::get('/daily', [StatisticsController::class, 'getPersonalDailyStatistics']);
-            Route::get('/daily/polylines', [StatisticsController::class, 'getPersonalDailyStatisticPolylines']);
+            Route::get('/daily/{date}', [StatisticsController::class, 'getPersonalDailyStatistics']);
         });
         Route::group(['prefix' => 'user'], static function() {
             Route::group(['middleware' => ['scope:write-follows']], static function() {

--- a/routes/api.php
+++ b/routes/api.php
@@ -93,6 +93,8 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
             Route::get('/global', [StatisticsController::class, 'getGlobalStatistics']);
             Route::post('export', [StatisticsController::class, 'generateTravelExport'])
                  ->middleware(['scope:write-exports'])->withoutMiddleware(['scope:read-statistics']);
+            Route::get('/daily', [StatisticsController::class, 'getPersonalDailyStatistics']);
+            Route::get('/daily/polylines', [StatisticsController::class, 'getPersonalDailyStatisticPolylines']);
         });
         Route::group(['prefix' => 'user'], static function() {
             Route::group(['middleware' => ['scope:write-follows']], static function() {

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.0",
     "info": {
         "title": "Träwelling API",
-        "description": "Träwelling user API description. This is an incomplete documentation with still many errors. The\n *      API is currently not yet stable. Endpoints are still being restructured. Both the URL and the request or body\n *      can be changed. Breaking changes will be announced on the Discord server: https://discord.gg/72t7564ZbV",
+        "description": "Träwelling user API description. This is an incomplete documentation with still many errors. The\r\n *      API is currently not yet stable. Endpoints are still being restructured. Both the URL and the request or body\r\n *      can be changed. Breaking changes will be announced on the Discord server: https://discord.gg/72t7564ZbV",
         "contact": {
             "email": "support@traewelling.de"
         },
@@ -236,7 +236,7 @@
                     "Auth"
                 ],
                 "summary": "Refresh Bearer Token",
-                "description": "This request issues a new Bearer-Token with a new expiration date while also revoking the old\n     *      token.",
+                "description": "This request issues a new Bearer-Token with a new expiration date while also revoking the old\r\n     *      token.",
                 "operationId": "refreshToken",
                 "responses": {
                     "200": {
@@ -550,7 +550,7 @@
                     "Events"
                 ],
                 "summary": "Shows current events with basic information",
-                "description": "Returns array of current events, used for a basic overview during checkiused for a basic\n     *      overview during checkin",
+                "description": "Returns array of current events, used for a basic overview during checkiused for a basic\r\n     *      overview during checkin",
                 "operationId": "getCurrentEvents",
                 "parameters": [
                     {
@@ -1017,7 +1017,7 @@
                     "Likes"
                 ],
                 "summary": "[Auth optional] Get likes for status",
-                "description": "Returns array of users that liked the status. Can return an empty dataset when the status\n     *      author or the requesting user has deactivated likes",
+                "description": "Returns array of users that liked the status. Can return an empty dataset when the status\r\n     *      author or the requesting user has deactivated likes",
                 "operationId": "getLikesForStatus",
                 "parameters": [
                     {
@@ -1936,6 +1936,155 @@
                 ]
             }
         },
+        "/statistics/daily": {
+            "get": {
+                "tags": [
+                    "Statistics"
+                ],
+                "summary": "Get statistics and statuses of one day",
+                "description": "Returns all statuses and statistics for the requested day",
+                "operationId": "getDailyStatistics",
+                "parameters": [
+                    {
+                        "name": "date",
+                        "in": "query",
+                        "description": "Date for which the statistics should be delivered",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "2023-07-25"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "statuses": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/Status"
+                                                    }
+                                                },
+                                                "count": {
+                                                    "type": "integer",
+                                                    "example": "2"
+                                                },
+                                                "distance": {
+                                                    "type": "integer",
+                                                    "example": "74026"
+                                                },
+                                                "duration": {
+                                                    "type": "integer",
+                                                    "example": "4711"
+                                                },
+                                                "points": {
+                                                    "type": "integer",
+                                                    "example": "42"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "404": {
+                        "description": "No statuses found"
+                    },
+                    "403": {
+                        "description": "User not authorized to access this"
+                    }
+                },
+                "security": [
+                    {
+                        "passport": [
+                            "read-statistics"
+                        ]
+                    },
+                    {
+                        "token": []
+                    }
+                ]
+            }
+        },
+        "/statistics/daily/polylines": {
+            "get": {
+                "tags": [
+                    "Statistics"
+                ],
+                "summary": "Get GeoJSON for statuses",
+                "description": "Returns GeoJSON for all requested status IDs",
+                "operationId": "getDailyStatisticPolylines",
+                "parameters": [
+                    {
+                        "name": "date",
+                        "in": "query",
+                        "description": "Date for which the polylines should be delivered",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "2023-07-25"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "type": {
+                                                    "example": "FeatureCollection"
+                                                },
+                                                "features": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/Polyline"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "404": {
+                        "description": "No statuses found"
+                    },
+                    "403": {
+                        "description": "User not authorized to access this"
+                    }
+                },
+                "security": [
+                    {
+                        "passport": [
+                            "read-statistics"
+                        ]
+                    },
+                    {
+                        "token": []
+                    }
+                ]
+            }
+        },
         "/statistics/global": {
             "get": {
                 "tags": [
@@ -2637,7 +2786,7 @@
                     "Status"
                 ],
                 "summary": "Create a StatusTag",
-                "description": "Creates a single StatusTag Object, if user is authorized to. <br><br>The key of a tag is free\n     *      text. You can choose it as you need it. However, <b>please use a namespace for tags</b>\n     *      (<i>namespace:xxx</i>) that only affect your own application.<br><br>For tags related to standard actions\n     *      we recommend the following tags in the trwl namespace:<br><ul><li>trwl:seat (i.e. 61)</li><li>trwl:wagon\n     *      (i.e. 25)</li><li>trwl:ticket (i.e. BahnCard 100 first))</li><li>trwl:travel_class (i.e. 1, 2, business,\n     *      economy, ...)</li><li>trwl:locomotive_class (BR424, BR450)</li><li>trwl:wagon_class (i.e. Bpmz)</li></ul>",
+                "description": "Creates a single StatusTag Object, if user is authorized to. <br><br>The key of a tag is free\r\n     *      text. You can choose it as you need it. However, <b>please use a namespace for tags</b>\r\n     *      (<i>namespace:xxx</i>) that only affect your own application.<br><br>For tags related to standard actions\r\n     *      we recommend the following tags in the trwl namespace:<br><ul><li>trwl:seat (i.e. 61)</li><li>trwl:wagon\r\n     *      (i.e. 25)</li><li>trwl:ticket (i.e. BahnCard 100 first))</li><li>trwl:travel_class (i.e. 1, 2, business,\r\n     *      economy, ...)</li><li>trwl:locomotive_class (BR424, BR450)</li><li>trwl:wagon_class (i.e. Bpmz)</li></ul>",
                 "operationId": "createSingleStatusTag",
                 "parameters": [
                     {
@@ -2886,7 +3035,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "description": "HAFAS Train model. This model might be subject to unexpected changes. See also\n     *                     external documentation at\n     *                     [https://v5.db.transport.rest/api.html#get-stopsiddepartures](https://v5.db.transport.rest/api.html#get-stopsiddepartures).",
+                                                "description": "HAFAS Train model. This model might be subject to unexpected changes. See also\r\n     *                     external documentation at\r\n     *                     [https://v5.db.transport.rest/api.html#get-stopsiddepartures](https://v5.db.transport.rest/api.html#get-stopsiddepartures).",
                                                 "externalDocs": "https://v5.db.transport.rest/api.html#get-stopsiddepartures",
                                                 "example": {
                                                     "tripId": "1|200513|0|81|6012023",
@@ -3322,7 +3471,7 @@
                     "Checkin"
                 ],
                 "summary": "Autocomplete for trainstations",
-                "description": "This request returns an array of max. 10 station objects matching the query. **CAUTION:** All\n     *      slashes (as well as encoded to %2F) in {query} need to be replaced, preferrably by a space (%20)",
+                "description": "This request returns an array of max. 10 station objects matching the query. **CAUTION:** All\r\n     *      slashes (as well as encoded to %2F) in {query} need to be replaced, preferrably by a space (%20)",
                 "operationId": "trainStationAutocomplete",
                 "parameters": [
                     {
@@ -3376,7 +3525,7 @@
                     "Checkin"
                 ],
                 "summary": "History for trainstations",
-                "description": "This request returns an array of max. 10 most recent station objects that the user has arrived\n     *      at.",
+                "description": "This request returns an array of max. 10 most recent station objects that the user has arrived\r\n     *      at.",
                 "operationId": "trainStationHistory",
                 "responses": {
                     "200": {
@@ -3429,7 +3578,7 @@
                                 "properties": {
                                     "confirmation": {
                                         "title": "confirmation",
-                                        "description": "Username of the to be deleted account (needs to match the currently logged in\n     *                  user)",
+                                        "description": "Username of the to be deleted account (needs to match the currently logged in\r\n     *                  user)",
                                         "example": "Gertrud123"
                                     }
                                 },
@@ -3606,7 +3755,7 @@
                     "User/Hide and Block"
                 ],
                 "summary": "Block a user",
-                "description": "Block a specific user. That user will not be able to see your statuses or profile information,\n     *      and cannot send you follow requests. Public statuses are still visible through the incognito mode.",
+                "description": "Block a specific user. That user will not be able to see your statuses or profile information,\r\n     *      and cannot send you follow requests. Public statuses are still visible through the incognito mode.",
                 "operationId": "createBlock",
                 "requestBody": {
                     "required": true,
@@ -3674,7 +3823,7 @@
                     "User/Hide and Block"
                 ],
                 "summary": "Unmute a user",
-                "description": "Unblock a specific user. They are now able to see your statuses and profile information again,\n     *      and send you follow requests.",
+                "description": "Unblock a specific user. They are now able to see your statuses and profile information again,\r\n     *      and send you follow requests.",
                 "operationId": "destroyBlock",
                 "requestBody": {
                     "required": true,
@@ -3744,7 +3893,7 @@
                     "User/Hide and Block"
                 ],
                 "summary": "Mute a user",
-                "description": "Mute a specific user. That way they will not be shown on your dashboard and in the active\n     *      journeys tab",
+                "description": "Mute a specific user. That way they will not be shown on your dashboard and in the active\r\n     *      journeys tab",
                 "operationId": "createMute",
                 "parameters": [
                     {
@@ -3802,7 +3951,7 @@
                     "User/Hide and Block"
                 ],
                 "summary": "Unmute a user",
-                "description": "Unmute a specific user. That way they will be shown on your dashboard and in the active\n     *      journeys tab again",
+                "description": "Unmute a specific user. That way they will be shown on your dashboard and in the active\r\n     *      journeys tab again",
                 "operationId": "destroyMute",
                 "parameters": [
                     {
@@ -4863,7 +5012,7 @@
                     },
                     "ibnr": {
                         "title": "ibnr",
-                        "description": "If true, the `start` and `destination` properties can be supplied as an ibnr. Otherwise they\n     *     should be given as the Träwelling-ID. Default behavior is `false`.",
+                        "description": "If true, the `start` and `destination` properties can be supplied as an ibnr. Otherwise they\r\n     *     should be given as the Träwelling-ID. Default behavior is `false`.",
                         "type": "boolean",
                         "example": "true",
                         "nullable": true
@@ -4902,7 +5051,7 @@
                     },
                     "force": {
                         "title": "force",
-                        "description": "If true, the checkin will be created, even if a colliding checkin exists. No points will be\n     *     awarded.",
+                        "description": "If true, the checkin will be created, even if a colliding checkin exists. No points will be\r\n     *     awarded.",
                         "type": "boolean",
                         "example": "false",
                         "nullable": true
@@ -5051,7 +5200,7 @@
                     },
                     "departure": {
                         "title": "departure",
-                        "description": "currently known departure time. Equal to departureReal if known. Else equal to\n     *     departurePlanned.",
+                        "description": "currently known departure time. Equal to departureReal if known. Else equal to\r\n     *     departurePlanned.",
                         "example": "2022-07-17T14:17:00+02:00",
                         "nullable": true
                     },
@@ -5551,7 +5700,7 @@
             },
             "MastodonVisibilityEnum": {
                 "title": "visibility",
-                "description": "What type of visibility (0=public, 1=unlisted, 2=followers, 3=private) did the user specify for\n *     future posts to Mastodon? Some instances such as chaos.social discourage bot posts on public timelines.",
+                "description": "What type of visibility (0=public, 1=unlisted, 2=followers, 3=private) did the user specify for\r\n *     future posts to Mastodon? Some instances such as chaos.social discourage bot posts on public timelines.",
                 "type": "integer",
                 "enum": [
                     0,
@@ -5610,7 +5759,7 @@
             },
             "VisibilityEnum": {
                 "title": "visibility",
-                "description": "What type of visibility (0=public, 1=unlisted, 2=followers, 3=private, 4=authenticated) did the\n *     user specify?",
+                "description": "What type of visibility (0=public, 1=unlisted, 2=followers, 3=private, 4=authenticated) did the\r\n *     user specify?",
                 "type": "integer",
                 "enum": [
                     0,

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.0",
     "info": {
         "title": "Träwelling API",
-        "description": "Träwelling user API description. This is an incomplete documentation with still many errors. The\r\n *      API is currently not yet stable. Endpoints are still being restructured. Both the URL and the request or body\r\n *      can be changed. Breaking changes will be announced on the Discord server: https://discord.gg/72t7564ZbV",
+        "description": "Träwelling user API description. This is an incomplete documentation with still many errors. The\n *      API is currently not yet stable. Endpoints are still being restructured. Both the URL and the request or body\n *      can be changed. Breaking changes will be announced on the Discord server: https://discord.gg/72t7564ZbV",
         "contact": {
             "email": "support@traewelling.de"
         },
@@ -18,7 +18,7 @@
             "description": "Production Server"
         },
         {
-            "url": "http://localhost:8000/api/v1",
+            "url": "https://traewelling.de/api/v1",
             "description": "This instance"
         }
     ],
@@ -236,7 +236,7 @@
                     "Auth"
                 ],
                 "summary": "Refresh Bearer Token",
-                "description": "This request issues a new Bearer-Token with a new expiration date while also revoking the old\r\n     *      token.",
+                "description": "This request issues a new Bearer-Token with a new expiration date while also revoking the old\n     *      token.",
                 "operationId": "refreshToken",
                 "responses": {
                     "200": {
@@ -550,7 +550,7 @@
                     "Events"
                 ],
                 "summary": "Shows current events with basic information",
-                "description": "Returns array of current events, used for a basic overview during checkiused for a basic\r\n     *      overview during checkin",
+                "description": "Returns array of current events, used for a basic overview during checkiused for a basic\n     *      overview during checkin",
                 "operationId": "getCurrentEvents",
                 "parameters": [
                     {
@@ -1017,7 +1017,7 @@
                     "Likes"
                 ],
                 "summary": "[Auth optional] Get likes for status",
-                "description": "Returns array of users that liked the status. Can return an empty dataset when the status\r\n     *      author or the requesting user has deactivated likes",
+                "description": "Returns array of users that liked the status. Can return an empty dataset when the status\n     *      author or the requesting user has deactivated likes",
                 "operationId": "getLikesForStatus",
                 "parameters": [
                     {
@@ -1936,7 +1936,7 @@
                 ]
             }
         },
-        "/statistics/daily": {
+        "/statistics/daily/{date}": {
             "get": {
                 "tags": [
                     "Statistics"
@@ -1946,13 +1946,13 @@
                 "operationId": "getDailyStatistics",
                 "parameters": [
                     {
-                        "name": "date",
+                        "name": "withPolylines",
                         "in": "query",
-                        "description": "Date for which the statistics should be delivered",
+                        "description": "If this parameter is set, the polylines will be returned as well. Otherwise attribute is null.",
                         "schema": {
                             "type": "string"
                         },
-                        "example": "2023-07-25"
+                        "example": ""
                     }
                 ],
                 "responses": {
@@ -1970,19 +1970,21 @@
                                                         "$ref": "#/components/schemas/Status"
                                                     }
                                                 },
-                                                "count": {
-                                                    "type": "integer",
-                                                    "example": "2"
+                                                "polylines": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/Polyline"
+                                                    }
                                                 },
-                                                "distance": {
+                                                "totalDistance": {
                                                     "type": "integer",
                                                     "example": "74026"
                                                 },
-                                                "duration": {
+                                                "totalDuration": {
                                                     "type": "integer",
                                                     "example": "4711"
                                                 },
-                                                "points": {
+                                                "totalPoints": {
                                                     "type": "integer",
                                                     "example": "42"
                                                 }
@@ -1998,73 +2000,8 @@
                     "400": {
                         "description": "Bad request"
                     },
-                    "404": {
-                        "description": "No statuses found"
-                    },
-                    "403": {
-                        "description": "User not authorized to access this"
-                    }
-                },
-                "security": [
-                    {
-                        "passport": [
-                            "read-statistics"
-                        ]
-                    },
-                    {
-                        "token": []
-                    }
-                ]
-            }
-        },
-        "/statistics/daily/polylines": {
-            "get": {
-                "tags": [
-                    "Statistics"
-                ],
-                "summary": "Get GeoJSON for statuses",
-                "description": "Returns GeoJSON for all requested status IDs",
-                "operationId": "getDailyStatisticPolylines",
-                "parameters": [
-                    {
-                        "name": "date",
-                        "in": "query",
-                        "description": "Date for which the polylines should be delivered",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "2023-07-25"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "data": {
-                                            "properties": {
-                                                "type": {
-                                                    "example": "FeatureCollection"
-                                                },
-                                                "features": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/components/schemas/Polyline"
-                                                    }
-                                                }
-                                            },
-                                            "type": "object"
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request"
+                    "401": {
+                        "description": "Unauthorized"
                     },
                     "404": {
                         "description": "No statuses found"
@@ -2786,7 +2723,7 @@
                     "Status"
                 ],
                 "summary": "Create a StatusTag",
-                "description": "Creates a single StatusTag Object, if user is authorized to. <br><br>The key of a tag is free\r\n     *      text. You can choose it as you need it. However, <b>please use a namespace for tags</b>\r\n     *      (<i>namespace:xxx</i>) that only affect your own application.<br><br>For tags related to standard actions\r\n     *      we recommend the following tags in the trwl namespace:<br><ul><li>trwl:seat (i.e. 61)</li><li>trwl:wagon\r\n     *      (i.e. 25)</li><li>trwl:ticket (i.e. BahnCard 100 first))</li><li>trwl:travel_class (i.e. 1, 2, business,\r\n     *      economy, ...)</li><li>trwl:locomotive_class (BR424, BR450)</li><li>trwl:wagon_class (i.e. Bpmz)</li></ul>",
+                "description": "Creates a single StatusTag Object, if user is authorized to. <br><br>The key of a tag is free\n     *      text. You can choose it as you need it. However, <b>please use a namespace for tags</b>\n     *      (<i>namespace:xxx</i>) that only affect your own application.<br><br>For tags related to standard actions\n     *      we recommend the following tags in the trwl namespace:<br><ul><li>trwl:seat (i.e. 61)</li><li>trwl:wagon\n     *      (i.e. 25)</li><li>trwl:ticket (i.e. BahnCard 100 first))</li><li>trwl:travel_class (i.e. 1, 2, business,\n     *      economy, ...)</li><li>trwl:locomotive_class (BR424, BR450)</li><li>trwl:wagon_class (i.e. Bpmz)</li></ul>",
                 "operationId": "createSingleStatusTag",
                 "parameters": [
                     {
@@ -3035,7 +2972,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "description": "HAFAS Train model. This model might be subject to unexpected changes. See also\r\n     *                     external documentation at\r\n     *                     [https://v5.db.transport.rest/api.html#get-stopsiddepartures](https://v5.db.transport.rest/api.html#get-stopsiddepartures).",
+                                                "description": "HAFAS Train model. This model might be subject to unexpected changes. See also\n     *                     external documentation at\n     *                     [https://v5.db.transport.rest/api.html#get-stopsiddepartures](https://v5.db.transport.rest/api.html#get-stopsiddepartures).",
                                                 "externalDocs": "https://v5.db.transport.rest/api.html#get-stopsiddepartures",
                                                 "example": {
                                                     "tripId": "1|200513|0|81|6012023",
@@ -3471,7 +3408,7 @@
                     "Checkin"
                 ],
                 "summary": "Autocomplete for trainstations",
-                "description": "This request returns an array of max. 10 station objects matching the query. **CAUTION:** All\r\n     *      slashes (as well as encoded to %2F) in {query} need to be replaced, preferrably by a space (%20)",
+                "description": "This request returns an array of max. 10 station objects matching the query. **CAUTION:** All\n     *      slashes (as well as encoded to %2F) in {query} need to be replaced, preferrably by a space (%20)",
                 "operationId": "trainStationAutocomplete",
                 "parameters": [
                     {
@@ -3525,7 +3462,7 @@
                     "Checkin"
                 ],
                 "summary": "History for trainstations",
-                "description": "This request returns an array of max. 10 most recent station objects that the user has arrived\r\n     *      at.",
+                "description": "This request returns an array of max. 10 most recent station objects that the user has arrived\n     *      at.",
                 "operationId": "trainStationHistory",
                 "responses": {
                     "200": {
@@ -3578,7 +3515,7 @@
                                 "properties": {
                                     "confirmation": {
                                         "title": "confirmation",
-                                        "description": "Username of the to be deleted account (needs to match the currently logged in\r\n     *                  user)",
+                                        "description": "Username of the to be deleted account (needs to match the currently logged in\n     *                  user)",
                                         "example": "Gertrud123"
                                     }
                                 },
@@ -3755,7 +3692,7 @@
                     "User/Hide and Block"
                 ],
                 "summary": "Block a user",
-                "description": "Block a specific user. That user will not be able to see your statuses or profile information,\r\n     *      and cannot send you follow requests. Public statuses are still visible through the incognito mode.",
+                "description": "Block a specific user. That user will not be able to see your statuses or profile information,\n     *      and cannot send you follow requests. Public statuses are still visible through the incognito mode.",
                 "operationId": "createBlock",
                 "requestBody": {
                     "required": true,
@@ -3823,7 +3760,7 @@
                     "User/Hide and Block"
                 ],
                 "summary": "Unmute a user",
-                "description": "Unblock a specific user. They are now able to see your statuses and profile information again,\r\n     *      and send you follow requests.",
+                "description": "Unblock a specific user. They are now able to see your statuses and profile information again,\n     *      and send you follow requests.",
                 "operationId": "destroyBlock",
                 "requestBody": {
                     "required": true,
@@ -3893,7 +3830,7 @@
                     "User/Hide and Block"
                 ],
                 "summary": "Mute a user",
-                "description": "Mute a specific user. That way they will not be shown on your dashboard and in the active\r\n     *      journeys tab",
+                "description": "Mute a specific user. That way they will not be shown on your dashboard and in the active\n     *      journeys tab",
                 "operationId": "createMute",
                 "parameters": [
                     {
@@ -3951,7 +3888,7 @@
                     "User/Hide and Block"
                 ],
                 "summary": "Unmute a user",
-                "description": "Unmute a specific user. That way they will be shown on your dashboard and in the active\r\n     *      journeys tab again",
+                "description": "Unmute a specific user. That way they will be shown on your dashboard and in the active\n     *      journeys tab again",
                 "operationId": "destroyMute",
                 "parameters": [
                     {
@@ -5012,7 +4949,7 @@
                     },
                     "ibnr": {
                         "title": "ibnr",
-                        "description": "If true, the `start` and `destination` properties can be supplied as an ibnr. Otherwise they\r\n     *     should be given as the Träwelling-ID. Default behavior is `false`.",
+                        "description": "If true, the `start` and `destination` properties can be supplied as an ibnr. Otherwise they\n     *     should be given as the Träwelling-ID. Default behavior is `false`.",
                         "type": "boolean",
                         "example": "true",
                         "nullable": true
@@ -5051,7 +4988,7 @@
                     },
                     "force": {
                         "title": "force",
-                        "description": "If true, the checkin will be created, even if a colliding checkin exists. No points will be\r\n     *     awarded.",
+                        "description": "If true, the checkin will be created, even if a colliding checkin exists. No points will be\n     *     awarded.",
                         "type": "boolean",
                         "example": "false",
                         "nullable": true
@@ -5200,7 +5137,7 @@
                     },
                     "departure": {
                         "title": "departure",
-                        "description": "currently known departure time. Equal to departureReal if known. Else equal to\r\n     *     departurePlanned.",
+                        "description": "currently known departure time. Equal to departureReal if known. Else equal to\n     *     departurePlanned.",
                         "example": "2022-07-17T14:17:00+02:00",
                         "nullable": true
                     },
@@ -5700,7 +5637,7 @@
             },
             "MastodonVisibilityEnum": {
                 "title": "visibility",
-                "description": "What type of visibility (0=public, 1=unlisted, 2=followers, 3=private) did the user specify for\r\n *     future posts to Mastodon? Some instances such as chaos.social discourage bot posts on public timelines.",
+                "description": "What type of visibility (0=public, 1=unlisted, 2=followers, 3=private) did the user specify for\n *     future posts to Mastodon? Some instances such as chaos.social discourage bot posts on public timelines.",
                 "type": "integer",
                 "enum": [
                     0,
@@ -5759,7 +5696,7 @@
             },
             "VisibilityEnum": {
                 "title": "visibility",
-                "description": "What type of visibility (0=public, 1=unlisted, 2=followers, 3=private, 4=authenticated) did the\r\n *     user specify?",
+                "description": "What type of visibility (0=public, 1=unlisted, 2=followers, 3=private, 4=authenticated) did the\n *     user specify?",
                 "type": "integer",
                 "enum": [
                     0,

--- a/tests/Feature/APIv1/StatisticsTest.php
+++ b/tests/Feature/APIv1/StatisticsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\APIv1;
+
+use App\Models\TrainCheckin;
+use App\Models\User;
+use App\Providers\AuthServiceProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\ApiTestCase;
+
+class StatisticsTest extends ApiTestCase
+{
+
+    use RefreshDatabase;
+
+    public function testDailyStatistics(): void {
+        $user      = User::factory()->create();
+        $userToken = $user->createToken('token', array_keys(AuthServiceProvider::$scopes))->accessToken;
+        TrainCheckin::factory(['user_id' => $user->id])->create();
+
+        $response = $this->get(
+            uri:     '/api/v1/statistics/daily/' . now()->format('Y-m-d'),
+            headers: ['Authorization' => 'Bearer ' . $userToken]
+        );
+        $response->assertOk();
+        $response->assertJsonStructure([
+                                           'data' => [
+                                               'statuses',
+                                               'polylines',
+                                               'totalDistance',
+                                               'totalDuration',
+                                               'totalPoints',
+                                           ]
+                                       ]);
+        $this->assertNull($response->json('data.polylines'));
+    }
+
+    public function testDailyStatisticsWithPolylines(): void {
+        $user      = User::factory()->create();
+        $userToken = $user->createToken('token', array_keys(AuthServiceProvider::$scopes))->accessToken;
+        TrainCheckin::factory(['user_id' => $user->id])->create();
+
+        $response = $this->get(
+            uri:     '/api/v1/statistics/daily/' . now()->format('Y-m-d') . '?withPolylines',
+            headers: ['Authorization' => 'Bearer ' . $userToken]
+        );
+        $response->assertOk();
+        $response->assertJsonStructure([
+                                           'data' => [
+                                               'statuses',
+                                               'polylines',
+                                               'totalDistance',
+                                               'totalDuration',
+                                               'totalPoints',
+                                           ]
+                                       ]);
+        $this->assertNotNull($response->json('data.polylines'));
+    }
+}


### PR DESCRIPTION
This PR closes #1754.
Daily statistics are delivered by endpoints:

- `api/v1/statistics/daily?date=2023-07-28` for statuses and stats
- `api/v1/statistics/daily/polylines?date=2023-07-28` for polylines of the statuses

Maybe you would like to add tests, I don't know how to do that :)
And maybe you would like to regenerate the API docs because Windows and PHPStorm doing CRLF things :)