### PR TITLE
🚸 Move regionalExp to the group of long-distance-trains

### DIFF
--- a/app/Enum/HafasTravelType.php
+++ b/app/Enum/HafasTravelType.php
@@ -29,16 +29,17 @@ enum HafasTravelType: string
 
     public function getEmoji(): string {
         return match ($this->value) {
-            'nationalExpress', 'national' => '🚄',
-            'regionalExp', 'regional'     => '🚆',
-            'suburban'                    => '🚋',
-            'bus'                         => '🚌',
-            'ferry'                       => '⛴',
-            'subway'                      => '🚇',
-            'tram'                        => '🚊',
-            'taxi'                        => '🚖',
-            'plane'                       => '✈️',
-            default                       => '',
+            'nationalExpress'         => '🚄',
+            'regionalExp', 'national' => '🚆',
+            'regional'                => '🚞',
+            'suburban'                => '🚋',
+            'bus'                     => '🚌',
+            'ferry'                   => '⛴',
+            'subway'                  => '🚇',
+            'tram'                    => '🚊',
+            'taxi'                    => '🚖',
+            'plane'                   => '✈️',
+            default                   => '',
         };
     }
 

--- a/config/trwl.php
+++ b/config/trwl.php
@@ -38,10 +38,9 @@ return [
             'subway'          => env('BASE_POINTS_TRAIN_SUBWAY', 2),
             'suburban'        => env('BASE_POINTS_TRAIN_SUBURBAN', 3),
             'ferry'           => env('BASE_POINTS_TRAIN_FERRY', 3),
-            'regional'        => env('BASE_POINTS_TRAIN_REGIONAL', 5),
-            'regionalExp'     => env('BASE_POINTS_TRAIN_REGIONALEXP', 6),
-            'express'         => env('BASE_POINTS_TRAIN_EXPRESS', 10),
-            'national'        => env('BASE_POINTS_TRAIN_NATIONAL', 10),
+            'regional'        => env('BASE_POINTS_TRAIN_REGIONAL', 6),
+            'regionalExp'     => env('BASE_POINTS_TRAIN_REGIONALEXP', 8),
+            'national'        => env('BASE_POINTS_TRAIN_NATIONAL', 8),
             'nationalExpress' => env('BASE_POINTS_TRAIN_NATIONALEXPRESS', 10),
         ]
     ],

--- a/tests/Unit/Transport/PointsCalculationTest.php
+++ b/tests/Unit/Transport/PointsCalculationTest.php
@@ -68,8 +68,8 @@ class PointsCalculationTest extends UnitTestCase
             '50km in an IC/ICE => 50/10 + 10 = 15 points'                      => [
                 15, HafasTravelType::NATIONAL_EXPRESS, now()->subMinutes(2), now()->addMinutes(10), TripSource::HAFAS
             ],
-            '50km in an RB => 50/10 + 5 = 10 points'                           => [
-                10, HafasTravelType::REGIONAL, now()->subMinutes(2), now()->addMinutes(10), TripSource::HAFAS
+            '50km in an RB => 50/10 + 6 = 11 points'                           => [
+                11, HafasTravelType::REGIONAL, now()->subMinutes(2), now()->addMinutes(10), TripSource::HAFAS
             ],
             '18km in a Bus => 20/10 + 2 = 4 points'                            => [
                 7, HafasTravelType::BUS, now()->subMinutes(2), now()->addMinutes(10), TripSource::HAFAS


### PR DESCRIPTION
We've been doing it wrong for way too many years and I'm sick of it.

regionalExp is NOT the category for RE, IRE, etc (looking at you DB-Rest 👀)

It's simply the category for [long-distance trains / D-Trains](https://en.wikipedia.org/wiki/Schnellzug) like Flix-Train, Westbahn, etc.

If you look at stations that ONLY run regional transport, you'll see a `"regionalExp": false`
![Screenshot 2024-07-24 at 23 11 21](https://github.com/user-attachments/assets/5cdb7681-02e9-40bc-80af-df87f88c94b9)


WB:
![Screenshot 2024-07-24 at 23 09 17](https://github.com/user-attachments/assets/e703e7bd-8e2a-46f3-9f43-d2c5227d28c5)
FLX:
![Screenshot 2024-07-24 at 23 09 55](https://github.com/user-attachments/assets/87986e1f-e8d1-48ef-b953-8e11740d8787)

