### PR TITLE
:bug: fix unexpected api behaviour due to nullable display names

### DIFF
--- a/database/migrations/2024_07_07_000000_make_display_name_not_nullable_at_users.php
+++ b/database/migrations/2024_07_07_000000_make_display_name_not_nullable_at_users.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void {
+        DB::table('users')
+          ->where('name', null)
+          ->update(['name' => DB::raw('username')]);
+
+        Schema::table('users', function(Blueprint $table) {
+            $table->string('name', 50)->nullable(false)->change();
+        });
+    }
+
+    public function down(): void {
+        Schema::table('users', function(Blueprint $table) {
+            $table->string('name')->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
reported by @marhei 

also set the max size of the column to the size we check via validator (50). I've checked that all users have <50 characters