### PR TITLE
:bug: Always use the manual times if given; Use the time-is-real tooltip even if punctual

### DIFF
--- a/app/Enum/TimeType.php
+++ b/app/Enum/TimeType.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Enum;
+
+enum TimeType: int
+{
+    case PLANNED = 0;
+    case REALTIME = 1;
+    case MANUAL = 9;
+
+    private function getTooltipStringId($timeType): string {
+        return match ($timeType) {
+            self::PLANNED  => 'time-is-planned',
+            self::REALTIME => 'time-is-real',
+            self::MANUAL  => 'time-is-manual'
+        };
+    }
+
+    public function getTooltip(): string {
+        return __(self::getTooltipStringId($this));
+    }
+}

--- a/resources/views/includes/status.blade.php
+++ b/resources/views/includes/status.blade.php
@@ -41,27 +41,30 @@
                 <li>
                     <i class="trwl-bulletpoint" aria-hidden="true"></i>
                     <span class="text-trwl float-end">
-                        @if(isset($status->trainCheckin->manual_departure) && $status->trainCheckin->manual_departure->toString() !== $status->trainCheckin->origin_stopover->departure_planned->toString())
-                        <small style="text-decoration: line-through;" class="text-muted">
-                                {{ userTime($status->trainCheckin->origin_stopover->departure_planned) }}
-                            </small>
-                            &nbsp;
-                            <span data-mdb-toggle="tooltip" title="{{__('time-is-manual')}}">
-                                {{ userTime($status->trainCheckin->manual_departure) }}
-                            </span>
-                        @elseif($status->trainCheckin?->origin_stopover?->isDepartureDelayed)
+                        @php
+                            $original_departure = $status->trainCheckin->origin_stopover?->departure_planned
+                                ?? $status->trainCheckin?->origin_stopover?->departure
+                                ?? $status->trainCheckin->departure;
+                            if (isset($status->trainCheckin->manual_departure)):
+                                $updated_departure = $status->trainCheckin->manual_departure;
+                                $tooltip_departure = 'time-is-manual';
+                            elseif (isset($status->trainCheckin->origin_stopover->departure_real)):
+                                $updated_departure = $status->trainCheckin->origin_stopover->departure_real;
+                                $tooltip_departure = 'time-is-real';
+                            else:
+                                $updated_departure = $original_departure;
+                                $tooltip_departure = 'time-is-planned';
+                            endif;
+                        @endphp
+                        @if($original_departure->toString() !== $updated_departure->toString())
                             <small style="text-decoration: line-through;" class="text-muted">
-                                {{ userTime($status->trainCheckin->origin_stopover->departure_planned) }}
+                                {{ userTime($original_departure) }}
                             </small>
                             &nbsp;
-                            <span data-mdb-toggle="tooltip" title="{{__('time-is-real')}}">
-                                {{ userTime($status->trainCheckin->origin_stopover->departure_real) }}
-                            </span>
-                        @else
-                            <span data-mdb-toggle="tooltip" title="{{__('time-is-planned')}}">
-                                {{ userTime($status->trainCheckin?->origin_stopover?->departure ?? $status->trainCheckin->departure) }}
-                            </span>
                         @endif
+                        <span data-mdb-toggle="tooltip" title="{{__($tooltip_departure)}}">
+                            {{ userTime($updated_departure) }}
+                        </span>
                     </span>
 
                     <a href="{{route('trains.stationboard', ['provider' => 'train', 'station' => $status->trainCheckin->originStation->ibnr])}}"
@@ -142,27 +145,30 @@
                 <li>
                     <i class="trwl-bulletpoint" aria-hidden="true"></i>
                     <span class="text-trwl float-end">
-                        @if(isset($status->trainCheckin->manual_arrival) && $status->trainCheckin->manual_arrival->toString() !== $status->trainCheckin->destination_stopover->arrival_planned->toString())
+                        @php
+                            $original_arrival = $status->trainCheckin->destination_stopover?->arrival_planned
+                                ?? $status->trainCheckin?->destination_stopover?->arrival
+                                ?? $status->trainCheckin->arrival;
+                            if (isset($status->trainCheckin->manual_arrival)):
+                                $updated_arrival = $status->trainCheckin->manual_arrival;
+                                $tooltip_arrival = 'time-is-manual';
+                            elseif (isset($status->trainCheckin->destination_stopover->arrival_real)):
+                                $updated_arrival = $status->trainCheckin->destination_stopover->arrival_real;
+                                $tooltip_arrival = 'time-is-real';
+                            else:
+                                $updated_arrival = $original_arrival;
+                                $tooltip_arrival = 'time-is-planned';
+                            endif;
+                        @endphp
+                        @if($original_arrival->toString() !== $updated_arrival->toString())
                             <small style="text-decoration: line-through;" class="text-muted">
-                                {{ userTime($status->trainCheckin->destination_stopover->arrival_planned) }}
+                                {{ userTime($original_arrival) }}
                             </small>
                             &nbsp;
-                            <span data-mdb-toggle="tooltip" title="{{__('time-is-manual')}}">
-                                {{ userTime($status->trainCheckin->manual_arrival) }}
-                            </span>
-                        @elseif($status->trainCheckin?->destination_stopover?->isArrivalDelayed && !isset($status->trainCheckin->manual_arrival))
-                            <small style="text-decoration: line-through;" class="text-muted">
-                                {{ userTime($status->trainCheckin->destination_stopover->arrival_planned) }}
-                            </small>
-                            &nbsp;
-                            <span data-mdb-toggle="tooltip" title="{{__('time-is-real')}}">
-                                {{ userTime($status->trainCheckin->destination_stopover->arrival_real) }}
-                            </span>
-                        @else
-                            <span data-mdb-toggle="tooltip" title="{{__('time-is-planned')}}">
-                                {{ userTime($status->trainCheckin?->destination_stopover?->arrival ?? $status->trainCheckin->arrival) }}
-                            </span>
                         @endif
+                        <span data-mdb-toggle="tooltip" title="{{__($tooltip_arrival)}}">
+                            {{ userTime($updated_arrival) }}
+                        </span>
                     </span>
                     <a href="{{route('trains.stationboard', ['provider' => 'train', 'station' => $status->trainCheckin->destinationStation->ibnr])}}"
                        class="text-trwl clearfix">

--- a/resources/views/includes/status.blade.php
+++ b/resources/views/includes/status.blade.php
@@ -42,28 +42,16 @@
                     <i class="trwl-bulletpoint" aria-hidden="true"></i>
                     <span class="text-trwl float-end">
                         @php
-                            $original_departure = $status->trainCheckin->origin_stopover?->departure_planned
-                                ?? $status->trainCheckin?->origin_stopover?->departure
-                                ?? $status->trainCheckin->departure;
-                            if (isset($status->trainCheckin->manual_departure)):
-                                $updated_departure = $status->trainCheckin->manual_departure;
-                                $tooltip_departure = 'time-is-manual';
-                            elseif (isset($status->trainCheckin->origin_stopover->departure_real)):
-                                $updated_departure = $status->trainCheckin->origin_stopover->departure_real;
-                                $tooltip_departure = 'time-is-real';
-                            else:
-                                $updated_departure = $original_departure;
-                                $tooltip_departure = 'time-is-planned';
-                            endif;
+                            $display_departure = $status->trainCheckin->displayDeparture;
                         @endphp
-                        @if($original_departure->toString() !== $updated_departure->toString())
+                        @isset($display_departure->original)
                             <small style="text-decoration: line-through;" class="text-muted">
-                                {{ userTime($original_departure) }}
+                                {{ userTime($display_departure->original) }}
                             </small>
                             &nbsp;
-                        @endif
-                        <span data-mdb-toggle="tooltip" title="{{__($tooltip_departure)}}">
-                            {{ userTime($updated_departure) }}
+                        @endisset
+                        <span data-mdb-toggle="tooltip" title="{{$display_departure->type->getTooltip()}}">
+                            {{ userTime($display_departure->time) }}
                         </span>
                     </span>
 
@@ -145,29 +133,15 @@
                 <li>
                     <i class="trwl-bulletpoint" aria-hidden="true"></i>
                     <span class="text-trwl float-end">
-                        @php
-                            $original_arrival = $status->trainCheckin->destination_stopover?->arrival_planned
-                                ?? $status->trainCheckin?->destination_stopover?->arrival
-                                ?? $status->trainCheckin->arrival;
-                            if (isset($status->trainCheckin->manual_arrival)):
-                                $updated_arrival = $status->trainCheckin->manual_arrival;
-                                $tooltip_arrival = 'time-is-manual';
-                            elseif (isset($status->trainCheckin->destination_stopover->arrival_real)):
-                                $updated_arrival = $status->trainCheckin->destination_stopover->arrival_real;
-                                $tooltip_arrival = 'time-is-real';
-                            else:
-                                $updated_arrival = $original_arrival;
-                                $tooltip_arrival = 'time-is-planned';
-                            endif;
-                        @endphp
-                        @if($original_arrival->toString() !== $updated_arrival->toString())
+                        @php($display_arrival = $status->trainCheckin->displayArrival)
+                        @isset($display_arrival->original)
                             <small style="text-decoration: line-through;" class="text-muted">
-                                {{ userTime($original_arrival) }}
+                                {{ userTime($display_arrival->original) }}
                             </small>
                             &nbsp;
-                        @endif
-                        <span data-mdb-toggle="tooltip" title="{{__($tooltip_arrival)}}">
-                            {{ userTime($updated_arrival) }}
+                        @endisset
+                        <span data-mdb-toggle="tooltip" title="{{$display_arrival->type->getTooltip()}}">
+                            {{ userTime($display_arrival->time) }}
                         </span>
                     </span>
                     <a href="{{route('trains.stationboard', ['provider' => 'train', 'station' => $status->trainCheckin->destinationStation->ibnr])}}"

--- a/tests/Feature/Status/TimeTypeTest.php
+++ b/tests/Feature/Status/TimeTypeTest.php
@@ -11,53 +11,80 @@ class TimeTypeTest extends TestCase
 {
     use RefreshDatabase;
 
-    /**
-     * @dataProvider manualTimeProvider
-     */
-    public function testManualTime(bool $targetArrival, ?int $manualDeltaMins, ?bool $shouldHaveOriginal, bool $shouldBeTypeManual) {
-        $checkin       = TrainCheckin::factory()->create();
-
-        if (isset($manualDeltaMins)) {
-            if ($targetArrival) {
-                $edit_time = $checkin->destination_stopover->arrival_planned->copy();
-                $checkin->manual_arrival = $edit_time->addMinutes($manualDeltaMins);
-            } else {
-                $edit_time = $checkin->origin_stopover->departure_planned->copy();
-                $checkin->manual_departure = $edit_time->addMinutes($manualDeltaMins);
-            }
-            $checkin->update();
-        }
-
-        if ($targetArrival) {
-            $display_time = $checkin->displayArrival;
-        } else {
-            $display_time = $checkin->displayDeparture;
-        }
-
-        if (isset($shouldHaveOriginal)) {
-            $this->assertTrue($shouldHaveOriginal === isset($display_time->original));
-        }
-        $this->assertTrue($shouldBeTypeManual === ($display_time->type === TimeType::MANUAL));
+    public static function getTimeTypeFindPreference(): array {
+        return [
+            [false, false, TimeType::PLANNED],
+            [false, true, TimeType::REALTIME],
+            [true, false, TimeType::MANUAL],
+            [true, true, TimeType::MANUAL],
+        ];
     }
 
-    public static function manualTimeProvider() {
-        $testData = [];
-        foreach ([false, true] as $b) {
-            $testData = array_merge($testData, [
-                [
-                    $b, null, null, false
-                ],
-                [
-                    $b, 0, false, true
-                ],
-                [
-                    $b, 2, true, true
-                ],
-                [
-                    $b, -1, true, true
-                ],
-            ]);
+    /**
+     * @dataProvider getTimeTypeFindPreference
+     */
+    public function testTimeTypeFindPreference(bool $manual, bool $delay, TimeType $expected): void {
+        // GIVEN
+        $checkin = TrainCheckin::factory()->create();
+
+        $checkin->origin_stopover->departure_real = null;
+        $checkin->origin_stopover->update();
+
+        // WHEN
+        if ($manual) $this->setManualDeparture($checkin, 8);
+        if ($delay) $this->setDelayedTrainDeparture($checkin, 5);
+
+        // THEN
+        $this->assertEquals($expected, $checkin->displayDeparture->type);
+
+        if ($manual || $delay) {
+            $this->assertNotNull($checkin->displayDeparture->original);
+
         }
-        return $testData;
+    }
+
+    public function testSameManualDeparture(): void {
+        // GIVEN
+        $checkin = TrainCheckin::factory()->create();
+
+        $checkin->origin_stopover->departure_real = null;
+        $checkin->origin_stopover->update();
+
+        // WHEN
+        $this->setManualDeparture($checkin, 0);
+
+        // THEN
+        $this->assertEquals(TimeType::MANUAL, $checkin->displayDeparture->type);
+        $this->assertNull($checkin->displayDeparture->original);
+    }
+
+    public function testSameRealTimeDeparture(): void {
+        // GIVEN
+        $checkin = TrainCheckin::factory()->create();
+
+        $checkin->origin_stopover->departure_real = null;
+        $checkin->origin_stopover->update();
+
+        // WHEN
+        $this->setDelayedTrainDeparture($checkin, 0);
+
+        // THEN
+        $this->assertEquals(TimeType::REALTIME, $checkin->displayDeparture->type);
+        $this->assertNull($checkin->displayDeparture->original);
+    }
+
+    private function setDelayedTrainDeparture($checkin, int $min) {
+        $checkin->origin_stopover->departure_real = $checkin->origin_stopover
+            ->departure_planned
+            ->copy()
+            ->addMinutes($min);
+        $checkin->origin_stopover->update();
+    }
+
+    private function setManualDeparture($checkin, int $min) {
+        $checkin->manual_departure = $checkin->departure
+            ->copy()
+            ->addMinutes($min);
+        $checkin->update();
     }
 }

--- a/tests/Feature/Status/TimeTypeTest.php
+++ b/tests/Feature/Status/TimeTypeTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature\Status;
+
+use App\Enum\TimeType;
+use App\Models\TrainCheckin;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TimeTypeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @dataProvider manualTimeProvider
+     */
+    public function testManualTime(bool $targetArrival, ?int $manualDeltaMins, ?bool $shouldHaveOriginal, bool $shouldBeTypeManual) {
+        $checkin       = TrainCheckin::factory()->create();
+
+        if (isset($manualDeltaMins)) {
+            if ($targetArrival) {
+                $edit_time = $checkin->destination_stopover->arrival_planned->copy();
+                $checkin->manual_arrival = $edit_time->addMinutes($manualDeltaMins);
+            } else {
+                $edit_time = $checkin->origin_stopover->departure_planned->copy();
+                $checkin->manual_departure = $edit_time->addMinutes($manualDeltaMins);
+            }
+            $checkin->update();
+        }
+
+        if ($targetArrival) {
+            $display_time = $checkin->displayArrival;
+        } else {
+            $display_time = $checkin->displayDeparture;
+        }
+
+        if (isset($shouldHaveOriginal)) {
+            $this->assertTrue($shouldHaveOriginal === isset($display_time->original));
+        }
+        $this->assertTrue($shouldBeTypeManual === ($display_time->type === TimeType::MANUAL));
+    }
+
+    public static function manualTimeProvider() {
+        $testData = [];
+        foreach ([false, true] as $b) {
+            $testData = array_merge($testData, [
+                [
+                    $b, null, null, false
+                ],
+                [
+                    $b, 0, false, true
+                ],
+                [
+                    $b, 2, true, true
+                ],
+                [
+                    $b, -1, true, true
+                ],
+            ]);
+        }
+        return $testData;
+    }
+}


### PR DESCRIPTION
The manual time will always get used first, including the according tooltip, no matter whether it by chance matches with the planned time.
This fixes #2068.

This PR changes other behavior as well:
Previously, if there was realtime data, but no delay, the time-is-planned tooltip would be used. With this change, it will be distinguishable whether there is actually no delay according to the real-time data or whether there is no real-time data.

Here are a bunch of example screenshots.

---

A status with real-time data and delay.
<img width="650" alt="rt-delay-no-edit" src="https://github.com/Traewelling/traewelling/assets/9254305/0ebfc4fa-6f1a-4556-86ab-b9f8990136b4">

The departure time has manually been changed to the planned one, and the arrival was changed to a non-planned one (just as an example! When manually changing it to the planned one, it will also correctly use the manual time and tooltip -- previously, it would have used the "planned time" tooltip. The fact that the manual time matches the planned time can be recognized by there not being the stricken-through time).
<img width="650" alt="rt-delay-edit-no-delay" src="https://github.com/Traewelling/traewelling/assets/9254305/74e7d9e5-263c-4809-9566-d450fb5fd5f8">

The manual edits have been cleared:  
same as the first screenshot in this section.

---

A status with real-time data and no delay.
<img width="650" alt="real-time-no-delay" src="https://github.com/Traewelling/traewelling/assets/9254305/36bb8508-b9f1-44ed-8abe-65499032bce0">

The time has manually been changed to the planned one.
<img width="650" alt="real-time-manual-no-delay" src="https://github.com/Traewelling/traewelling/assets/9254305/3736050d-af48-4baa-92b6-cd78b2c7b627">

A delay was added manually.
<img width="650" alt="real-time-manual-delay" src="https://github.com/Traewelling/traewelling/assets/9254305/1d898404-c99c-4b3f-ba00-65bd319d2f46">

The manual edits have been cleared:  
same as the first screenshot in this section.

---

A status without real-time data.
<img width="650" alt="nort" src="https://github.com/Traewelling/traewelling/assets/9254305/5245b61e-2e70-4200-90ce-6b34c3fdfc78">

A delay has manually been added.
<img width="650" alt="nort-manual-delay" src="https://github.com/Traewelling/traewelling/assets/9254305/f9109389-b083-4aa7-96a0-7d3b90418cb8">

The time has manually been changed to the planned one (not cleared).
<img width="650" alt="nort-manual-no-delay" src="https://github.com/Traewelling/traewelling/assets/9254305/34a5ef2c-fb77-4ebb-ae8a-5cfcf8cba811">

The manual edits have been cleared:  
same as the first screenshot in this section.
