### PR TITLE
:children_crossing: Fix touch handling in stationboard

### DIFF
--- a/resources/js/components/stationboard.js
+++ b/resources/js/components/stationboard.js
@@ -17,7 +17,7 @@ for (let delay of delays) {
 
 var touchmoved;
 $(document)
-    .on("click touchstart", ".trainrow", function () {
+    .on("click touchend", ".trainrow", function () {
         var lineName        = $(this).data("linename");
         var tripID          = $(this).data("tripid");
         var start           = $(this).data("start");


### PR DESCRIPTION
The logic for `.trainrow`s will be the same as for `.train-destinationrow`s with this. Previously, the `if (!touchmoved)` condition always evaluated to true as it was already triggered on `touchstart` as opposed to `touchend` for `.trainrow`s.

This will prevent the accidental selection of a train in the stationboard, which previously forced users to try to use the very narrow margins of the page to scroll in the stationboard view.