### PR TITLE
:ambulance: add timeout for most interactions with mastodon servers

### DIFF
--- a/app/Http/Controllers/Backend/Social/MastodonController.php
+++ b/app/Http/Controllers/Backend/Social/MastodonController.php
@@ -12,6 +12,7 @@ use App\Notifications\MastodonNotSent;
 use Error;
 use Exception;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Facades\Log;
 use Laravel\Socialite\Contracts\User as SocialiteUser;
 use Revolution\Mastodon\Facades\Mastodon;
@@ -182,7 +183,7 @@ abstract class MastodonController extends Controller
         $client = self::getClient($user);
 
         try {
-            $context = $client->get('/statuses/' . $mastodonPostId . '/context');
+            $context = $client->call("GET", "/statuses/{$mastodonPostId}/context", options: self::getRequestOptions());
         } catch (GuzzleException $e) {
             Log::info("Unable to chain toot because of an issue with the connecting mastodon server.");
             if ($e->getCode() == 404) {
@@ -227,5 +228,8 @@ abstract class MastodonController extends Controller
             ->whereNotNull('mastodon_post_id')
             ->latest()
             ->first();
+    }
+    public static function getRequestOptions(): array {
+        return [RequestOptions::TIMEOUT => config("trwl.mastodon_timeout_seconds")];
     }
 }

--- a/config/trwl.php
+++ b/config/trwl.php
@@ -1,25 +1,26 @@
 <?php
 
 return [
-    'post_social'           => env('POST_SOCIAL', false),
+    'post_social'              => env('POST_SOCIAL', false),
 
     # Mastodon
-    'mastodon_domain'       => env('MASTODON_DOMAIN'),
-    'mastodon_id'           => env('MASTODON_ID'),
-    'mastodon_secret'       => env('MASTODON_SECRET'),
-    'mastodon_redirect'     => env('MASTODON_REDIRECT'),
-    'mastodon_appname'      => env('MASTODON_APPNAME'),
+    'mastodon_domain'          => env('MASTODON_DOMAIN'),
+    'mastodon_id'              => env('MASTODON_ID'),
+    'mastodon_secret'          => env('MASTODON_SECRET'),
+    'mastodon_redirect'        => env('MASTODON_REDIRECT'),
+    'mastodon_appname'         => env('MASTODON_APPNAME'),
+    'mastodon_timeout_seconds' => env("MASTODON_TIMEOUT_SECONDS", 5),
 
     # Brouter
-    'brouter_url'           => env('BROUTER_URL', 'https://brouter.de/'),
-    'brouter_timeout'       => env('BROUTER_TIMEOUT', 10),
+    'brouter_url'              => env('BROUTER_URL', 'https://brouter.de/'),
+    'brouter_timeout'          => env('BROUTER_TIMEOUT', 10),
 
     # DB_REST
-    'db_rest'               => env('DB_REST', 'https://v5.db.transport.rest/'),
-    'db_rest_timeout'       => env('DB_REST_TIMEOUT', 10),
+    'db_rest'                  => env('DB_REST', 'https://v5.db.transport.rest/'),
+    'db_rest_timeout'          => env('DB_REST_TIMEOUT', 10),
 
     # Points
-    'base_points'           => [
+    'base_points'              => [
         'time_window' => [
             # time windows before and after a journey to get points
             'good_enough' => [
@@ -44,13 +45,13 @@ return [
             'nationalExpress' => env('BASE_POINTS_TRAIN_NATIONALEXPRESS', 10),
         ]
     ],
-    'refresh'               => [
+    'refresh'                  => [
         'max_trips_per_minute' => env('REFRESH_TRIPS_PER_MINUTE', 1)
     ],
-    'cache'                 => [
+    'cache'                    => [
         'global-statistics-retention-seconds' => env('GLOBAL_STATISTICS_CACHE_RETENTION_SECONDS', 60 * 60),
         'leaderboard-retention-seconds'       => env('LEADERBOARD_CACHE_RETENTION_SECONDS', 5 * 60)
     ],
-    'year_in_review_active' => env('YEAR_IN_REVIEW_ACTIVE', false),
-    'webhooks_active'       => env('WEBHOOKS_ACTIVE', false),
+    'year_in_review_active'    => env('YEAR_IN_REVIEW_ACTIVE', false),
+    'webhooks_active'          => env('WEBHOOKS_ACTIVE', false),
 ];

--- a/tests/Feature/Social/MastodonControllerTest.php
+++ b/tests/Feature/Social/MastodonControllerTest.php
@@ -59,9 +59,9 @@ class MastodonControllerTest extends TestCase
          * - end.
          */
 
-        Mastodon::shouldReceive('get')
+        Mastodon::shouldReceive('call')
                 ->once()
-                ->with(self::OP_CONTEXT_URL)
+                ->with("GET", self::OP_CONTEXT_URL, MastodonController::getRequestOptions())
                 ->andReturn(["descendants" => []]);
 
         $this->assertEquals(self::TOOTID_OP, MastodonController::getEndOfChain($user, self::TOOTID_OP));
@@ -75,9 +75,9 @@ class MastodonControllerTest extends TestCase
          * - toodid-answer from userid-answer
          */
 
-        Mastodon::shouldReceive('get')
+        Mastodon::shouldReceive('call')
                 ->once()
-                ->with(self::OP_CONTEXT_URL)
+                ->with("GET", self::OP_CONTEXT_URL, MastodonController::getRequestOptions())
                 ->andReturn(
                     [
                         "descendants" => [
@@ -105,9 +105,9 @@ class MastodonControllerTest extends TestCase
          *   - tootid-answer2 from userid-op
          */
 
-        Mastodon::shouldReceive('get')
+        Mastodon::shouldReceive('call')
                 ->once()
-                ->with(self::OP_CONTEXT_URL)
+                ->with("GET", self::OP_CONTEXT_URL, MastodonController::getRequestOptions())
                 ->andReturn(
                     [
                         "descendants" => [
@@ -142,9 +142,9 @@ class MastodonControllerTest extends TestCase
          * - tootid-answer from userid-op <== THIS ONE
          */
 
-        Mastodon::shouldReceive('get')
+        Mastodon::shouldReceive('call')
                 ->once()
-                ->with(self::OP_CONTEXT_URL)
+                ->with("GET", self::OP_CONTEXT_URL, MastodonController::getRequestOptions())
                 ->andReturn(
                     [
                         "descendants" => [
@@ -171,9 +171,9 @@ class MastodonControllerTest extends TestCase
          * - tootid-answer from userid-op with mention of userid-bob <== THIS ONE
          */
 
-        Mastodon::shouldReceive('get')
+        Mastodon::shouldReceive('call')
                 ->once()
-                ->with(self::OP_CONTEXT_URL)
+                ->with("GET", self::OP_CONTEXT_URL, MastodonController::getRequestOptions())
                 ->andReturn(
                     [
                         "descendants" => [
@@ -200,9 +200,9 @@ class MastodonControllerTest extends TestCase
          * - tootid-answer from userid-op with mention of userid-bob which is a DM
          */
 
-        Mastodon::shouldReceive('get')
+        Mastodon::shouldReceive('call')
                 ->once()
-                ->with(self::OP_CONTEXT_URL)
+                ->with("GET", self::OP_CONTEXT_URL, MastodonController::getRequestOptions())
                 ->andReturn(
                     [
                         "descendants" => [
@@ -230,9 +230,9 @@ class MastodonControllerTest extends TestCase
          *   - tootid-answer2 from userid-op <== THIS ONE
          */
 
-        Mastodon::shouldReceive('get')
+        Mastodon::shouldReceive('call')
                 ->once()
-                ->with(self::OP_CONTEXT_URL)
+                ->with("GET", self::OP_CONTEXT_URL, MastodonController::getRequestOptions())
                 ->andReturn(
                     [
                         "descendants" => [
@@ -271,9 +271,9 @@ class MastodonControllerTest extends TestCase
          *   - tootid-answer3 from userid-answer
          */
 
-        Mastodon::shouldReceive('get')
+        Mastodon::shouldReceive('call')
                 ->once()
-                ->with(self::OP_CONTEXT_URL)
+                ->with("GET", self::OP_CONTEXT_URL, MastodonController::getRequestOptions())
                 ->andReturn(
                     [
                         "descendants" => [
@@ -319,9 +319,9 @@ class MastodonControllerTest extends TestCase
          * Original post is deleted.
          */
 
-        Mastodon::shouldReceive('get')
+        Mastodon::shouldReceive('call')
                 ->once()
-                ->with(self::OP_CONTEXT_URL)
+                ->with("GET", self::OP_CONTEXT_URL, MastodonController::getRequestOptions())
                 ->andThrowExceptions([new ClientException(
                                           '{"error":"Record not found"}',
                                           new Request('GET', self::OP_CONTEXT_URL),
@@ -340,9 +340,9 @@ class MastodonControllerTest extends TestCase
          * Original post is deleted.
          */
 
-        Mastodon::shouldReceive('get')
+        Mastodon::shouldReceive('call')
                 ->once()
-                ->with(self::OP_CONTEXT_URL)
+                ->with("GET", self::OP_CONTEXT_URL, MastodonController::getRequestOptions())
                 ->andThrowExceptions([new ConnectException("server not available",
                                                            new Request('GET', self::OP_CONTEXT_URL)
                                       )]);


### PR DESCRIPTION
This should cover most of the issues with bad-performing or offline mastodon servers by setting a timeout.

In a bad situation, it means that the mastodon-link in the profiles isn't there for an hour.