### PR TITLE
:bug: fix type error on broken polylines

### DIFF
--- a/app/Http/Controllers/Backend/Support/LocationController.php
+++ b/app/Http/Controllers/Backend/Support/LocationController.php
@@ -145,9 +145,14 @@ class LocationController
      * @throws JsonException
      */
     private function getPolylineWithTimestamps(): stdClass {
-        $geoJsonObj = json_decode('{"type":"FeatureCollection","features":[]}', false, 512, JSON_THROW_ON_ERROR);
         if (isset($this->trip->polyline)) {
+            // decode GeoJSON object from polyline
             $geoJsonObj = json_decode($this->trip->polyline->polyline, false, 512, JSON_THROW_ON_ERROR);
+        } else {
+            // create empty GeoJSON object
+            $geoJsonObj           = new stdClass();
+            $geoJsonObj->type     = 'FeatureCollection';
+            $geoJsonObj->features = [];
         }
         $stopovers = $this->trip->stopovers;
 
@@ -226,7 +231,7 @@ class LocationController
     private function getPolylineBetween(bool $preserveKeys = true): stdClass|FeatureCollection {
         $this->trip->loadMissing(['stopovers.station']);
         $geoJson = $this->getPolylineWithTimestamps();
-        if (count($geoJson->features) === 0) {
+        if (count((array) $geoJson->features) === 0) {
             return $this->createPolylineFromStopovers();
         }
 
@@ -257,10 +262,10 @@ class LocationController
         }
         if (is_array($features)) { // object is a rarely stdClass without content if no features in the GeoJSON
             $slicedFeatures    = array_slice(
-                $features,
-                $originIndex,
-                $destinationIndex - $originIndex + 1,
-                $preserveKeys
+                array:         $features,
+                offset:        $originIndex,
+                length:        $destinationIndex - $originIndex + 1,
+                preserve_keys: $preserveKeys
             );
             $geoJson->features = $slicedFeatures;
         }


### PR DESCRIPTION
fixes #2467

This only fixes the 500 bug itself, but not the cause.

The given Polyline by Brouter isn't correct. The Featurekeys are broken and features should be an array, not an object:

```json
{
    "type": "FeatureCollection",
    "features": {
        "0": {
            "type": "Feature",
            "properties": {
                "id": 8530257,
                "name": "Bern DMB",
                "departure_planned": "2024-04-06T13:42:00.000000Z",
                "arrival_planned": "2024-04-06T13:42:00.000000Z"
            },
            "geometry": {
                "type": "Point",
                "coordinates": [
                    7.440954,
                    46.946516
                ]
            }
        },
        "": {
            "properties": {
                "id": 8530258,
                "name": "Marzili",
                "departure_planned": "2024-04-06T13:43:00.000000Z",
                "arrival_planned": "2024-04-06T13:43:00.000000Z"
            }
        }
    }
}
```