### PR TITLE
:bug: move avatar spacing to parent div

### DIFF
--- a/resources/views/settings/profile.blade.php
+++ b/resources/views/settings/profile.blade.php
@@ -15,10 +15,10 @@
                                 {{ __('settings.picture') }}
                             </label>
                             <div class="col-md-6 text-center">
-                                <div class="image-box">
+                                <div class="image-box pb-2">
                                     <img
                                         src="{{ \App\Http\Controllers\Backend\User\ProfilePictureController::getUrl(auth()->user()) }}"
-                                        style="max-width: 96px" alt="{{__('settings.picture')}}" class="pb-2"
+                                        style="max-width: 96px" alt="{{__('settings.picture')}}"
                                         id="theProfilePicture" loading="lazy" decoding="async"
                                     />
                                 </div>


### PR DESCRIPTION
Fixes [this issue](https://discord.com/channels/906993329777020928/1129713818801549392/1174051300921593866) (reported in Discord), where the profile picture is egg-shaped because the padding on the `img` element messes with the aspect-ratio.

![grafik](https://github.com/Traewelling/traewelling/assets/11841072/9c86f0d2-4b40-44c2-bdad-5abfa87bf8ca)
