### PR TITLE
:bug: Handle arrival and departure separately to retain more realtime data

### DIFF
--- a/app/Console/Commands/RefreshCurrentTrips.php
+++ b/app/Console/Commands/RefreshCurrentTrips.php
@@ -51,8 +51,8 @@ class RefreshCurrentTrips extends Command
                 $trip->update(['last_refreshed' => now()]);
 
                 $rawHafas    = HafasController::fetchRawHafasTrip($trip->trip_id, $trip->linename);
-                $updatedRows = HafasController::refreshStopovers($rawHafas);
-                $this->info('Updated ' . $updatedRows . ' rows.');
+                $updatedCounts = HafasController::refreshStopovers($rawHafas);
+                $this->info('Updated ' . $updatedCounts->stopovers . ' stopovers.');
 
                 //set duration for refreshed trips to null, so it will be recalculated
                 Checkin::where('trip_id', $trip->trip_id)->update(['duration' => null]);


### PR DESCRIPTION
fixes #2174

Also updating the cancelled attribute here by the way, since it only got set once before.