### PR TITLE
✨ Add endpoint to fetch tags for multiple statuses

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -165,6 +165,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
             Route::get('status/{id}', [StatusController::class, 'show']);
             Route::get('status/{id}/likes', [LikesController::class, 'show']);
             Route::get('status/{statusId}/tags', [StatusTagController::class, 'index']);
+            Route::get('statuses/{statusIds}/tags', [StatusTagController::class, 'indexForMultiple']);
             Route::get('stopovers/{parameters}', [StatusController::class, 'getStopovers']);
             Route::get('polyline/{parameters}', [StatusController::class, 'getPolyline']);
             Route::get('event/{slug}', [EventController::class, 'show']);

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -2753,6 +2753,78 @@
                 ]
             }
         },
+        "/statuses/{statusIds}/tags": {
+            "get": {
+                "tags": [
+                    "Status"
+                ],
+                "summary": "Show all tags for multiple statuses which are visible for the current user",
+                "description": "Returns a collection of all visible tags for the given statuses, if user is authorized",
+                "operationId": "getTagsForMultipleStatuses",
+                "parameters": [
+                    {
+                        "name": "statusIds",
+                        "in": "path",
+                        "description": "Status-ID",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "1337,4711"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "1337": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/StatusTag"
+                                                    }
+                                                },
+                                                "4711": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/StatusTag"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "No status found for this id"
+                    },
+                    "403": {
+                        "description": "User not authorized to access this status"
+                    }
+                },
+                "security": [
+                    {
+                        "passport": []
+                    },
+                    {
+                        "token": []
+                    }
+                ]
+            }
+        },
         "/status/{statusId}/tags/{tagKey}": {
             "put": {
                 "tags": [
@@ -5881,7 +5953,7 @@
             },
             "token": {
                 "type": "apiKey",
-                "description": "Enter token in format \"Bearer \\<token\\>\"",
+                "description": "Enter token in format \"Bearer \\<token\\>\". You can create your personal access token at https://traewelling.de/settings/applications. We recommend this method for prototyping purposes. For all other use cases please use the oAuth method above.",
                 "name": "Authorization",
                 "in": "header"
             }


### PR DESCRIPTION
Fixes #1943.

Diskussion: Should we opt for this as the default behavior of GET [/status/{statusId}/tags](https://traewelling.de/api/documentation#/Status/getTagsForStatus)? Should we remove the old endpoint as deprecated? Should we keep both?