### PR TITLE
:mute: remove old queue monitoring data to prevent filling up the database

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -33,6 +33,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('trwl:hideStatus')->daily();
         $schedule->command('trwl:cache:leaderboard')->withoutOverlapping()->everyFiveMinutes();
         $schedule->command('cache:clear-database')->daily();
+        $schedule->command('queue-monitor:purge --beforeDays=7')->daily();
 
         if (config('trwl.year_in_review_active')) {
             $schedule->command('trwl:cache-year-in-review')->withoutOverlapping()->dailyAt('2:00');


### PR DESCRIPTION
Closes https://github.com/Traewelling/traewelling/issues/1841.

Please let me know, if anyone thinks that the "7" should be configurable or if its okay to hardcode that.