### PR TITLE
♻️ Adapt operator(s) endpoint to adhere to zalando convention

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -4,6 +4,10 @@ In this we try to keep track of changes to the API.
 Primarily this should document changes that are not backwards compatible or belongs to already documented endpoints.
 This is to help you keep track of the changes and to help you update your code accordingly.
 
+## 2024-06-01
+
+Changed `/operator` to `/operators`
+
 ## 2024-05-31
 
 The `StatusResource` is now returning the whole `UserResource` for the user who created it in the `userDetails` field.

--- a/app/Http/Controllers/API/v1/OperatorController.php
+++ b/app/Http/Controllers/API/v1/OperatorController.php
@@ -10,7 +10,7 @@ class OperatorController extends Controller
 {
     /**
      * @OA\Get(
-     *      path="/operator",
+     *      path="/operators",
      *      summary="Get a list of all operators.",
      *      tags={"Checkin"},
      *      @OA\Response(

--- a/routes/api.php
+++ b/routes/api.php
@@ -177,7 +177,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['return-json']], static functio
         Route::put('station/{oldStationId}/merge/{newStationId}', [StationController::class, 'merge']); // currently admin/backend only
 
         Route::apiResource('report', ReportController::class);
-        Route::apiResource('operator', OperatorController::class)->only(['index']);
+        Route::apiResource('operators', OperatorController::class)->only(['index']);
     });
 
     Route::group(['middleware' => ['privacy-policy']], static function() {

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1247,13 +1247,13 @@
                 ]
             }
         },
-        "/operator": {
+        "/operators": {
             "get": {
                 "tags": [
                     "Checkin"
                 ],
                 "summary": "Get a list of all operators.",
-                "operationId": "5e836fb23709a92be4c939e036765dbb",
+                "operationId": "bcfcf8686980cf0fcdc751b2e13fa4f7",
                 "responses": {
                     "200": {
                         "description": "successful operation",

--- a/tests/Feature/APIv1/OperatorTest.php
+++ b/tests/Feature/APIv1/OperatorTest.php
@@ -13,12 +13,12 @@ class OperatorTest extends ApiTestCase
 
     use RefreshDatabase;
 
-    public function testOperatorIndex(): void {
+    public function testOperatorsIndex(): void {
         Passport::actingAs(User::factory()->create(), ['*']);
 
         HafasOperator::factory()->count(3)->create();
 
-        $response = $this->get('/api/v1/operator');
+        $response = $this->get('/api/v1/operators');
         $response->assertOk();
         $response->assertJsonCount(3, 'data');
         $response->assertJsonStructure([


### PR DESCRIPTION
The endpoint `/operator` will be changed to `/operators`

> [!NOTE]
> The renamed endpoint was only set up yesterday, so it doesn't really affect anyone - unless you're really really early.