### PR TITLE
:children_crossing: update social post length to 500 chars

### DIFF
--- a/app/Http/Controllers/Backend/Helper/StatusHelper.php
+++ b/app/Http/Controllers/Backend/Helper/StatusHelper.php
@@ -66,9 +66,9 @@ class StatusHelper
             $body           = $this->mastodon ? $this->getMastodonBody() : $this->status->body;
             $appendix       = $this->generateAppendix();
             $appendixLength = strlen($appendix) + 30;
-            $postText       = substr($body, 0, 280 - $appendixLength);
+            $postText       = substr($body, 0, 500 - $appendixLength);
             if (strlen($postText) !== strlen($body)) {
-                $postText .= '...';
+                $postText .= '…';
             }
             $postText .= $appendix;
 


### PR DESCRIPTION
As Twitter social posting is not working anymore, the maximum post length can be upped to 500 chars, the default maximum length for a Mastodon post.
Also updated the `...` to a true unicode `…`, saving some more chars. 