### PR TITLE
:bug: fix missing translation when no locale is set

### DIFF
--- a/app/Mail/AccountDeletionNotificationTwoWeeksBefore.php
+++ b/app/Mail/AccountDeletionNotificationTwoWeeksBefore.php
@@ -27,7 +27,7 @@ class AccountDeletionNotificationTwoWeeksBefore extends Mailable
     }
 
     public function content(): Content {
-        App::setLocale($this->user?->language);
+        App::setLocale($this->user?->language ?? config('app.locale', 'en'));
         return new Content(
             view: 'mail.account_deletion_notification_two_weeks_before',
             with: [


### PR DESCRIPTION
Maybe a few emails were sent out today with missing translations. Oops.

![image](https://github.com/Traewelling/traewelling/assets/4103693/3982060d-c61d-4489-a3a5-272cebebd0da)

![image](https://github.com/Traewelling/traewelling/assets/4103693/13f345a6-e233-4020-becb-2ce6597cbf52)
