### PR TITLE
:stethoscope: Implement health monitoring routes

### DIFF
--- a/app/Console/Commands/SchedulerCanary.php
+++ b/app/Console/Commands/SchedulerCanary.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enum\CacheKey;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+class SchedulerCanary extends Command
+{
+    protected $signature = 'app:scheduler-canary';
+
+    protected $description = 'Set a cache item to the current time stamp. Referred to in Health Controller';
+
+    public function handle()
+    {
+        Cache::put(CacheKey::SchedulerCanary, time());
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -30,6 +30,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('trwl:cleanUpPasswordResets')->dailyAt('1:45');
         $schedule->command('trwl:cleanUpNotifications')->dailyAt('1:50');
         $schedule->command('trwl:refreshTrips')->withoutOverlapping()->everyMinute();
+        $schedule->command('trwl:scheduler-canary')->withoutOverlapping()->everyMinute();
         $schedule->command('trwl:hideStatus')->daily();
         $schedule->command('trwl:cache:leaderboard')->withoutOverlapping()->everyFiveMinutes();
         $schedule->command('cache:clear-database')->daily();

--- a/app/Enum/CacheKey.php
+++ b/app/Enum/CacheKey.php
@@ -11,6 +11,7 @@ class CacheKey
     public const LeaderboardGlobalPoints   = 'LeaderboardGlobalPoints';
     public const LeaderboardGlobalDistance = 'LeaderboardGlobalDistance';
     public const LeaderboardMonth          = 'LeaderboardMonth';
+    public const SchedulerCanary           = 'scheduler-canary';
     public const StatisticsGlobal          = 'StatisticsGlobal';
 
     public static function getFriendsLeaderboardKey(int $userId): string {

--- a/app/Http/Controllers/API/v1/HealthMonitorController.php
+++ b/app/Http/Controllers/API/v1/HealthMonitorController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers\API\v1;
+
+use App\Enum\CacheKey;
+use App\Http\Controllers\HafasController;
+use Illuminate\Database\QueryException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Queue;
+
+class HealthMonitorController
+{
+
+    public function healthReady(): JsonResponse {
+        $checks = [
+            "database_reachable" => $this->isDatabaseReachable()
+        ];
+
+        return response()
+            ->json($checks)
+            ->setStatusCode(array_product($checks) ? 200 : 500);
+    }
+
+    public function healthFitness(): JsonResponse {
+        $checks = [
+            "database_reachable" => $this->isDatabaseReachable(),
+            "queue_running"      => $this->isQueueRunning(),
+            "db_rest_reachable"  => $this->isDbRestReachable(),
+            "scheduler_running"  => $this->isSchedulerRunning(),
+        ];
+
+        return response()
+            ->json($checks)
+            ->setStatusCode(array_product($checks) ? 200 : 500);
+    }
+
+    private function isDatabaseReachable(): bool {
+        try {
+            DB::connection()->getPdo();
+            return true;
+        } catch (QueryException $e) {
+            Log::info("Health Monitor ran into Query exception. Is the database not available?");
+            return false;
+        }
+    }
+
+    private function isQueueRunning(): bool {
+        $size = Queue::size();
+        return $size < 10;
+    }
+
+    private function isDbRestReachable(): bool {
+        $response = HafasController::getHttpClient()
+                                   ->get("/stations/8000105");
+        return $response->successful();
+    }
+
+    private function isSchedulerRunning(): bool {
+        $lastScheduler = Cache::get(CacheKey::SchedulerCanary, 0);
+        return time() - $lastScheduler < 60;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,7 @@
 use App\Http\Controllers\API\v1\AuthController as v1Auth;
 use App\Http\Controllers\API\v1\EventController;
 use App\Http\Controllers\API\v1\FollowController;
+use App\Http\Controllers\API\v1\HealthMonitorController;
 use App\Http\Controllers\API\v1\IcsController;
 use App\Http\Controllers\API\v1\LikesController;
 use App\Http\Controllers\API\v1\NotificationsController;
@@ -42,6 +43,11 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
 
     Route::get('static/privacy', [PrivacyPolicyController::class, 'getPrivacyPolicy'])
          ->name('api.v1.getPrivacyPolicy');
+
+    Route::get("/health/ready", [HealthMonitorController::class, 'healthReady'])
+         ->name("api.health.ready");
+    Route::get("/health/fitness", [HealthMonitorController::class, 'healthFitness'])
+         ->name("api.health.fitness");
 
     Route::group(['middleware' => ['auth:api', 'privacy-policy']], static function() {
         Route::post('event', [EventController::class, 'suggest'])->middleware(['scope:write-event-suggestions']);

--- a/tests/Feature/APIv1/HealthMonitorTest.php
+++ b/tests/Feature/APIv1/HealthMonitorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature\APIv1;
+
+use App\Console\Commands\SchedulerCanary;
+use App\Enum\CacheKey;
+use Illuminate\Cache\CacheManager;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue as Queue;
+use Mockery;
+use Tests\TestCase;
+
+class HealthMonitorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void {
+        parent::setUp();
+
+        Http::preventStrayRequests();
+        Http::fake([
+                       '/stations*' => Http::response([self::FRANKFURT_HBF]),
+                   ]);
+
+        $this->app->bind('cache', fn($app) => new CacheManager($app));
+        $this->app->bind('cache.store', fn($app) => $app['cache']->store('array'));
+
+        (new SchedulerCanary())->handle();
+    }
+
+    public function tearDown(): void {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function testBothRoutesReturn200OnTestingSetup(): void {
+        $this->get(route("api.health.ready"))
+             ->assertStatus(200)
+             ->assertJson([
+                              "database_reachable" => true
+                          ]);
+
+        $this->get(route("api.health.fitness"))
+             ->assertStatus(200)
+             ->assertJson([
+                              "database_reachable" => true,
+                              "queue_running"      => true,
+                              "db_rest_reachable"  => true,
+                              "scheduler_running"  => true,
+                          ]);
+    }
+
+    public function testBothRoutesReturn500IfDatabaseIsntReachable(): void {
+        DB::shouldReceive("connection")
+          ->once()
+          ->andThrow(new QueryException("default",
+                                        "TEST QUERY",
+                                        [],
+                                        new \Exception("mock exception")));
+
+        $this->get(route("api.health.ready"))
+             ->assertStatus(500)
+             ->assertJson(["database_reachable" => false]);
+    }
+
+    public function testFitnessRouteReturns500IfQueueIsClogged(): void {
+        Queue::fake();
+        Queue::shouldReceive('size')->andReturn(11);
+
+        $this->get(route("api.health.fitness"))
+             ->assertStatus(500)
+             ->assertJson(["queue_running" => false]);
+    }
+
+    public function testFitnessRouteReturns500IfDbRestIsntReachable(): void {
+        self::clearExistingHttpFakes();
+        Http::fake([
+                       '/stations*' => Http::response([self::FRANKFURT_HBF], 500),
+                   ]);
+
+        $this->get(route("api.health.fitness"))
+             ->assertStatus(500)
+             ->assertJson(["db_rest_reachable" => false]);
+    }
+
+    public function testFitnessRouteReturns500IfSchedulerHasNotRunInALongTime(): void {
+        Cache::store("array")
+             ->put(CacheKey::SchedulerCanary, time() - 600);
+
+        $this->get(route("api.health.fitness"))
+             ->assertStatus(500)
+             ->assertJson(["scheduler_running" => false]);
+    }
+
+    public function testFitnessRouteReturns500IfSchedulerHasNeverRun(): void {
+        Cache::store("array")
+             ->forget(CacheKey::SchedulerCanary);
+
+        $this->get(route("api.health.fitness"))
+             ->assertStatus(500)
+             ->assertJson(["scheduler_running" => false]);
+    }
+
+    private static function clearExistingHttpFakes(): void {
+        $reflection = new \ReflectionObject(Http::getFacadeRoot());
+        $property   = $reflection->getProperty('stubCallbacks');
+        $property->setValue(Http::getFacadeRoot(), collect());
+    }
+}


### PR DESCRIPTION
This PR introduces two health routes. The readiness probe (`/api/v1/health/ready`) checks if the database connection is available, and implicitly checks if the Laravel app is booted.
The second probe (`/api/v1/health/fitness`) does an more indepth check into the state of the application. It will:
* **check the database connection**
* **queue clog**. Basically: Are there suspiciously many jobs in the queue which makes us think that the queue process isn't working? From my understanding, each check-in spawns at least three jobs, plus webhooks, so I've put the threshhold to 9 Jobs waiting in the queue.
*  **db rest availability**. Does a real call to db-rest, just like the application would. This will break once FF/8000105 is removed for some reasons.
* **scheduler is up**. The PR sets up a `scheduler-canary` command which will set a cache value to the current `time()` once per minute. In the health route, it is checked when the canary the last time.


Currently missing:

- [ ] Update the `Dockerfile` to contain the `HEALTHCHECK` statement.
- [ ] Add an authentication to the route. _Debatable_, on the one hand, the routes reveal information over the instance which are potentially exploitable, on the other hand, apps may use the information and share it with their users. _Please discuss._
- [ ] If we decide to make the route public, we should also update our API documentation accordingly.
- [ ] After merge and rollout: Use the route in the status page and our internal monitoring. We can discuss this privately.