### PR TITLE
:card_file_box: drop `type` column of `statuses` table

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -4,6 +4,16 @@ In this we try to keep track of changes to the API.
 Primarily this should document changes that are not backwards compatible or belongs to already documented endpoints.
 This is to help you keep track of the changes and to help you update your code accordingly.
 
+## 2023-11-23
+
+The attribute `type` in the `Status` Model is marked as deprecated and now returns a blank string for all statuses as it
+is not used.
+
+> [!IMPORTANT]
+> **Backwards compatibility** - Will not break your code until February 2024.
+>
+> After that, the attribute will be removed.
+
 ## 2023-11-22
 
 The attribute `role` in the `User` Model is marked as deprecated and now returns `0` for all users.
@@ -15,7 +25,8 @@ The attribute `role` in the `User` Model is marked as deprecated and now returns
 
 ## 2023-11-21
 
-The attribute `twitterUrl` in the `User` Model is marked as deprecated and returns `null`, as Traewelling does not support Twitter anymore.
+The attribute `twitterUrl` in the `User` Model is marked as deprecated and returns `null`, as Traewelling does not
+support Twitter anymore.
 
 > [!IMPORTANT]
 > **Backwards compatibility** - Will not break your code until February 2024.
@@ -29,7 +40,7 @@ There are `distance` and `duration` attributes, which you can use to calculate t
 
 > [!IMPORTANT]
 > **Backwards compatibility** - Will not break your code until December 2023.
-> 
+>
 > As of now, the `speed` attribute return 0 for all objects and will be removed after 2023-12-31.
 
 ## 2023-09-22

--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -267,8 +267,7 @@ class StatusController extends Controller
         Business         $business,
         StatusVisibility $visibility,
         string           $body = null,
-        int              $eventId = null, //TODO: change to Event Object
-        string           $type = "hafas"
+        int              $eventId = null //TODO: change to Event Object
     ): Status {
         $event = null;
         if ($eventId !== null) {
@@ -283,7 +282,6 @@ class StatusController extends Controller
                                   'body'       => $body,
                                   'business'   => $business,
                                   'visibility' => $visibility,
-                                  'type'       => $type,
                                   'event_id'   => $event?->id
                               ]);
     }

--- a/app/Http/Resources/StatusResource.php
+++ b/app/Http/Resources/StatusResource.php
@@ -20,7 +20,7 @@ class StatusResource extends JsonResource
         return [
             'id'             => (int) $this->id,
             'body'           => (string) $this->body,
-            'type'           => (string) $this->type,
+            'type'           => '', //TODO: deprecated: remove after 2024-02
             'user'           => (int) $this->user->id,
             'username'       => (string) $this->user->username,
             'profilePicture' => ProfilePictureController::getUrl($this->user),

--- a/app/Virtual/Models/Status.php
+++ b/app/Virtual/Models/Status.php
@@ -39,17 +39,6 @@ class Status
     public $body;
 
     /**
-     * @OA\Property (
-     *     title="type",
-     *     description="type of status",
-     *     example="HAFAS"
-     * )
-     *
-     * @var string
-     */
-    private $type;
-
-    /**
      * @OA\Property(
      *     title="user",
      *     description="user id",

--- a/database/factories/StatusFactory.php
+++ b/database/factories/StatusFactory.php
@@ -16,7 +16,6 @@ class StatusFactory extends Factory
             'user_id'    => User::factory(),
             'business'   => $this->faker->randomElement(Business::cases())->value,
             'visibility' => StatusVisibility::PUBLIC,
-            'type'       => 'hafas',
             'event_id'   => null,
         ];
     }

--- a/database/migrations/2023_11_23_000000_remove_type_from_statuses.php
+++ b/database/migrations/2023_11_23_000000_remove_type_from_statuses.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * This migration removes the type column from the statuses table.
+ * This attribut was planned to differ between hafas and custom statuses, but was never used.
+ * It's now planned to merge the status and train_checkins models into one model and create manual trags directly to
+ * the trips (currently "hafas_trips") table.
+ */
+return new class extends Migration
+{
+    public function up(): void {
+        Schema::dropColumns('statuses', ['type']);
+    }
+
+    public function down(): void {
+        Schema::table('statuses', static function(Blueprint $table) {
+            $table->string('type')->default('hafas')->after('visibility');
+        });
+    }
+};

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -4911,12 +4911,6 @@
                         "description": "User defined status text",
                         "example": "Hello world!"
                     },
-                    "type": {
-                        "title": "type",
-                        "description": "type of status",
-                        "type": "string",
-                        "example": "HAFAS"
-                    },
                     "user": {
                         "title": "user",
                         "description": "user id",


### PR DESCRIPTION
preparation for #2145

This migration removes the type column from the statuses table.
This attribut was planned to differ between hafas and custom statuses, but was never used.
It's now planned to merge the status and train_checkins models into one model and create manual trags directly to the trips (currently "hafas_trips") table.