### PR TITLE
🐛 Migration fails on large datasets

### DIFF
--- a/database/migrations/2023_09_23_162754_add-parent-to-polylines.php
+++ b/database/migrations/2023_09_23_162754_add-parent-to-polylines.php
@@ -3,27 +3,34 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 return new class extends Migration
 {
     public function up(): void {
-        if (!Schema::hasColumn('poly_lines', 'parent_id') {
-            Schema::table('poly_lines', function(Blueprint $table) {
+        if (!Schema::hasColumn('poly_lines', 'parent_id')) {
+            Schema::table('poly_lines', function (Blueprint $table) {
                 $table->unsignedBigInteger('parent_id')->nullable()->after('id');
                 $table->foreign('parent_id')->references('id')->on('poly_lines');
             });
+        } else {
+            $output = new ConsoleOutput();
+            $output->writeln("\nColumn already exists. Skipping.");
         }
     }
 
     public function down(): void {
         try {
-            Schema::table('poly_lines', function(Blueprint $table) {
+            Schema::table('poly_lines', function (Blueprint $table) {
                 $table->dropForeign(['parent_id']);
                 $table->dropColumn('parent_id');
             });
-        } catch(\Throwable) {
-            Schema::table('poly_lines, function(Blueprint $table) {
-                $table->dropColumn('parent_id);
+        } catch (\Throwable) {
+            $output = new ConsoleOutput();
+            $output->writeln("\nForeign key didn't exist. Dropping only column.");
+
+            Schema::table('poly_lines', function (Blueprint $table) {
+                $table->dropColumn('parent_id');
             });
         }
     }

--- a/database/migrations/2023_09_23_162754_add-parent-to-polylines.php
+++ b/database/migrations/2023_09_23_162754_add-parent-to-polylines.php
@@ -7,16 +7,24 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration
 {
     public function up(): void {
-        Schema::table('poly_lines', function(Blueprint $table) {
-            $table->unsignedBigInteger('parent_id')->nullable()->after('id');
-            $table->foreign('parent_id')->references('id')->on('poly_lines');
-        });
+        if (!Schema::hasColumn('poly_lines', 'parent_id') {
+            Schema::table('poly_lines', function(Blueprint $table) {
+                $table->unsignedBigInteger('parent_id')->nullable()->after('id');
+                $table->foreign('parent_id')->references('id')->on('poly_lines');
+            });
+        }
     }
 
     public function down(): void {
-        Schema::table('poly_lines', function(Blueprint $table) {
-            $table->dropForeign(['parent_id']);
-            $table->dropColumn('parent_id');
-        });
+        try {
+            Schema::table('poly_lines', function(Blueprint $table) {
+                $table->dropForeign(['parent_id']);
+                $table->dropColumn('parent_id');
+            });
+        } catch(\Throwable) {
+            Schema::table('poly_lines, function(Blueprint $table) {
+                $table->dropColumn('parent_id);
+            });
+        }
     }
 };


### PR DESCRIPTION
Since this migration likely times out with a large dataset, there has to be a fallback so that it will not break in the next migration run.

The Column will most likely be created, but the foreign key might not. The only practical approach in Laravel to check if a foreign key exists is, to just catch the exception if the migration fails to drop a non existing foreign