### PR TITLE
:lipstick: Make export column select a little larger

### DIFF
--- a/resources/views/export.blade.php
+++ b/resources/views/export.blade.php
@@ -26,7 +26,7 @@
                                 {{__('export.columns')}}
                             </p>
 
-                            <select class="form-select" multiple name="columns[]" required>
+                            <select class="form-select" size="12" multiple name="columns[]" required>
                                 @foreach(\App\Enum\ExportableColumn::cases() as $column)
                                     <option value="{{$column->value}}">
                                         {{$column->title()}}


### PR DESCRIPTION
In response to a discord question, now 12 columns are shown instead of the default (4). On Chrome/Android, it still opens the multi-picker system UI and doesnt make the page larger than needed.

<img width="1132" alt="image" src="https://github.com/Traewelling/traewelling/assets/2796271/4954c904-13b8-4e37-8963-9aad19d35b1c">
