### PR TITLE
🐛 fix docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,7 +23,7 @@ else
 
         echo "Running as app..."
 
-        if [ ${SEED_DB} == "true" ]; then
+        if [ "${SEED_DB}" = "true" ]; then
             echo "Resetting OAuth keys and seeding database"
             runuser -u www-data -- php artisan migrate:fresh --seed --force
             runuser -u www-data -- php artisan passport:install --force --quiet --no-interaction


### PR DESCRIPTION
I tried to get the docker setup running. I noticed that container create an error message if the `SEED_DB` is not set (which it isnt by the default docker-compose.yml).

The Resulting error message looks like this:
```
/var/www/html/docker-entrypoint.sh: line 26: [: ==: unary operator expected
```

It seems like the script continues in the else case of that if because `/bin/[` returns an non zero exit code. So there is no unexpected behaviour. Just an error message, that does not need to be.