### PR TITLE
Add Yearly Stats

### DIFF
--- a/app/Http/Controllers/Backend/Stats/YearlyStatsController.php
+++ b/app/Http/Controllers/Backend/Stats/YearlyStatsController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Backend\Stats;
+
+use App\Http\Controllers\Controller;
+use App\Models\Status;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class YearlyStatsController extends Controller
+{
+    public static function getStatusesOnDate(User $user, int $year): Collection {
+        return Status::with(['trainCheckin'])
+                     ->join('train_checkins', 'statuses.id', '=', 'train_checkins.status_id')
+                     ->where('statuses.user_id', $user->id)
+                     ->where('train_checkins.departure', '>=', new Carbon($year ."-01-01"))
+                     ->where('train_checkins.departure', '<=', new Carbon($year ."-12-31"))
+                     ->select('statuses.*')
+                     ->get()
+                     ->sortBy('trainCheckin.departure');
+    }
+}

--- a/app/Http/Controllers/Frontend/Stats/YearlyStatsController.php
+++ b/app/Http/Controllers/Frontend/Stats/YearlyStatsController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Frontend\Stats;
+
+use App\Http\Controllers\Backend\GeoController;
+use App\Http\Controllers\Controller;
+use App\Models\Status;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Date;
+use App\Http\Controllers\Backend\Stats\YearlyStatsController as YearlyStatsBackend;
+use Illuminate\View\View;
+
+class YearlyStatsController extends Controller
+{
+    public function renderYearlyStats(string $year): View {
+        $statuses = YearlyStatsBackend::getStatusesOnDate(Auth::user(), (int)$year)
+                                     ->map(function(Status $status) {
+                                         $status->mapLines = GeoController::getMapLinesForCheckin($status->trainCheckin, true);
+                                         return $status;
+                                     });
+
+        $yearBefore = ((int)$year) - 1;
+        $yearAfter = null;
+        if((int) $year < (new Carbon())->year) {
+            $yearAfter = ((int)$year) + 1;
+        }
+
+        return view('stats.yearly', [
+            'year'     => $year,
+            'yearBefore' => $yearBefore,
+            'yearAfter' => $yearAfter,
+            'statuses' => $statuses,
+        ]);
+    }
+}

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -623,6 +623,7 @@
     "support.go-to-github": "Bitte melde uns Softwarefehler und Verbesserungsvorschläge auf GitHub. Nutze dafür die folgenden Buttons. Über dieses Formular können wir dir helfen, wenn du Probleme mit deinem Account oder Checkins auf traewelling.de hast.",
     "no-journeys-day": "An diesem Tag hast du in keine Fahrt eingecheckt.",
     "stats-day": "Deine Fahrten am :date",
+    "stats-year": "Deine Fahrten in :year",
     "stats.stations.description": "Karte deiner durchfahrenen Stationen",
     "stats.stations.passed": "Durchgefahrene Station",
     "stats.stations.changed": "Einstieg / Ausstieg / Umstieg",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -624,6 +624,7 @@
     "support.go-to-github": "Please report software bugs and improvement suggestions on GitHub. Use the buttons below to do so. We can help you with this form if you have problems with your account or checkins on traewelling.de.",
     "no-journeys-day": "You didn't check into any journeys that day.",
     "stats-day": "Your journeys at :date",
+    "stats-year": "Your journeys in :year",
     "stats.stations.description": "Map of your passed stations",
     "stats.stations.passed": "Passed station",
     "stats.stations.changed": "Entry / Exit / Change",

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -49,6 +49,7 @@ body {
 @import "./components/custom-buttons";
 @import "./components/stationboard";
 @import "./components/dailyStats";
+@import "./components/yearlyStats";
 @import "./components/maps";
 
 .table-vertical-center td {

--- a/resources/sass/components/yearlyStats.scss
+++ b/resources/sass/components/yearlyStats.scss
@@ -1,0 +1,23 @@
+#yearly-stats-statsbar {
+    .col-lg-3 {
+        border-right: 1px solid rgba(0, 0, 0, 0.125);
+
+        // md to lg breakpoint
+        @media screen and (max-width: 992px) {
+            &:nth-child(2) {
+                border-right: 0;
+            }
+        }
+
+        &:last-child {
+            border-right: 0;
+        }
+
+        // lg to xl breakpoint
+        @media screen and (max-width: 1200px) {
+            i {
+                display: block;
+            }
+        }
+    }
+}

--- a/resources/views/stats/yearly.blade.php
+++ b/resources/views/stats/yearly.blade.php
@@ -1,0 +1,92 @@
+@extends('layouts.app')
+@section('title', __('stats-year', ['year' => $year]))
+
+@section('content')
+    <div class="container">
+        <div class="row">
+            <div class="col-12 mb-3">
+                <h1 class="fs-4">{{__('stats-year', ['year' => $year])}}</h1>
+
+                <a href="{{route('stats.yearly', ['year' => $yearBefore])}}"
+                   class="btn btn-primary"
+                >
+                    <i class="fa-solid fa-arrow-left" aria-hidden="true"></i>
+                    {{$yearBefore}}
+                </a>
+                @if(!empty($yearAfter))
+                    <a href="{{route('stats.yearly', ['year' => $yearAfter])}}"
+                       class="btn btn-primary float-end"
+                    >
+                        {{$yearAfter}}
+                        <i class="fa-solid fa-arrow-right" aria-hidden="true"></i>
+                    </a>
+                @endif
+            </div>
+
+            <div class="col-md-6 mb-4">
+                <div id="map" style="min-height: 600px;"></div>
+                <script>
+                    window.addEventListener("load", () => {
+                        let map = L.map(document.getElementById('map'), {
+                            center: [50.3, 10.47],
+                            zoom: 5
+                        });
+
+                        let featureGroup = L.featureGroup().addTo(map);
+
+                        setTilingLayer(mapprovider, map);
+
+                        @foreach($statuses as $status)
+                        try {
+                        let coordinates = {{json_encode($status->mapLines)}};
+                            L.polyline(coordinates)
+                                .setStyle({color: "rgb(192, 57, 43)", weight: 5})
+                                .addTo(featureGroup);
+                        } catch (e) {
+                            console.error(e);
+                        }
+
+                    @endforeach
+
+                    map.fitBounds(featureGroup.getBounds());
+                });
+
+                </script>
+            </div>
+            <div class="col-md-6">
+                @if($statuses->count() === 0)
+                    <div class="alert alert-warning text-center fs-4">
+                        {{__('no-journeys-day')}}
+                    </div>
+                @else
+                    <div class="row text-center fs-5" id="yearly-stats-statsbar">
+                        <div class="col-6 mb-3 col-lg-3">
+                            <i class="fa-solid fa-train"></i>
+                            {{$statuses->count()}}
+                            {{__('stats.trips')}}
+                        </div>
+                        <div class="col-6 mb-3 col-lg-3">
+                            <i class="fa-solid fa-route"></i>
+                            {{round($statuses->sum('trainCheckin.distance') / 1000)}} km
+                        </div>
+                        <div class="col-6 mb-3 col-lg-3">
+                            <i class="fa-regular fa-clock"></i>
+                            {!! durationToSpan(secondsToDuration($statuses->sum('trainCheckin.duration') * 60)) !!}
+                        </div>
+                        <div class="col-6 mb-3 col-lg-3">
+                            <i class="fa fa-dice-d20"></i>
+                            {{$statuses->sum('trainCheckin.points')}} {{__('profile.points-abbr')}}
+                        </div>
+                    </div>
+
+                    @foreach($statuses as $status)
+                        @include('includes.status')
+                    @endforeach
+                @endif
+            </div>
+        </div>
+    </div>
+
+    @include('includes.edit-modal')
+    @include('includes.delete-modal')
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\Frontend\Social\SocialController;
 use App\Http\Controllers\Frontend\StatisticController;
 use App\Http\Controllers\Frontend\Stats\DailyStatsController;
 use App\Http\Controllers\Frontend\Stats\YearInReviewController;
+use App\Http\Controllers\Frontend\Stats\YearlyStatsController;
 use App\Http\Controllers\Frontend\Support\SupportController;
 use App\Http\Controllers\Frontend\Transport\StatusController;
 use App\Http\Controllers\Frontend\User\ProfilePictureController;
@@ -141,6 +142,8 @@ Route::middleware(['auth', 'privacy'])->group(function() {
              ->name('stats.stations');
         Route::get('/daily/{dateString}', [DailyStatsController::class, 'renderDailyStats'])
              ->name('stats.daily');
+        Route::get('/yearly/{year}', [YearlyStatsController::class, 'renderYearlyStats'])
+             ->name('stats.yearly');
     });
 
     Route::get('/support', [SupportController::class, 'renderSupportPage'])->name('support');


### PR DESCRIPTION
This pull request adds yearly stats, styled similarly to the daily stats. 
We need to determine exactly where to integrate it.
For now, only views and controllers have been added.

There are no links to this feature from other pages at the moment.

I added this feature because I find it really nice to see where I've been within the current year and to track the routes I took during my travels.