### PR TITLE
:technologist: unpaginate trusted users endpoint

### DIFF
--- a/app/Http/Controllers/API/v1/TrustedUserController.php
+++ b/app/Http/Controllers/API/v1/TrustedUserController.php
@@ -25,9 +25,9 @@ class TrustedUserController extends Controller
      *     tags={"User"},
      *     @OA\Parameter(name="user", in="path", required=true, description="ID of the user (or string 'self' for current user)", @OA\Schema(type="string")),
      *     @OA\Response(response="200", description="List of trusted users",
-     *           @OA\JsonContent(
-     *               @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/TrustedUserResource")),
-     *           )
+     *          @OA\JsonContent(
+     *              @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/TrustedUserResource")),
+     *          )
      *     ),
      *     @OA\Response(response="401", description="Unauthorized"),
      *     @OA\Response(response="403", description="Forbidden"),
@@ -39,7 +39,7 @@ class TrustedUserController extends Controller
     public function index(string|int $userIdOrSelf): AnonymousResourceCollection {
         $user = $this->getUserOrSelf($userIdOrSelf);
         $this->authorize('update', $user);
-        return TrustedUserResource::collection($user->trustedUsers()->orderBy('trusted_id')->cursorPaginate(10));
+        return TrustedUserResource::collection($user->trustedUsers);
     }
 
     /**

--- a/tests/Feature/APIv1/TrustedUserTest.php
+++ b/tests/Feature/APIv1/TrustedUserTest.php
@@ -14,7 +14,7 @@ class TrustedUserTest extends ApiTestCase
 
     use RefreshDatabase;
 
-    public function testListPagination(): void {
+    public function testList(): void {
         $user        = User::factory()->create();
         $trustedUser = User::factory()->count(12)->create();
         $this->actAsApiUserWithAllScopes($user);
@@ -27,21 +27,12 @@ class TrustedUserTest extends ApiTestCase
         // list trusted users
         $response = $this->getJson("/api/v1/user/self/trusted");
         $response->assertOk();
-        $response->assertJsonCount(10, 'data');
+        $response->assertJsonCount(12, 'data');
         $response->assertJsonStructure([
                                            'data',
-                                           'links' => ['first', 'last', 'prev', 'next'],
-                                           'meta'  => ['path', 'per_page', 'next_cursor', 'prev_cursor'],
                                        ]);
-
-        //try next cursor
-        $nextCursorResponse = $this->getJson($response->json('links.next'));
-        $nextCursorResponse->assertOk();
-
-        $nextCursorResponse->dump();
-        //TODO: why isn't the cursor working? Every request is showing from the beginning.
     }
-    
+
     public function testIndexTrustedByUsers(): void {
         $user = User::factory()->create();
         $this->actAsApiUserWithAllScopes($user);


### PR DESCRIPTION
> [!CAUTION]
> possible breaking change, if you've already implemented trusted users in your application

The endpoint `/user/{self/userId}/trusted` will be NOT-paginated from the next release. As this endpoint is new, I think this change can be made without problems. The structure itself won't change. Only the pagination is no longer available and all users will be printed with one request.

(notification for api users in https://github.com/Traewelling/traewelling/discussions/2806#discussioncomment-10274281)