### PR TITLE
:zap: Improve performance of polyline cleanup

### DIFF
--- a/app/Console/Commands/CleanUpPolylines.php
+++ b/app/Console/Commands/CleanUpPolylines.php
@@ -2,21 +2,43 @@
 
 namespace App\Console\Commands;
 
-use App\Models\Trip;
 use App\Models\PolyLine;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 class CleanUpPolylines extends Command
 {
     protected $signature   = 'trwl:cleanUpPolylines';
-    protected $description = 'Delete unused and old polylines from database';
+    protected $description = 'Find and delete unused and old polylines from database';
 
     public function handle(): int {
-        $usedPolylineIds = Trip::where('polyline_id', '<>', null)->groupBy('polyline_id')->select('polyline_id');
-        $usedParentIds   = Polyline::where('parent_id', '<>', null)->groupBy('parent_id')->select('parent_id');
-        $affectedRows    = Polyline::whereNotIn('id', $usedPolylineIds)->whereNotIn('id', $usedParentIds)->delete();
-        Log::debug($affectedRows . ' unused polylines deleted.');
+        $start        = microtime(true);
+        $rows = DB::table('poly_lines')
+                          ->selectRaw('poly_lines.id, poly_lines.parent_id')
+                          ->leftJoin('hafas_trips', 'poly_lines.id', '=', 'hafas_trips.polyline_id')
+                          ->leftJoin(
+                              'poly_lines AS parent_poly_lines',
+                              'poly_lines.id',
+                              '=',
+                              'parent_poly_lines.parent_id'
+                          )
+                          ->whereRaw('hafas_trips.polyline_id IS NULL AND parent_poly_lines.parent_id IS NULL')
+                          ->get();
+        $this->info('Found ' . $rows->count() . ' unused polylines.');
+        $affectedRows = 0;
+
+        // get 100 rows at a time
+        foreach ($rows->chunk(100) as $chunk) {
+            $ids = $chunk->pluck('id')->toArray();
+            $affectedRows += PolyLine::whereIn('id', $ids)->delete();
+            $this->output->write('.');
+        }
+        $this->output->newLine();
+
+        $time_elapsed_secs = microtime(true) - $start;
+        Log::debug($affectedRows . ' unused polylines deleted in ' . $time_elapsed_secs . ' seconds.');
+        $this->info($affectedRows . ' unused polylines deleted in ' . $time_elapsed_secs . ' seconds.');
         return 0;
     }
 }


### PR DESCRIPTION
Chunk polyline cleanup to reduce table lock time.

Cuts down time __drastically__. Regular runtime ~1 hour. Now ~30 seconds:

<img width="863" alt="image" src="https://github.com/Traewelling/traewelling/assets/1267894/41a7f18c-71f0-4a0d-a6c5-f29e33fc5b7c">
 