### PR TITLE
:card_file_box: drop twitter secrets

### DIFF
--- a/app/Http/Controllers/Frontend/Social/SocialController.php
+++ b/app/Http/Controllers/Frontend/Social/SocialController.php
@@ -32,11 +32,9 @@ class SocialController extends Controller
         }
 
         if ($validated['provider'] === 'twitter') {
-            //Twitter destroy is possible as we keep saving the last access tokens and account ids
+            //Twitter destroy is possible as we keep saving the last known user id
             $user->socialProfile->update([
-                                             'twitter_id'          => null,
-                                             'twitter_token'       => null,
-                                             'twitter_tokenSecret' => null
+                                             'twitter_id' => null,
                                          ]);
         } elseif ($validated['provider'] === 'mastodon') {
             $user->socialProfile->update([

--- a/app/Models/SocialLoginProfile.php
+++ b/app/Models/SocialLoginProfile.php
@@ -11,10 +11,10 @@ class SocialLoginProfile extends Model
 
     protected $fillable = [
         'user_id',
-        'twitter_id', 'twitter_token', 'twitter_tokenSecret', 'twitter_refresh_token', 'twitter_token_expires_at',
+        'twitter_id',
         'mastodon_id', 'mastodon_server', 'mastodon_token', 'mastodon_visibility'
     ];
-    protected $hidden   = ['twitter_token', 'twitter_tokenSecret', 'twitter_refresh_token', 'mastodon_server', 'mastodon_token'];
+    protected $hidden   = ['mastodon_server', 'mastodon_token'];
     protected $casts    = [
         'id'                       => 'integer',
         'user_id'                  => 'integer',
@@ -22,10 +22,6 @@ class SocialLoginProfile extends Model
         'mastodon_id'              => 'integer',
         'mastodon_server'          => 'integer',
         'mastodon_visibility'      => MastodonVisibility::class,
-        'twitter_token'            => 'encrypted',
-        'twitter_tokenSecret'      => 'encrypted',
-        'twitter_refresh_token'    => 'encrypted',
-        'twitter_token_expires_at' => 'datetime',
         'mastodon_token'           => 'encrypted',
     ];
 

--- a/database/migrations/2023_11_21_000000_drop_twitter_secrets.php
+++ b/database/migrations/2023_11_21_000000_drop_twitter_secrets.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void {
+        Schema::dropColumns('social_login_profiles', [
+            'twitter_token',
+            'twitter_tokenSecret',
+            'twitter_refresh_token',
+            'twitter_token_expires_at',
+        ]);
+    }
+};


### PR DESCRIPTION
Drop secrets - but keep the user id, so if we ever need to verify a user or reimplement twitter (i don't hope so) we can use this again.

Users have still the option to remove the twitter id from their profile in the settings.