### PR TITLE
:bug: Fix leaflet maps

### DIFF
--- a/resources/vue/components/ActiveJourneyMap.vue
+++ b/resources/vue/components/ActiveJourneyMap.vue
@@ -7,8 +7,8 @@
 </template>
 
 <script>
-import 'leaflet'
-import 'Leaflet-MovingMaker/MovingMarker'
+import 'leaflet';
+import('Leaflet-MovingMaker/MovingMarker');
 
 const trainIcon = L.divIcon({
     className: 'custom-div-icon',


### PR DESCRIPTION
Fix #2093.

This fixed `TypeError: L.Marker.movingMarker is not a function` and `L.Marker.MovingMarker is not a constructor` locally. I hope it'll also fix it in production.

For anyone (like me) who wonders why this works: `import "xyz";` and `import(xyz);` is not the same. 
The first one is a static import. This evaluates the code at load time. 
import with regular brackets is a so-called "dynamic import". This evaluates the code as-needed. This is especially needed, since leaflet plugins are mostly scripts and not modules. 

My assumption is, that vite as a bundler evaluates the code once and then "ignores" it or does not "expose" it to the rest of the code. Or it doesn't even evaluate it since it's a script.

Either way: I hope someone with the same problem will stumble upon this and it'll save them some 6-ish hours of unsuccessful googling.

Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import#description