### PR TITLE
⚡ Reduce time & strain on database whilst cleaning up

### DIFF
--- a/app/Console/Commands/CleanUpHafasTrips.php
+++ b/app/Console/Commands/CleanUpHafasTrips.php
@@ -5,16 +5,33 @@ namespace App\Console\Commands;
 use App\Models\Trip;
 use App\Models\Checkin;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 class CleanUpHafasTrips extends Command
 {
     protected $signature   = 'trwl:cleanUpHafasTrips';
-    protected $description = 'Delete unused and old Trips from database';
+    protected $description = 'Find and delete unused and old Trips from database';
 
     public function handle(): int {
-        $usedTripIds  = Checkin::groupBy('trip_id')->select('trip_id');
-        $affectedRows = Trip::whereNotIn('trip_id', $usedTripIds)->delete();
+        $affectedRows = 0;
+        $this->info('Deleting unused Trips...');
+        $this->output->writeln('');
+        do {
+            $result = DB::table('hafas_trips')
+                        ->leftJoin('train_checkins', 'hafas_trips.trip_id', '=', 'train_checkins.trip_id')
+                        ->whereNull('train_checkins.trip_id')
+                        ->limit(1000)
+                        ->delete();
+
+            if ($result > 0) {
+                $affectedRows += $result;
+                $this->output->write('.');
+            }
+        } while ($result > 0);
+        $this->output->writeln('');
+
+        $this->info($affectedRows . ' unused Trips deleted.');
         Log::debug($affectedRows . ' unused Trips deleted.');
         return 0;
     }

--- a/app/Console/Commands/CleanUpNotifications.php
+++ b/app/Console/Commands/CleanUpNotifications.php
@@ -13,8 +13,28 @@ class CleanUpNotifications extends Command
 
     public function handle(): int {
         $this->info("Removing old notifications...");
-        $affectedRows = DatabaseNotification::where('read_at', '<', now()->subDays(30))->delete();
+        $affectedRows = 0;
+        do {
+            $results = DatabaseNotification::where('read_at', '<', now()->subDays(30))->limit(1000)->delete();
+            $affectedRows += $results;
+            if ($results > 0) {
+                $this->output->write('.');
+            }
+        } while ($results > 0);
+        $this->output->writeln('');
         $this->info("Removed $affectedRows old and read notifications.");
+
+        $affectedRows = 0;
+        $this->output->writeln('');
+        do {
+            $results = DatabaseNotification::where('read_at', '<', now()->subMonths(6))->limit(1000)->delete();
+            if ($results > 0) {
+                $this->output->write('.');
+            }
+        } while ($results > 0);
+        $this->info("Removed $affectedRows old and unread notifications.");
+
+
         return Command::SUCCESS;
     }
 }

--- a/app/Console/Commands/CleanUpPasswordResets.php
+++ b/app/Console/Commands/CleanUpPasswordResets.php
@@ -12,9 +12,20 @@ class CleanUpPasswordResets extends Command
     protected $description = 'Delete expired password reset tokens';
 
     public function handle(): int {
-        $rowsAffected = DB::table('password_resets')
-                          ->where('created_at', '<', Carbon::now()->subHour()->toIso8601String())
-                          ->delete();
+        $this->info('Deleting expired password reset tokens...');
+        $this->output->writeln('');
+        $rowsAffected = 0;
+        do {
+            $result = DB::table('password_resets')
+                              ->where('created_at', '<', Carbon::now()->subHour()->toIso8601String())
+                              ->limit(1000)
+                              ->delete();
+            if ($rowsAffected > 0) {
+                $this->output->write('.');
+            }
+            $rowsAffected += $result;
+        } while ($result > 0);
+        $this->output->writeln('');
 
         $this->info('Deleted ' . $rowsAffected . ' expired password reset tokens');
         return 0;

--- a/app/Console/Commands/CleanUpUsers.php
+++ b/app/Console/Commands/CleanUpUsers.php
@@ -4,7 +4,6 @@ namespace App\Console\Commands;
 
 use App\Models\User;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
 
 class CleanUpUsers extends Command
 {
@@ -12,12 +11,21 @@ class CleanUpUsers extends Command
     protected $description = 'Delete users who have registered but have not agreed to the privacy policy';
 
     public function handle(): int {
-        $privacyUsers = User::where('privacy_ack_at', null)
-                            ->where('created_at', '<', now()->subDay())
-                            ->get();
-        foreach ($privacyUsers as $user) {
-            $user->delete();
-        }
+        $affectedRows = 0;
+        $this->info('Deleting users who have not agreed to the privacy policy...');
+        $this->output->writeln('');
+        do {
+            $result = User::where('privacy_ack_at', null)
+                                ->where('created_at', '<', now()->subDay())
+                                ->limit(1000)
+                                ->delete();
+            if ($result > 0) {
+                $affectedRows += $result;
+                $this->output->write('.');
+            }
+        } while ($result < 0);
+        $this->info($affectedRows . ' users deleted.');
+
         return 0;
     }
 }

--- a/app/Console/Commands/ClearDatabaseCache.php
+++ b/app/Console/Commands/ClearDatabaseCache.php
@@ -12,7 +12,19 @@ class ClearDatabaseCache extends Command
     protected $description = 'Clear the database cache and deletes expired cache keys';
 
     public function handle(): int {
-        $affectedRows = DB::table('cache')->where('expiration', '<', now()->timestamp)->delete();
+        $this->info('Clearing database cache...');
+        $this->output->writeln('');
+        $affectedRows = 0;
+        do {
+            $result = DB::table('cache')
+                        ->where('expiration', '<', now()->timestamp)
+                        ->limit(1000)
+                        ->delete();
+            if ($result > 0) {
+                $this->output->write('.');
+                $affectedRows += $result;
+            }
+        } while ($result > 0);
         $this->info("Deleted {$affectedRows} expired cache keys");
         return Command::SUCCESS;
     }


### PR DESCRIPTION
Limit delete requests to 1000 entries / request to reduce table lock size and runtime