### PR TITLE
:sparkles: add Co2 savings to profile view

### DIFF
--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -43,6 +43,9 @@
                     <span class="profile-stats">
                             <span class="font-weight-bold"><i class="fa fa-route d-inline"></i>&nbsp;{{ number($user->train_distance / 1000) }}</span><span
                                 class="small font-weight-lighter">km</span>
+			    <span class="font-weight-bold ps-sm-2">
+                                <i class="fa fa-leaf d-inline"></i>&nbsp; {{ number_format($user->train_distance * 15 / 1000, 0)  }}t
+                            </span>
                             <span class="font-weight-bold ps-sm-2"><i class="fa fa-stopwatch d-inline"></i>&nbsp;{!! durationToSpan(secondsToDuration($user->train_duration * 60)) !!}</span>
                             <span class="font-weight-bold ps-sm-2">
                                 <i class="fa fa-dice-d20 d-inline"></i>&nbsp;{{ $user->points }}

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -44,7 +44,7 @@
                             <span class="font-weight-bold"><i class="fa fa-route d-inline"></i>&nbsp;{{ number($user->train_distance / 1000) }}</span><span
                                 class="small font-weight-lighter">km</span>
 			    <span class="font-weight-bold ps-sm-2">
-                                <i class="fa fa-leaf d-inline"></i>&nbsp; {{ number_format($user->train_distance * 15 / 1000, 0)  }}t
+                                <i class="fa fa-leaf d-inline"></i>&nbsp; {{ number_format($user->train_distance * 15 / 100 , 0)  }}t
                             </span>
                             <span class="font-weight-bold ps-sm-2"><i class="fa fa-stopwatch d-inline"></i>&nbsp;{!! durationToSpan(secondsToDuration($user->train_duration * 60)) !!}</span>
                             <span class="font-weight-bold ps-sm-2">


### PR DESCRIPTION
I want to see how much co2 I've safed against driving by car with the train during my live.
I used following source https://www.quarks.de/umwelt/klimawandel/co2-rechner-fuer-auto-flugzeug-und-co/

Unfortunately it's not easy to calculate how much the user has been driven by ÖPNV or IC(E). So I used the factor 15 to calculate the value and divided it by 100.