### PR TITLE
:memo: Fix contributing.md link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ However, we welcome anyone who wants to contribute to the project!
 If you find a bug or have an idea for a new feature, please feel free to open an issue / discussion on GitHub.
 We also encourage you to help us out by fixing bugs and implementing new features yourself.
 
-Please see the [contributing guidelines](docs/CONTRIBUTING.md) for more information.
+Please see the [contributing guidelines](docs/contributing.md) for more information.
 
 ## License
 


### PR DESCRIPTION
Fixes the link to contributing.md so that it does not lead to a 404.

GitHub still recognises the file even if it is not uppercased.