### PR TITLE
🐛 Fix issues related to checking into international trains

### DIFF
--- a/app/Http/Controllers/FrontendTransportController.php
+++ b/app/Http/Controllers/FrontendTransportController.php
@@ -127,6 +127,7 @@ class FrontendTransportController extends Controller
                 // in long term to support multiple data providers we only support IDs here - no IBNRs.
                 $startStation = Station::findOrFail($validated['start']);
             }
+
             $departure = Carbon::parse($validated['departure']);
 
             $trip = TrainCheckinController::getHafasTrip(
@@ -137,9 +138,9 @@ class FrontendTransportController extends Controller
 
             $encounteredStart = false;
             $stopovers = $trip->stopovers
-                ->filter(function(Stopover $stopover) use ($departure, $startStation, &$encounteredStart): bool {
+                ->filter(function(Stopover $stopover) use ($startStation, &$encounteredStart): bool {
                     if (!$encounteredStart) { // this assumes stopovers being ordered correctly
-                        $encounteredStart = $stopover->departure_planned == $departure && $stopover->station->is($startStation);
+                        $encounteredStart = $stopover->station->is($startStation);
                         return false;
                     }
                     return true;

--- a/resources/vue/components/CheckinInterface.vue
+++ b/resources/vue/components/CheckinInterface.vue
@@ -38,7 +38,7 @@ export default {
                 business: this.business,
                 ibnr: true,
                 tripId: this.selectedTrain.tripId,
-                lineName: this.selectedTrain.line.name || this.selectedTrain.line.fahrtNr,
+                lineName: this.selectedTrain.line.name ?? this.selectedTrain.line.fahrtNr,
                 start: this.selectedTrain.stop.id,
                 destination: this.selectedDestination.evaIdentifier,
                 departure: DateTime.fromISO(this.selectedTrain.plannedWhen).setZone("UTC").toISO(),

--- a/resources/vue/components/CheckinInterface.vue
+++ b/resources/vue/components/CheckinInterface.vue
@@ -38,7 +38,7 @@ export default {
                 business: this.business,
                 ibnr: true,
                 tripId: this.selectedTrain.tripId,
-                lineName: this.selectedTrain.line.name,
+                lineName: this.selectedTrain.line.name || this.selectedTrain.line.fahrtNr,
                 start: this.selectedTrain.stop.id,
                 destination: this.selectedDestination.evaIdentifier,
                 departure: DateTime.fromISO(this.selectedTrain.plannedWhen).setZone("UTC").toISO(),

--- a/resources/vue/components/Stationboard.vue
+++ b/resources/vue/components/Stationboard.vue
@@ -135,7 +135,7 @@ export default {
                 <ProductIcon :product="selectedTrain.line.product"/>
             </div>
             <div class="col-auto align-items-center d-flex me-3">
-                <LineIndicator :product-name="selectedTrain.line.product" :number="selectedTrain.line.name"/>
+                <LineIndicator :product-name="selectedTrain.line.product" :number="selectedTrain.line.name !== null ? selectedTrain.line.name : selectedTrain.line.fahrtNr"/>
             </div>
             <template v-if="selectedDestination">
                 <div class="col-auto align-items-center d-flex me-3">
@@ -164,7 +164,7 @@ export default {
                     <ProductIcon :product="item.line.product"/>
                 </div>
                 <div class="col-2 align-items-center d-flex me-3 justify-content-center">
-                    <LineIndicator :productName="item.line.product" :number="item.line.name"/>
+                    <LineIndicator :productName="item.line.product" :number="item.line.name !== null ? item.line.name : item.line.fahrtNr"/>
                 </div>
                 <div class="col align-items-center d-flex second-stop">
                     <div>


### PR DESCRIPTION
As issue #2401 already mentioned, checking into UK trains does not seem to work. Neither using the old check-in interface nor using the new (experimental) one.

I've never worked on the Träwelling codebase before, so take this with a grain of salt 😅

## New check-in interface
To me it looks like the issue with the new interface was due to many UK trains not having a line name provided in the data. Some Vue components were not accounting for that.
I fixed this by checking for empty line names and using the `fahrtNr` as a fallback. This seemed to be the preferred solution looking at the old interface.
This actually seems to resolve the display glitches and the 422 errors when trying to check into a train:
![Screenshot 2024-03-10 at 18 49 50](https://github.com/Traewelling/traewelling/assets/36338179/cc67044f-5ecd-4fad-92c4-46af2b134c22)

## Old check-in interface
However, the old interface doesn't seem to have any issues with empty line names. The only problem there is the empty stopovers. As far as I can tell, this issue is related to the filtering of stopovers introduced in #2322.

The UK trains seem to provide the planned departure (`departure_planned`) in their own timezone. Hence, checking against the departure time passed by the front end does not work (as the UK time is one hour behind).

I removed the departure time check and only kept the check against the start station passed by the front end. I hope this is sufficient? Not entirely sure on that one though.

Before:
![Screenshot 2024-03-10 at 18 47 15](https://github.com/Traewelling/traewelling/assets/36338179/e022f678-6274-4e35-a902-81523cb0497e)


After:
![Screenshot 2024-03-10 at 18 48 04](https://github.com/Traewelling/traewelling/assets/36338179/bac4eeb8-7dc8-466f-b4e2-d846e0ffe3b4)

Resolves #2401 