### PR TITLE
⚖️ add ability to disallow manual trips

### DIFF
--- a/app/Http/Controllers/API/v1/TripController.php
+++ b/app/Http/Controllers/API/v1/TripController.php
@@ -32,7 +32,7 @@ class TripController extends Controller
      */
     public function createTrip(Request $request): TripResource|JsonResponse {
         if (!auth()->user()?->can('create-manual-trip')) {
-            return response()->json('This endpoint is currently only available for open-beta users (you can enable open beta in your settings).', 403);
+            return response()->json(['message' => 'This endpoint is currently only available for open-beta users (you can enable open beta in your settings).'], 403);
         }
         if (auth()->user()?->can('disallow-manual-trips')) {
             return response()->json(['message' => 'You are not allowed to create manual trips'], 403);

--- a/app/Http/Controllers/API/v1/TripController.php
+++ b/app/Http/Controllers/API/v1/TripController.php
@@ -10,7 +10,9 @@ use App\Http\Resources\TripResource;
 use App\Models\HafasOperator;
 use App\Models\Station;
 use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rules\Enum;
 
@@ -22,15 +24,18 @@ class TripController extends Controller
      *
      * @param Request $request
      *
-     * @return TripResource
+     * @return TripResource|Response
      *
      * @todo add docs
      * @todo currently the stations need to be in the database. We need to add a fallback to HAFAS.
      *       -> later solve the problem for non-existing stations
      */
-    public function createTrip(Request $request): TripResource {
+    public function createTrip(Request $request): TripResource|JsonResponse {
         if (!auth()->user()?->can('create-manual-trip')) {
-            abort(403, 'this endpoint is currently only available for beta users');
+            return response()->json('This endpoint is currently only available for open-beta users (you can enable open beta in your settings).', 403);
+        }
+        if (auth()->user()?->can('disallow-manual-trips')) {
+            return response()->json(['message' => 'You are not allowed to create manual trips'], 403);
         }
 
         $validated = $request->validate(

--- a/database/seeders/Constants/PermissionSeeder.php
+++ b/database/seeders/Constants/PermissionSeeder.php
@@ -14,25 +14,27 @@ class PermissionSeeder extends Seeder
 {
     public function run(): void {
         //Create roles
-        $roleAdmin          = Role::updateOrCreate(['name' => 'admin']);
-        $roleEventModerator = Role::updateOrCreate(['name' => 'event-moderator']);
-        $roleOpenBeta       = Role::updateOrCreate(['name' => 'open-beta']);
-        $roleClosedBeta     = Role::updateOrCreate(['name' => 'closed-beta']);
+        $roleAdmin               = Role::updateOrCreate(['name' => 'admin']);
+        $roleEventModerator      = Role::updateOrCreate(['name' => 'event-moderator']);
+        $roleOpenBeta            = Role::updateOrCreate(['name' => 'open-beta']);
+        $roleClosedBeta          = Role::updateOrCreate(['name' => 'closed-beta']);
+        $roleDisallowManualTrips = Role::updateOrCreate(['name' => 'disallow-manual-trips']);
 
         //Create permissions
-        $permissionViewBackend      = Permission::updateOrCreate(['name' => 'view-backend']);
-        $permissionViewEvents       = Permission::updateOrCreate(['name' => 'view-events']);
-        $permissionAcceptEvents     = Permission::updateOrCreate(['name' => 'accept-events']);
-        $permissionDenyEvents       = Permission::updateOrCreate(['name' => 'deny-events']);
-        $permissionCreateEvents     = Permission::updateOrCreate(['name' => 'create-events']);
-        $permissionUpdateEvents     = Permission::updateOrCreate(['name' => 'update-events']);
-        $permissionDeleteEvents     = Permission::updateOrCreate(['name' => 'delete-events']);
-        $permissionCreateManualTrip = Permission::updateOrCreate(['name' => 'create-manual-trip']);
-        $permissionViewActivity     = Permission::updateOrCreate(['name' => 'view activity']);
-        $permissionViewEventHistory = Permission::updateOrCreate(['name' => 'view event history']);
-        $permissionCreateStations   = Permission::updateOrCreate(['name' => 'create stations']);
-        $permissionUpdateStations   = Permission::updateOrCreate(['name' => 'update stations']);
-        $permissionDeleteStations   = Permission::updateOrCreate(['name' => 'delete stations']);
+        $permissionViewBackend         = Permission::updateOrCreate(['name' => 'view-backend']);
+        $permissionViewEvents          = Permission::updateOrCreate(['name' => 'view-events']);
+        $permissionAcceptEvents        = Permission::updateOrCreate(['name' => 'accept-events']);
+        $permissionDenyEvents          = Permission::updateOrCreate(['name' => 'deny-events']);
+        $permissionCreateEvents        = Permission::updateOrCreate(['name' => 'create-events']);
+        $permissionUpdateEvents        = Permission::updateOrCreate(['name' => 'update-events']);
+        $permissionDeleteEvents        = Permission::updateOrCreate(['name' => 'delete-events']);
+        $permissionCreateManualTrip    = Permission::updateOrCreate(['name' => 'create-manual-trip']);
+        $permissionViewActivity        = Permission::updateOrCreate(['name' => 'view activity']);
+        $permissionViewEventHistory    = Permission::updateOrCreate(['name' => 'view event history']);
+        $permissionCreateStations      = Permission::updateOrCreate(['name' => 'create stations']);
+        $permissionUpdateStations      = Permission::updateOrCreate(['name' => 'update stations']);
+        $permissionDeleteStations      = Permission::updateOrCreate(['name' => 'delete stations']);
+        $permissionDisallowManualTrips = Permission::updateOrCreate(['name' => 'disallow-manual-trips']);
 
         //Assign permissions to admin role
         $roleAdmin->givePermissionTo($permissionViewBackend);
@@ -48,6 +50,7 @@ class PermissionSeeder extends Seeder
         $roleAdmin->givePermissionTo($permissionCreateStations);
         $roleAdmin->givePermissionTo($permissionUpdateStations);
         $roleAdmin->givePermissionTo($permissionDeleteStations);
+        $roleDisallowManualTrips->givePermissionTo($permissionDisallowManualTrips);
 
         //Assign permissions to event-moderator role
         $roleEventModerator->givePermissionTo($permissionViewBackend);

--- a/resources/views/vuestationboard.blade.php
+++ b/resources/views/vuestationboard.blade.php
@@ -8,7 +8,7 @@
             <div class="col-md-8 col-lg-7" id="station-board-new">
                 <Stationboard></Stationboard>
 
-                @if(auth()->user()->hasRole('open-beta'))
+                @if(auth()->user()->hasRole('open-beta') && !auth()->user()->can('disallow-manual-trips'))
                     <div class="text-center mt-4">
                         <hr/>
                         <p>

--- a/resources/vue/components/TripCreation/TripCreationForm.vue
+++ b/resources/vue/components/TripCreation/TripCreationForm.vue
@@ -102,7 +102,7 @@ export default {
 
                         window.location.href = `/stationboard?${new URLSearchParams(query).toString()}`;
                     });
-                } else if (data.status === 422) {
+                } else if (data.status === 403 || data.status === 422) {
                     data.json().then((result) => {
                         alert(result.message);
                     });


### PR DESCRIPTION
Unfortunately, I don't like it either, but since some users do not adhere to the rules even after repeated references to the community guidelines, we unfortunately have to intervene in some places and need an additional role here that allows us to prevent the creation of manual journeys.