### PR TITLE
🩺🐛 Fix job queue counts

### DIFF
--- a/.idea/trwl.iml
+++ b/.idea/trwl.iml
@@ -178,6 +178,8 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/zircote/swagger-php" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/promphp/prometheus_client_php" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/spatie/laravel-prometheus" />
+      <excludePattern pattern=".devenv/*" />
+      <excludePattern pattern=".direnv/*" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/app/Providers/PrometheusServiceProvider.php
+++ b/app/Providers/PrometheusServiceProvider.php
@@ -97,12 +97,17 @@ class PrometheusServiceProvider extends ServiceProvider
     }
 
 
-    private function getJobsByDisplayName($table_name): array {
-        return DB::table($table_name)
-                 ->get("payload")
-                 ->map(fn($row) => json_decode($row->payload))
-                 ->countBy(fn($payload) => $payload->displayName)
-                 ->mapWithKeys(fn($total, $key) => [$total, [$key]])
-                 ->toArray();
+    public static function getJobsByDisplayName($table_name): array {
+        $counts = DB::table($table_name)
+                    ->get("payload")
+                    ->map(fn($row) => json_decode($row->payload))
+                    ->countBy(fn($payload) => $payload->displayName)
+                    ->toArray();
+
+        return array_map(
+            fn($jobname, $count) => [$count, [$jobname]],
+            array_keys($counts),
+            array_values($counts)
+        );
     }
 }

--- a/tests/Unit/Providers/PrometheusServiceProviderTest.php
+++ b/tests/Unit/Providers/PrometheusServiceProviderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\Providers;
+
+use App\Providers\PrometheusServiceProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Tests\ApiTestCase;
+use function PHPUnit\Framework\assertEquals;
+
+class PrometheusServiceProviderTest extends ApiTestCase
+{
+    use RefreshDatabase;
+
+    const TABLENAME = "jobs";
+
+    public function testGetJobsByDisplayName() {
+        // GIVEN
+        DB::shouldReceive('table')
+          ->with(self::TABLENAME)
+          ->once()
+          ->andReturnSelf();
+
+        DB::shouldReceive("get")
+          ->with("payload")
+          ->andReturn(
+              Collection::make(
+                  array_merge([
+                                  ...array_fill(0, 4, (object) ["payload" => json_encode(["displayName" => "JobA"])]),
+                                  ...array_fill(0, 7, (object) ["payload" => json_encode(["displayName" => "JobB"])]),
+                                  ...array_fill(0, 2, (object) ["payload" => json_encode(["displayName" => "JobC"])]),
+                              ])));
+
+        $actual = PrometheusServiceProvider::getJobsByDisplayName(self::TABLENAME);
+
+        assertEquals([
+                         [4, ["JobA"]],
+                         [7, ["JobB"]],
+                         [2, ["JobC"]]
+                     ], $actual);
+    }
+}


### PR DESCRIPTION
Previously, only the last job was shown with its count, due to unproper use of `mapWithKeys` on my end.
