### PR TITLE
:bug: Add display_timezone to config for better timezone handling

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -6,9 +6,12 @@ use Illuminate\Support\Carbon;
  * @see https://stackoverflow.com/a/437642
  */
 function number($number, $decimals = 2) {
-    return number_format($number, $decimals,
-                         __('dates.decimal_point'),
-                         __('dates.thousands_sep'));
+    return number_format(
+        $number,
+        $decimals,
+        __('dates.decimal_point'),
+        __('dates.thousands_sep')
+    );
 }
 
 /**
@@ -43,13 +46,13 @@ function durationToSpan($duration): string {
     return $return;
 }
 
-function userTime(null|Carbon|\Carbon\Carbon|string $time=null, ?string $format=null, bool $iso=true): string {
+function userTime(null|Carbon|\Carbon\Carbon|string $time = null, ?string $format = null, bool $iso = true): string {
     if ($time === null) {
         return '';
     }
     $format   = $format ?? __('time-format');
     $time     = $time instanceof \Carbon\Carbon ? $time : Carbon::parse($time);
-    $timezone = auth()->user()->timezone ?? config('app.timezone');
+    $timezone = auth()->user()->timezone ?? config('app.display_timezone');
     if ($iso) {
         return $time->tz($timezone)->isoFormat($format);
     }

--- a/config/app.php
+++ b/config/app.php
@@ -71,6 +71,9 @@ return [
 
     'timezone' => 'UTC',
 
+    // This timezone will be used for displaying time in the frontend, when not logged in.
+    'display_timezone' => 'Europe/Berlin',
+
     /*
     |--------------------------------------------------------------------------
     | Application Locale Configuration

--- a/config/app.php
+++ b/config/app.php
@@ -72,7 +72,7 @@ return [
     'timezone' => 'UTC',
 
     // This timezone will be used for displaying time in the frontend, when not logged in.
-    'display_timezone' => 'Europe/Berlin',
+    'display_timezone' => env('DISPLAY_TIMEZONE', 'Europe/Berlin'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Related to #1834.

This will set the default display timezone to Europe/Berlin. This is the timezone with our biggest user base, so this is the best compromise for now.

