### PR TITLE
:sparkles: Remove webhook from database when webhook client has responded with 410 Gone

### DIFF
--- a/app/Enum/MonitoringCounter.php
+++ b/app/Enum/MonitoringCounter.php
@@ -9,4 +9,5 @@ enum MonitoringCounter: string {
     case StatusDeleted = "StatusDeleted";
     case UserCreated   = "UserCreated";
     case UserDeleted   = "UserDeleted";
+    case WebhookAbsent = "WebhookAbsent";
 }

--- a/app/Listeners/RemoveAbsentWebhooksListener.php
+++ b/app/Listeners/RemoveAbsentWebhooksListener.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Enum\CacheKey;
+use App\Enum\MonitoringCounter;
+use App\Models\Webhook;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Spatie\WebhookServer\Events\WebhookCallFailedEvent;
+
+class RemoveAbsentWebhooksListener
+{
+    public function handle(WebhookCallFailedEvent $event) {
+        if (!$event->response) {
+            return;
+        }
+
+        if ($event->response->getStatusCode() !== 410) {
+            return;
+        }
+
+        $webhookId = $event->headers["X-Trwl-Webhook-Id"];
+        Webhook::findOrFail($webhookId)->delete();
+        Log::info("Deleted Webhook {webhookId} from User {userId} because server has sent 410 Gone response.", [
+            "webhookId" => $webhookId,
+            "userId"    => $event->headers["X-Trwl-User-Id"]
+        ]);
+        Cache::increment(CacheKey::getMonitoringCounterKey(MonitoringCounter::WebhookAbsent));
+    }
+}

--- a/app/Listeners/RemoveAbsentWebhooksListener.php
+++ b/app/Listeners/RemoveAbsentWebhooksListener.php
@@ -12,11 +12,7 @@ use Spatie\WebhookServer\Events\WebhookCallFailedEvent;
 class RemoveAbsentWebhooksListener
 {
     public function handle(WebhookCallFailedEvent $event) {
-        if (!$event->response) {
-            return;
-        }
-
-        if ($event->response->getStatusCode() !== 410) {
+        if (!$event->response || $event->response->getStatusCode() !== 410) {
             return;
         }
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -7,6 +7,7 @@ use App\Events\StatusUpdateEvent;
 use App\Events\UserCheckedIn;
 use App\Jobs\PostStatusOnMastodon;
 use App\Listeners\NotificationSentWebhookListener;
+use App\Listeners\RemoveAbsentWebhooksListener;
 use App\Listeners\StatusCreateCheckPolylineListener;
 use App\Listeners\StatusCreateWebhookListener;
 use App\Listeners\StatusDeleteWebhookListener;
@@ -36,21 +37,24 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
-        Registered::class        => [
+        Registered::class             => [
             //SendEmailVerificationNotification::class,
         ],
-        UserCheckedIn::class     => [
+        UserCheckedIn::class          => [
             StatusCreateWebhookListener::class,
             StatusCreateCheckPolylineListener::class,
         ],
-        StatusUpdateEvent::class => [
+        StatusUpdateEvent::class      => [
             StatusUpdateWebhookListener::class
         ],
-        StatusDeleteEvent::class => [
+        StatusDeleteEvent::class      => [
             StatusDeleteWebhookListener::class
         ],
-        NotificationSent::class  => [
+        NotificationSent::class       => [
             NotificationSentWebhookListener::class
+        ],
+        WebhookCallFailedEvent::class => [
+            RemoveAbsentWebhooksListener::class
         ]
     ];
 

--- a/app/Providers/PrometheusServiceProvider.php
+++ b/app/Providers/PrometheusServiceProvider.php
@@ -95,6 +95,10 @@ class PrometheusServiceProvider extends ServiceProvider
                                ->toArray();
                   });
 
+        Prometheus::addGauge('absent_webhooks_deleted')
+                  ->helpText("How many webhooks were responded with Gone and were thus deleted from our side?")
+                  ->value(fn() => Cache::get(CacheKey::getMonitoringCounterKey(MonitoringCounter::WebhookAbsent)));
+
         Prometheus::addGauge("profile_image_count")
                   ->helpText("How many profile images are stored?")
                   ->value(function() {

--- a/tests/Feature/Webhooks/RemoveAbsentWebhooksListenerTest.php
+++ b/tests/Feature/Webhooks/RemoveAbsentWebhooksListenerTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Feature\Webhooks;
+
+use App\Enum\WebhookEvent;
+use App\Listeners\RemoveAbsentWebhooksListener;
+use App\Models\User;
+use App\Models\Webhook;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Spatie\WebhookServer\Events\WebhookCallFailedEvent;
+use Tests\TestCase;
+use function PHPUnit\Framework\assertEquals;
+
+class RemoveAbsentWebhooksListenerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testItRemovesAbsentWebhook() {
+        // GIVEN
+        $alice   = User::factory()->create();
+        $client  = $this->createWebhookClient($alice);
+        $webhook = $this->createWebhook($alice, $client, [WebhookEvent::NOTIFICATION]);
+        assertEquals(1, Webhook::where("id", "=", $webhook->id)->count());
+
+        // WHEN
+        $underTest = new RemoveAbsentWebhooksListener();
+        $underTest->handle(
+            new WebhookCallFailedEvent(
+                httpVerb:      "POST",
+                webhookUrl:    $webhook->url,
+                payload:       ["not" => "relevant"],
+                headers:       [
+                                   "X-Trwl-User-Id"    => $alice->id,
+                                   "X-Trwl-Webhook-Id" => $webhook->id,
+                               ],
+                meta:          ["not" => "relevant"],
+                tags:          ["not" => "relevant"],
+                attempt:       1,
+                response:      new Response(410 /* GONE */),
+                errorType:     "GuzzleHttp\Exception\ClientException",
+                errorMessage:  "410 Gone",
+                uuid:          Str::uuid(),
+                transferStats: null
+            ));
+
+        // THEN
+        assertEquals(0, Webhook::where("id", "=", $webhook->id)->count());
+    }
+
+    public function testItDoesntInteractWhenOtherReturnCode() {
+        // GIVEN
+        $alice   = User::factory()->create();
+        $client  = $this->createWebhookClient($alice);
+        $webhook = $this->createWebhook($alice, $client, [WebhookEvent::NOTIFICATION]);
+        assertEquals(1, Webhook::where("id", "=", $webhook->id)->count());
+
+        // WHEN
+        $underTest = new RemoveAbsentWebhooksListener();
+
+        $underTest->handle(
+            new WebhookCallFailedEvent(
+                httpVerb:      "POST",
+                webhookUrl:    $webhook->url,
+                payload:       ["not" => "relevant"],
+                headers:       ["not" => "relevant"],
+                meta:          ["not" => "relevant"],
+                tags:          ["not" => "relevant"],
+                attempt:       1,
+                response:      new Response(503 /* SERVICE UNAVAILABLE */),
+                errorType:     "GuzzleHttp\Exception\ClientException",
+                errorMessage:  "503 Service Unavailable",
+                uuid:          Str::uuid(),
+                transferStats: null
+            ));
+
+        // THEN
+        assertEquals(1, Webhook::where("id", "=", $webhook->id)->count());
+    }
+
+    public function testItDoesntInteractWhenConnectException() {
+        // GIVEN
+        $alice   = User::factory()->create();
+        $client  = $this->createWebhookClient($alice);
+        $webhook = $this->createWebhook($alice, $client, [WebhookEvent::NOTIFICATION]);
+        assertEquals(1, Webhook::where("id", "=", $webhook->id)->count());
+
+        // WHEN
+        $underTest = new RemoveAbsentWebhooksListener();
+        $underTest->handle(new WebhookCallFailedEvent(
+                               httpVerb:      "POST",
+                               webhookUrl:    $webhook->url,
+                               payload:       ["not" => "relevant"],
+                               headers:       ["not" => "relevant"],
+                               meta:          ["not" => "relevant"],
+                               tags:          ["not" => "relevant"],
+                               attempt:       1,
+                               response:      null,
+                               errorType:     "GuzzleHttp\Exception\ConnectException",
+                               errorMessage:  "Unable to connect to Server",
+                               uuid:          Str::uuid(),
+                               transferStats: null
+                           ));
+
+        // THEN
+        assertEquals(1, Webhook::where("id", "=", $webhook->id)->count());
+    }
+
+    public function testItThrowsWhenWebhookToDeleteCannotBeFound() {
+        // GIVEN
+        $alice = User::factory()->create();
+
+        $unknown_webhook_id = 42;
+        assertEquals(0, Webhook::where("id", "=", $unknown_webhook_id)->count());
+
+        // WHEN
+        $underTest = new RemoveAbsentWebhooksListener();
+
+        $this->assertThrows(fn() => $underTest->handle(
+            new WebhookCallFailedEvent(
+                httpVerb:      "POST",
+                webhookUrl:    "https://example.com/trwl-webhook",
+                payload:       ["not" => "relevant"],
+                headers:       [
+                                   "X-Trwl-User-Id"    => $alice->id,
+                                   "X-Trwl-Webhook-Id" => $unknown_webhook_id,
+                               ],
+                meta:          ["not" => "relevant"],
+                tags:          ["not" => "relevant"],
+                attempt:       1,
+                response:      new Response(410 /* GONE */),
+                errorType:     "GuzzleHttp\Exception\ClientException",
+                errorMessage:  "410 Gone",
+                uuid:          Str::uuid(),
+                transferStats: null
+            )),
+            ModelNotFoundException::class);
+    }
+}


### PR DESCRIPTION
Background: Some users have a large number of webhooks configured, often for the same URL, i.e. because they uninstalled and reinstalled an app. The old webhook will usually not be discarded, so when webhook events are fired, dozens of requests are sent out. The webhook client (FCM, APNS, ...) knows if the app is still installed and can respond to us if it isn't anymore.

**TODO:** I have added unit tests as far as I understood the library to work. However, I don't have a working webhook-able installation here, so if @MrKrisKrisu or @NyCodeGHG could check out the feature on their side, that would be great.