### PR TITLE
Improvements for running tests etc. from flake

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ MIX_APP_NAME=Träwelling
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=http://localhost:8000
 FORCE_HTTPS=false
 
 L5_SWAGGER_CONST_HOST=http://localhost:8000/api/v1

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,8 @@
         ...
       }: {
         devenv.shells.default = {config, ...}: {
+          # See https://github.com/cachix/devenv/issues/528#issuecomment-1556108767
+          containers = lib.mkForce {};
           languages = {
             php.enable = true;
             javascript.enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,11 @@
             php = "${config.languages.php.package}/bin/php";
             npm = "${config.languages.javascript.package}/bin/npm";
             mysql = config.services.mysql.package;
+
+            envKeys = builtins.attrNames config.env;
+            unsetEnv = builtins.concatStringsSep "\n" (
+              map (key: "unset ${key}") envKeys
+            );
           in {
             setup-devenv.exec = ''
               set -eo pipefail
@@ -83,7 +88,9 @@
               ${php} artisan passport:install > /dev/null
             '';
             serve.exec = ''
-              APP_URL=http://localhost:8000 ${npm} run dev &
+              # Unset .env variables, so laravel reads the .env files by itself
+              ${unsetEnv}
+              ${npm} run dev &
               ${php} artisan serve
             '';
           };

--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,11 @@
               ${npm} run dev &
               ${php} artisan serve
             '';
+            artisan.exec = ''
+              # Unset .env variables, so laravel reads the .env files by itself
+              ${unsetEnv}
+              exec ${php} artisan $@
+            '';
           };
         };
         formatter = pkgs.alejandra;


### PR DESCRIPTION
The Laravel test runner gets confused when the .env file is loaded in the environment.
The set environment override the .env.testing options, so they need to be unset for the tests to work correctly.
I added a small wrapper for artisan which also unsets the environment variables, so that part is done by laravel itself.
I also added a workaround for [this issue](https://github.com/cachix/devenv/issues/528#issuecomment-1556108767).
