### PR TITLE
:children_crossing: More flexible station autocomplete & better ordering

### DIFF
--- a/app/Http/Controllers/HafasController.php
+++ b/app/Http/Controllers/HafasController.php
@@ -7,9 +7,9 @@ use App\Enum\TravelType;
 use App\Enum\TripSource;
 use App\Exceptions\HafasException;
 use App\Models\HafasOperator;
-use App\Models\Trip;
 use App\Models\Station;
 use App\Models\Stopover;
+use App\Models\Trip;
 use Carbon\Carbon;
 use Carbon\CarbonTimeZone;
 use Exception;
@@ -120,11 +120,15 @@ abstract class HafasController extends Controller
 
     private static function upsertStations(array $payload) {
         $ibnrs = array_column($payload, 'ibnr');
-        if (empty($ibnrs)) return new Collection();
+        if (empty($ibnrs)) {
+            return new Collection();
+        }
         Station::upsert($payload, ['ibnr'], ['name', 'latitude', 'longitude']);
-        return Station::whereIn('ibnr', $ibnrs)->get()->sortBy(function($station) use ($ibnrs) {
-            return array_search($station->ibnr, $ibnrs);
-        })->values();
+        return Station::whereIn('ibnr', $ibnrs)->get()
+                      ->sortBy(function(Station $station) use ($ibnrs) {
+                          return array_search($station->ibnr, $ibnrs);
+                      })
+                      ->values();
     }
 
     /**

--- a/app/Http/Controllers/HafasController.php
+++ b/app/Http/Controllers/HafasController.php
@@ -120,8 +120,11 @@ abstract class HafasController extends Controller
 
     private static function upsertStations(array $payload) {
         $ibnrs = array_column($payload, 'ibnr');
+        if (empty($ibnrs)) return new Collection();
         Station::upsert($payload, ['ibnr'], ['name', 'latitude', 'longitude']);
-        return Station::whereIn('ibnr', $ibnrs)->get();
+        return Station::whereIn('ibnr', $ibnrs)->get()->sortBy(function($station) use ($ibnrs) {
+            return array_search($station->ibnr, $ibnrs);
+        })->values();
     }
 
     /**

--- a/resources/js/components/station-autocomplete.js
+++ b/resources/js/components/station-autocomplete.js
@@ -20,6 +20,7 @@ const popularStations = [
         autoFirst: true,
         sort: false,
         list: popularStations,
+        filter: () => true,
         container: function () {
             container.classList.add("awesomplete");
             return container;


### PR DESCRIPTION
Awesomplete by default filters everything where the search string does not match a substring of the results.  
When searching for "schieferstr. hagen", the list is empty since the stop is called "Schieferstr., Hagen (Westf)", so the missing comma after the dot is the culprit in this example.

Sure, one could just submit without selecting something from the list and hope it works, but it won't give the user what they wanted in all cases. The current behaviour could really be improved.  
By removing the filter, we can just show all results the API gave us instead of making Awesomplete drop them all.

This is the result after the changes, matching the search results I get when trying out the same search term in the good old bhftafel.exe search box.

<img src="https://github.com/Traewelling/traewelling/assets/9254305/60b4d764-f045-4ba7-b5d2-b4d1d88dd80d" width="600px" />

Note however that this may result in the yellow highlighting not being shown at all anymore. This could be improved by highlighting every word separately, looking at the search string by space separation. Not sure whether there's an easy way to do this in Awesomplete.

The change in HafasController was required to keep the sensible order provided by the API based on the relevance rather than whatever our database returns.  
This also leads to an improved experience in the vue-based station search from the experimental features.