### PR TITLE
🧑‍💻 Add Referencable Exception

### DIFF
--- a/app/Exceptions/AlreadyAcceptedException.php
+++ b/app/Exceptions/AlreadyAcceptedException.php
@@ -6,10 +6,9 @@ use App\Models\PrivacyAgreement;
 use App\Models\User;
 use Exception;
 
-class AlreadyAcceptedException extends Exception
+class AlreadyAcceptedException extends Referencable
 {
     private User $user;
-    private User $initiator;
 
     /**
      * AlreadyFollowingException constructor.

--- a/app/Exceptions/AlreadyFollowingException.php
+++ b/app/Exceptions/AlreadyFollowingException.php
@@ -5,7 +5,7 @@ namespace App\Exceptions;
 use App\Models\User;
 use Exception;
 
-class AlreadyFollowingException extends Exception
+class AlreadyFollowingException extends Referencable
 {
     private User $user;
     private User $initiator;

--- a/app/Exceptions/CheckInCollisionException.php
+++ b/app/Exceptions/CheckInCollisionException.php
@@ -6,7 +6,7 @@ use App\Models\TrainCheckin;
 use Exception;
 use Throwable;
 
-class CheckInCollisionException extends Exception
+class CheckInCollisionException extends Referencable
 {
     private $trainCheckIn;
 

--- a/app/Exceptions/DataOverflowException.php
+++ b/app/Exceptions/DataOverflowException.php
@@ -4,7 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 
-class DataOverflowException extends Exception
+class DataOverflowException extends Referencable
 {
     //
 }

--- a/app/Exceptions/DistanceDeviationException.php
+++ b/app/Exceptions/DistanceDeviationException.php
@@ -4,7 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 
-class DistanceDeviationException extends Exception
+class DistanceDeviationException extends Referencable
 {
     //
 }

--- a/app/Exceptions/HafasException.php
+++ b/app/Exceptions/HafasException.php
@@ -4,7 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 
-class HafasException extends Exception
+class HafasException extends Referencable
 {
     //
 }

--- a/app/Exceptions/NotConnectedException.php
+++ b/app/Exceptions/NotConnectedException.php
@@ -4,7 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 
-class NotConnectedException extends Exception
+class NotConnectedException extends Referencable
 {
     //
 }

--- a/app/Exceptions/PermissionException.php
+++ b/app/Exceptions/PermissionException.php
@@ -4,7 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 
-class PermissionException extends Exception
+class PermissionException extends Referencable
 {
     //
 }

--- a/app/Exceptions/RateLimitExceededException.php
+++ b/app/Exceptions/RateLimitExceededException.php
@@ -4,7 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 
-class RateLimitExceededException extends Exception
+class RateLimitExceededException extends Referencable
 {
     //
 }

--- a/app/Exceptions/Referencable.php
+++ b/app/Exceptions/Referencable.php
@@ -4,7 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 
-abstract class Referencable extends Exception
+class Referencable extends Exception
 {
     public readonly string $reference;
     protected array $context = [];

--- a/app/Exceptions/Referencable.php
+++ b/app/Exceptions/Referencable.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+abstract class Referencable extends Exception
+{
+    public readonly string $reference;
+    protected array $context = [];
+
+    public function __construct(string $message = "", string $reference = null)
+    {
+        $this->reference = $reference ?? uniqid();
+        parent::__construct($message);
+    }
+
+    public function reference(): string {
+        return $this->reference;
+    }
+
+    public function context(): array {
+        return ['reference' => $this->reference] + $this->context;
+    }
+}

--- a/app/Exceptions/ShouldDeleteNotificationException.php
+++ b/app/Exceptions/ShouldDeleteNotificationException.php
@@ -9,6 +9,6 @@ use Exception;
  * that it has become useless (e.g. The like doesn't exist anymore or the other person removed
  * their check-in).
  */
-class ShouldDeleteNotificationException extends Exception
+class ShouldDeleteNotificationException extends Referencable
 {
 }

--- a/app/Exceptions/StationNotOnTripException.php
+++ b/app/Exceptions/StationNotOnTripException.php
@@ -2,9 +2,40 @@
 
 namespace App\Exceptions;
 
-use Exception;
+use App\Models\HafasTrip;
+use App\Models\TrainStation;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
 
-class StationNotOnTripException extends Exception
+class StationNotOnTripException extends Referencable
 {
-    //
+
+    /**
+     * @param TrainStation $origin
+     * @param TrainStation $destination
+     * @param Carbon       $departure
+     * @param Carbon       $arrival
+     * @param HafasTrip    $trip
+     */
+    public function __construct(
+        ?TrainStation $origin = null,
+        ?TrainStation $destination = null,
+        ?Carbon $departure = null,
+        ?Carbon $arrival = null,
+        ?HafasTrip $trip = null
+    ) {
+        $this->context = [
+            'origin'      => $origin->id ?? null,
+            'destination' => $destination->id ?? null,
+            'departure'   => $departure ? $departure->toIso8601String() : null,
+            'arrival'     => $arrival ? $arrival->toIso8601String() : null,
+            'trip'        => $trip->trip_id ?? null
+        ];
+
+        parent::__construct("Station not on trip");
+
+        Log::debug('Checkin: No stop found for origin or destination (HafasTrip ' . $this->context['trip'] . ')');
+        Log::debug('Checkin: Origin: ' . $this->context['origin'] . ', ' . $this->context['departure']);
+        Log::debug('Checkin: Destination: ' . $this->context['destination'] . ', ' . $this->context['arrival']);
+    }
 }

--- a/app/Exceptions/StationNotOnTripException.php
+++ b/app/Exceptions/StationNotOnTripException.php
@@ -11,11 +11,11 @@ class StationNotOnTripException extends Referencable
 {
 
     /**
-     * @param TrainStation $origin
-     * @param TrainStation $destination
-     * @param Carbon       $departure
-     * @param Carbon       $arrival
-     * @param HafasTrip    $trip
+     * @param TrainStation|null $origin
+     * @param TrainStation|null $destination
+     * @param Carbon|null       $departure
+     * @param Carbon|null       $arrival
+     * @param HafasTrip|null    $trip
      */
     public function __construct(
         ?TrainStation $origin = null,

--- a/app/Exceptions/StatusAlreadyLikedException.php
+++ b/app/Exceptions/StatusAlreadyLikedException.php
@@ -6,7 +6,7 @@ use App\Models\Status;
 use App\Models\User;
 use Exception;
 
-class StatusAlreadyLikedException extends Exception
+class StatusAlreadyLikedException extends Referencable
 {
     private $user;
     private $status;

--- a/app/Exceptions/TrainCheckinAlreadyExistException.php
+++ b/app/Exceptions/TrainCheckinAlreadyExistException.php
@@ -4,7 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 
-class TrainCheckinAlreadyExistException extends Exception
+class TrainCheckinAlreadyExistException extends Referencable
 {
     //
 }

--- a/app/Exceptions/UserAlreadyBlockedException.php
+++ b/app/Exceptions/UserAlreadyBlockedException.php
@@ -4,7 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 
-class UserAlreadyBlockedException extends Exception
+class UserAlreadyBlockedException extends Referencable
 {
     //
 }

--- a/app/Exceptions/UserAlreadyMutedException.php
+++ b/app/Exceptions/UserAlreadyMutedException.php
@@ -4,7 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 
-class UserAlreadyMutedException extends Exception
+class UserAlreadyMutedException extends Referencable
 {
     //
 }

--- a/app/Exceptions/UserNotBlockedException.php
+++ b/app/Exceptions/UserNotBlockedException.php
@@ -4,7 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 
-class UserNotBlockedException extends Exception
+class UserNotBlockedException extends Referencable
 {
     //
 }

--- a/app/Exceptions/UserNotMutedException.php
+++ b/app/Exceptions/UserNotMutedException.php
@@ -4,7 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 
-class UserNotMutedException extends Exception
+class UserNotMutedException extends Referencable
 {
     //
 }

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -80,12 +80,12 @@ function hasStationBoardTimezoneOffsetToUser(Collection $departures, User $user)
     return false;
 }
 
-function errorMessage(Exception $exception): array|null|string {
+function errorMessage(Exception $exception, ?string $text = null): array|null|string {
+    $text = $text ?? __('messages.exception.general');
+
     if (!$exception instanceof Referencable) {
-        return __('messages.exception.general');
+        return $text;
     }
 
-    return __('messages.exception.general')
-           . ' '
-           . __('messages.exception.reference', ['reference' => $exception->reference()]);
+    return $text . ' ' . __('messages.exception.reference', ['reference' => $exception->reference()]);
 }

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -3,8 +3,6 @@
 use App\Exceptions\Referencable;
 use App\Models\User;
 use Carbon\CarbonTimeZone;
-use Illuminate\Contracts\Translation\Translator;
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Exceptions\Referencable;
 use App\Models\User;
 use Carbon\CarbonTimeZone;
+use Illuminate\Contracts\Translation\Translator;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
@@ -75,4 +78,14 @@ function hasStationBoardTimezoneOffsetToUser(Collection $departures, User $user)
     }
 
     return false;
+}
+
+function errorMessage(Exception $exception): array|null|string {
+    if (!$exception instanceof Referencable) {
+        return __('messages.exception.general');
+    }
+
+    return __('messages.exception.general')
+           . ' '
+           . __('messages.exception.reference', ['reference' => $exception->reference()]);
 }

--- a/app/Http/Controllers/Backend/Transport/TrainCheckinController.php
+++ b/app/Http/Controllers/Backend/Transport/TrainCheckinController.php
@@ -143,10 +143,13 @@ abstract class TrainCheckinController extends Controller
                                      ->first();
 
         if (empty($firstStop) || empty($lastStop)) {
-            Log::debug('TrainCheckin: No stop found for origin or destination (HafasTrip ' . $trip->trip_id . ')');
-            Log::debug('TrainCheckin: Origin-ID: ' . $origin->id . ', Departure: ' . $departure->toIso8601String());
-            Log::debug('TrainCheckin: Destination-ID: ' . $destination->id . ', Arrival: ' . $arrival->toIso8601String());
-            throw new StationNotOnTripException();
+            throw new StationNotOnTripException(
+                origin:      $origin,
+                destination: $destination,
+                departure:   $departure,
+                arrival:     $arrival,
+                trip:        $trip
+            );
         }
 
         $overlapping = TransportController::getOverlappingCheckIns(

--- a/app/Http/Controllers/FrontendTransportController.php
+++ b/app/Http/Controllers/FrontendTransportController.php
@@ -226,7 +226,7 @@ class FrontendTransportController extends Controller
             report($exception);
             return redirect()
                 ->route('dashboard')
-                ->with('error', __('messages.exception.general'));
+                ->with('error', errorMessage($exception));
         }
     }
 

--- a/app/Http/Controllers/FrontendTransportController.php
+++ b/app/Http/Controllers/FrontendTransportController.php
@@ -217,7 +217,7 @@ class FrontendTransportController extends Controller
 
         } catch (TrainCheckinAlreadyExistException) {
             return redirect()->route('dashboard')
-                             ->with('error', __('messages.exception.general'));
+                             ->with('error', __('messages.exception.already-checkedin'));
         } catch (AlreadyCheckedInException) {
             $message = __('messages.exception.already-checkedin') . ' ' . __('messages.exception.maybe-too-fast');
             return redirect()->route('dashboard')

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -252,6 +252,7 @@
     "messages.cookie-notice-button": "Okay",
     "messages.cookie-notice-learn": "Mehr erfahren",
     "messages.exception.general": "Es ist ein Fehler aufgetreten. Bitte probiere es erneut.",
+    "messages.exception.reference": "Fehler-Referenz: :reference",
     "messages.exception.generalHafas": "Es gab ein Problem mit der Schnittstelle zu den Fahrplandaten. Bitte probiere es erneut.",
     "messages.exception.hafas.502": "Der Fahrplan konnte nicht geladen werden. Bitte versuche es gleich erneut.",
     "messages.exception.already-checkedin": "Es existiert bereits ein Checkin in dieser Verbindung.",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -234,6 +234,7 @@
     "messages.cookie-notice-button": "Okay",
     "messages.cookie-notice-learn": "Learn more",
     "messages.exception.general": "An unknown error occurred. Please try again.",
+    "messages.exception.reference": "Error reference: :reference",
     "messages.exception.generalHafas": "There was a problem with the interface to the timetable data. Please try again.",
     "messages.exception.hafas.502": "The timetable could not be loaded. Please try again in a moment.",
     "messages.account.please-confirm": "Please enter <i><b>:delete</b></i> to confirm the deletion.",

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,6 +1,12 @@
 @extends('layouts.illustrated-layout')
+@php
+if (!$exception instanceof \App\Exceptions\Referencable) {
+    $exception = $exception->getPrevious();
+}
+@endphp
 
 @section('image', asset('images/covers/derailment.jpg'))
 @section('title', __('Server Error'))
 @section('code', '500')
 @section('message', __('Server Error'))
+@section('reference', errorMessage($exception, ''))

--- a/resources/views/layouts/illustrated-layout.blade.php
+++ b/resources/views/layouts/illustrated-layout.blade.php
@@ -461,7 +461,8 @@
                     <div class="w-16 h-1 bg-trwl-light my-3 md:my-6"></div>
 
                     <p class="text-grey-darker text-2xl md:text-3xl font-light mb-8 leading-normal">
-                        @yield('message')
+                        @yield('message')<br>
+                        @yield('reference')
                     </p>
 
                     <a href="{{ app('router')->has('home') ? route('home') : url('/') }}">

--- a/tests/Unit/HelperMethodTest.php
+++ b/tests/Unit/HelperMethodTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use App\Exceptions\StationNotOnTripException;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Support\Carbon as IlluminateCarbon;
@@ -164,5 +165,19 @@ class HelperMethodTest extends UnitTestCase
             'CET, cancelled, cancelled, wrong timezone'  => [false, [$cancelledCorrectCET, $cancelledWrongCET]],
             'CET, no stations'                           => [false, []],
         ];
+    }
+
+    public function testHelperMethodWithReference(): void {
+        $exception = $this->mock(StationNotOnTripException::class, function ($mock) {
+            $mock->shouldReceive('reference')->andReturn('referenceTest');
+        });
+
+        $text = __('messages.exception.reference', ['reference' => 'referenceTest']);
+
+        $this->assertStringEndsWith($text, errorMessage($exception));
+    }
+
+    public function testHelperMethodWithoutReference(): void {
+        $this->assertEquals(__('messages.exception.general'), errorMessage(new \Exception()));
     }
 }

--- a/tests/Unit/HelperMethodTest.php
+++ b/tests/Unit/HelperMethodTest.php
@@ -175,9 +175,11 @@ class HelperMethodTest extends UnitTestCase
         $text = __('messages.exception.reference', ['reference' => 'referenceTest']);
 
         $this->assertStringEndsWith($text, errorMessage($exception));
+        $this->assertStringEndsWith("Text? " . $text, errorMessage($exception, "Text?"));
     }
 
     public function testHelperMethodWithoutReference(): void {
         $this->assertEquals(__('messages.exception.general'), errorMessage(new \Exception()));
+        $this->assertEquals("Text?", errorMessage(new \Exception(), "Text?"));
     }
 }


### PR DESCRIPTION
In order to provide a better support experience for us and the user, we should be able to find a specific exception in the logs easier. (Stuff like #2111 isn't the easiest to debug because we can't give the user any further context)

This PR adds the functionality of adding "references" to exceptions, which are written to the logfiles and reported to the users.

### Cought error in frontend
<img width="319" alt="Screenshot 2023-11-11 at 23 24 32" src="https://github.com/Traewelling/traewelling/assets/1267894/6df70eb4-68c5-483d-8d99-186955ce810e">

### Expected reference in logs
<img width="276" alt="Screenshot 2023-11-11 at 23 25 42" src="https://github.com/Traewelling/traewelling/assets/1267894/a9661431-565b-4f92-bf4f-3d2b49accf1a">

### Responses of uncought errors in frontend + API
<img width="509" alt="Screenshot 2023-11-12 at 00 34 15" src="https://github.com/Traewelling/traewelling/assets/1267894/df9bab43-818a-4d0e-825d-e2f3a37b6098">
<img width="336" alt="Screenshot 2023-11-12 at 00 52 04" src="https://github.com/Traewelling/traewelling/assets/1267894/02d6dd9e-5334-4090-bb2f-5f98167ce7fc">

### Reference of non-custom exception in logs
<img width="646" alt="Screenshot 2023-11-12 at 01 03 22" src="https://github.com/Traewelling/traewelling/assets/1267894/d7fbf273-01fc-4009-bb5a-44f4b3f0f942">

