### PR TITLE
:ambulance: Fix notification data contained in webhook

### DIFF
--- a/app/Listeners/NotificationSentWebhookListener.php
+++ b/app/Listeners/NotificationSentWebhookListener.php
@@ -14,7 +14,7 @@ class NotificationSentWebhookListener
             return;
         }
         $user = User::where('id', $event->notifiable->id)->first();
-        $notification = $user->notifications->find($event->notification->id)->first();
+        $notification = $user->notifications->where('id', $event->notification->id)->first();
         WebhookController::sendNotificationWebhook($user, $notification);
     }
 }


### PR DESCRIPTION
This PR fixes that the notification, which triggers the webhook, was not contained in the webhook. 