### PR TITLE
✨Show correct event date, Add data on event page

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -31,6 +31,8 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property int     totalDistance
  * @property int     totalDuration
  * @property bool    isPride
+ * @property Carbon  start         Timestamp of event starts (returns event_start or checkin_start)
+ * @property Carbon  end           Timestamp of event ends (returns event_end or checkin_end)
  */
 class Event extends Model
 {
@@ -78,6 +80,14 @@ class Event extends Model
     public function getIsPrideAttribute(): bool {
         $eventNameLowercase = strtolower($this->name);
         return Str::contains($eventNameLowercase, ['csd', 'pride']);
+    }
+
+    public function getStartAttribute(): Carbon {
+        return $this->event_start?$this->event_start:$this->checkin_start;
+    }
+
+    public function getEndAttribute(): Carbon {
+        return $this->event_end?$this->event_end:$this->checkin_end;
     }
 
     public function approvedBy(): HasOne {

--- a/lang/de.json
+++ b/lang/de.json
@@ -653,6 +653,7 @@
     "delete": "Löschen",
     "active-tokens-count": ":count aktive Token|:count aktive Tokens",
     "user.blocked.text": "Du kannst die Check-ins von :username nicht sehen, da du den Nutzer blockiert hast.",
+    "events.disclaimer.extendedcheckin": "Erweiterter Zeitraum für Checkin vorhanden.",
     "events.disclaimer.organizer": "Träwelling ist nicht der Veranstalter.",
     "events.disclaimer.source": "Diese Veranstaltung wurde von einem Träwelling User vorgeschlagen und durch uns genehmigt.",
     "events.disclaimer.warranty": "Träwelling übernimmt keine Gewähr auf die Korrektheit oder Vollständigkeit der Daten.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -656,6 +656,7 @@
     "delete": "Delete",
     "active-tokens-count": ":count active token|:count active tokens",
     "settings.profilePicture.deleted": "Your profile picture was deleted successfully.",
+    "events.disclaimer.extendedcheckin": "You have an extended check-in timespan.",
     "events.disclaimer.organizer": "Träwelling is not the organizer.",
     "events.disclaimer.source": "This event was suggested by a Träwelling user and approved by us.",
     "events.disclaimer.warranty": "Träwelling does not guarantee the correctness or completeness of the data.",

--- a/resources/views/events/overview.blade.php
+++ b/resources/views/events/overview.blade.php
@@ -40,11 +40,14 @@
                                                     @endisset
                                                 </td>
                                                 <td>
-                                                    @if($event->checkin_start->isSameDay($event->end))
-                                                        {{$event->checkin_start->format('d.m.Y')}}
+                                                    @if($event->start->isSameDay($event->end))
+                                                        {{$event->start->format('d.m.Y')}}
                                                     @else
-                                                        {{$event->checkin_start->format('d.m.Y')}}
-                                                        - {{$event->checkin_end->format('d.m.Y')}}
+                                                        {{$event->start->format('d.m.Y')}}
+                                                        - {{$event->end->format('d.m.Y')}}
+                                                    @endif
+                                                    @if($event->event_start || $event->event_end)
+                                                        *
                                                     @endif
                                                 </td>
                                                 <td>
@@ -60,6 +63,9 @@
                                 </table>
                             </div>
                             {{$liveAndUpcomingEvents->links()}}
+                            <small class="text-muted">
+                                <sup>*</sup> {{__('events.disclaimer.extendedcheckin')}}
+                            </small>
                         @endif
                     </div>
                 </div>

--- a/resources/views/eventsMap.blade.php
+++ b/resources/views/eventsMap.blade.php
@@ -17,6 +17,14 @@
                         </strong>
                     </h1>
                     <h2 class="h2-responsive">
+                        @if($event->start->isSameDay($event->end))
+                            {{$event->start->format('d.m.Y')}}
+                        @else
+                            {{$event->start->format('d.m.Y')}}
+                            - {{$event->end->format('d.m.Y')}}
+                        @endif
+                    </h2>
+                    <h2 class="h2-responsive">
                         <span class="font-weight-bold">
                             <i class="fa fa-route d-inline"></i>
                             {{ number($event->totalDistance / 1000, 0) }}


### PR DESCRIPTION
- Show correct date of event if there is an extended timespan for checkin
- Now show date only if event is only one day
- add date of event on detail page