### PR TITLE
:card_file_box: add index for `name`, `status` and `queue` on `queue_monitor`

### DIFF
--- a/database/migrations/2024_05_22_000005_add_index_name_status_queue_on_queue_monitor.php
+++ b/database/migrations/2024_05_22_000005_add_index_name_status_queue_on_queue_monitor.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+
+    public function up(): void {
+        Schema::table('queue_monitor', static function(Blueprint $table) {
+            $table->index(['name', 'status', 'queue']);
+        });
+    }
+
+    public function down(): void {
+        Schema::table('queue_monitor', static function(Blueprint $table) {
+            $table->dropIndex(['name', 'status', 'queue']);
+        });
+    }
+};


### PR DESCRIPTION
```
# Thread_id: 34524  Schema: traewelling  QC_hit: No
# Query_time: 0.319590  Lock_time: 0.000020  Rows_sent: 15  Rows_examined: 136305
# Rows_affected: 0  Bytes_sent: 0
# Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: 151968
# Full_scan: Yes  Full_join: No  Tmp_table: Yes  Tmp_table_on_disk: No
# Filesort: Yes  Filesort_on_disk: No  Merge_passes: 0  Priority_queue: No
#
# explain: id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
# explain: 1	SIMPLE	queue_monitor	ALL	NULL	NULL	NULL	NULL	128888	136275.00	100.00	100.00	Using temporary; Using filesort
#
SET timestamp=1716383614;
select count(*) AS total, name, status, queue from `queue_monitor` group by `name`, `status`, `queue`;
```