### PR TITLE
:bug: Fix "uneditable" 0min checkins & allow checking in to a destination 0 min away

### DIFF
--- a/app/Http/Controllers/Backend/Transport/StationController.php
+++ b/app/Http/Controllers/Backend/Transport/StationController.php
@@ -69,9 +69,14 @@ abstract class StationController extends Controller
     }
 
     public static function getAlternativeDestinationsForCheckin(Checkin $checkin): Collection {
+        $encounteredOrigin = false;
         return $checkin->trip->stopovers
-            ->filter(function(Stopover $stopover) use ($checkin) {
-                return ($stopover->arrival_planned ?? $stopover->departure_planned)->isAfter($checkin->departure);
+            ->filter(function(Stopover $stopover) use ($checkin, &$encounteredOrigin): bool {
+                if (!$encounteredOrigin) { // this assumes stopovers being ordered correctly
+                    $encounteredOrigin = $stopover->departure_planned == $checkin->departure && $stopover->is($checkin->originStopover);
+                    return false;
+                }
+                return true;
             })
             ->map(function(Stopover $stopover) {
                 return [

--- a/app/Http/Controllers/FrontendTransportController.php
+++ b/app/Http/Controllers/FrontendTransportController.php
@@ -130,9 +130,14 @@ class FrontendTransportController extends Controller
                 $startStation->id,
             );
 
+            $encounteredStart = false;
             $stopovers = $trip->stopovers
-                ->filter(function(Stopover $stopover) use ($departure): bool {
-                    return $stopover->departure_planned->isAfter($departure);
+                ->filter(function(Stopover $stopover) use ($departure, $startStation, &$encounteredStart): bool {
+                    if (!$encounteredStart) { // this assumes stopovers being ordered correctly
+                        $encounteredStart = $stopover->departure_planned == $departure && $stopover->station->is($startStation);
+                        return false;
+                    }
+                    return true;
                 });
 
             // Find out where this train terminates and offer this as a "fast check-in" option.


### PR DESCRIPTION
It is currently not possible to edit a checkin where the arrival at the destination is the same time as the departure from the origin without changing the destination. You are forced to change the destination or to delete and recreate the checkin.

Before:

<img src="https://github.com/Traewelling/traewelling/assets/9254305/a53289ba-249f-407e-828c-6717d4210882" width="500px" />

After:

<img src="https://github.com/Traewelling/traewelling/assets/9254305/6e43afa8-ee8a-46fc-aa82-f6b95c8a5f1a" width="500px" />

---

I was wondering whether there are more issues related to these lovely 0 minute durations between stopovers and I found another issue here:

Trip view for start at stopover Obernahmer: it is possible to check in with destination Obernahmer Land or Lahmen Hasen.
<img src="https://github.com/Traewelling/traewelling/assets/9254305/4f64fa38-bdf6-43d1-9493-0bce5683db48" width="500px" />

Trip view for start at stopover Obernahmer Land: it is not possible to check in towards Lahmen Hasen.

<img src="https://github.com/Traewelling/traewelling/assets/9254305/a0824f71-73f4-480e-91ed-7ee17d104ee3" width="500px" />

With the fix applied 🐇

<img src="https://github.com/Traewelling/traewelling/assets/9254305/8b1ea18b-9289-49cf-a16d-2f02a2f3be47" width="500px" />

---

I didn't deduplicate the code because I kept using the stopover for the existing checkin edit case, and station + departure for the new trip case. I also don't use the planned arrival anymore inside getAlternativeDestinationsForCheckin since the remaining code determines the exact stopover after which every remaining stopover will pass.
I hope there are no cases where the condition never evaluates to true; or where the pair of (departure + stopover), or (departure + station) are not uniquely identifying exactly one stopover of a trip.
