### PR TITLE
:arrow_up: Upgrade from Node 19 (EOL) to Node 20 in CI

### DIFF
--- a/.github/workflows/nodejs-audit.yml
+++ b/.github/workflows/nodejs-audit.yml
@@ -9,16 +9,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 19.x ]
+        node-version: [ 20.x ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Check for vulnerabilities
         run: npm audit
-
-        env:
-          CI: true

--- a/.github/workflows/nodejs-prod.yml
+++ b/.github/workflows/nodejs-prod.yml
@@ -9,18 +9,15 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 18.x, 19.x ]
+        node-version: [ 18.x, 20.x ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Run production build
         run: npm run build
-
-        env:
-          CI: true


### PR DESCRIPTION
- Upgrades from Node 19 which reached [End of Life](https://endoflife.date/nodejs) to Node 20
- Upgrades actions versions
- Removes the `CI` env because thats set by default by github
- Uses `npm ci` instead of `npm install` in ci to use exact lockfile versions