### PR TITLE
🚑 Fix urlencoding in Hafas

### DIFF
--- a/app/Http/Controllers/HafasController.php
+++ b/app/Http/Controllers/HafasController.php
@@ -360,7 +360,7 @@ abstract class HafasController extends Controller
      * @throws HafasException|JsonException
      */
     public static function fetchRawHafasTrip(string $tripId, string $lineName) {
-        $tripResponse = self::getHttpClient()->get("trips/" . urlencode($tripId), [
+        $tripResponse = self::getHttpClient()->get("trips/" . rawurlencode($tripId), [
             'lineName'  => $lineName,
             'polyline'  => 'true',
             'stopovers' => 'true'
@@ -371,6 +371,7 @@ abstract class HafasController extends Controller
         }
         //sometimes HAFAS returnes 502 Bad Gateway
         if ($tripResponse->status() === 502) {
+            Log::error('Cannot fetch trip with id: ' . $tripId);
             throw new HafasException(__('messages.exception.hafas.502'));
         }
         Log::error('Unknown HAFAS Error (fetchRawHafasTrip)', [


### PR DESCRIPTION
Remove ++ and set %20.



For more context, see: https://stackoverflow.com/a/1634293/13310679 , https://www.php.net/manual/en/function.rawurlencode.php and https://www.php.net/manual/en/function.urlencode.php



> This differs from the [» RFC 3986](http://www.faqs.org/rfcs/rfc3986) encoding (see [rawurlencode()](https://www.php.net/manual/en/function.rawurlencode.php)) in that for historical reasons, spaces are encoded as plus (+) signs.This differs from the [» RFC 3986](http://www.faqs.org/rfcs/rfc3986) encoding (see [rawurlencode()](https://www.php.net/manual/en/function.rawurlencode.php)) in that for historical reasons, spaces are encoded as plus (+) signs.


