### PR TITLE
:children_crossing: allow searching for identifiers with 2 characters

### DIFF
--- a/resources/vue/components/StationAutocomplete.vue
+++ b/resources/vue/components/StationAutocomplete.vue
@@ -95,7 +95,7 @@ export default {
         },
         autocomplete() {
             this.loading = true;
-            if (!this.stationInput || this.stationInput.length < 3) {
+            if (!this.stationInput || this.stationInput.length < 2) {
                 this.autocompleteList = [];
                 this.loading          = false;
                 return;


### PR DESCRIPTION
fixes #2533