### PR TITLE
:passport_control: add role `deactivate-account-usage`

### DIFF
--- a/app/Http/Controllers/API/v1/FollowController.php
+++ b/app/Http/Controllers/API/v1/FollowController.php
@@ -54,6 +54,7 @@ class FollowController extends Controller
      */
     public function createFollow(int $userId): JsonResponse {
         try {
+            $this->authorize('create', Follow::class);
             $userToFollow         = User::findOrFail($userId);
             $createFollowResponse = FollowBackend::createOrRequestFollow(Auth::user(), $userToFollow);
             return $this->sendResponse(new UserResource($createFollowResponse), 201);

--- a/app/Http/Controllers/API/v1/LikesController.php
+++ b/app/Http/Controllers/API/v1/LikesController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API\v1;
 use App\Exceptions\StatusAlreadyLikedException;
 use App\Http\Controllers\StatusController as StatusBackend;
 use App\Http\Resources\UserResource;
+use App\Models\Like;
 use App\Models\Status;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -104,6 +105,7 @@ class LikesController extends Controller
      */
     public function create(int $statusId): JsonResponse {
         try {
+            $this->authorize('create', Like::class);
             $status = Status::findOrFail($statusId);
             StatusBackend::createLike(Auth::user(), $status);
             return $this->sendResponse(

--- a/app/Http/Controllers/API/v1/StatusController.php
+++ b/app/Http/Controllers/API/v1/StatusController.php
@@ -418,6 +418,11 @@ class StatusController extends Controller
             $status = Status::findOrFail($statusId);
             $this->authorize('update', $status);
 
+            //Check for disallowed status visibility changes
+            if(auth()->user()->can('disallow-status-visibility-change') && $validated['visibility'] !== StatusVisibility::PRIVATE->value) {
+                return $this->sendError('You are not allowed to change the visibility to anything else than private', 403);
+            }
+
             if (isset($validated['destinationId'], $validated['destinationArrivalPlanned'])
                 && ((int) $validated['destinationId']) !== $status->checkin->destinationStopover->station->id) {
                 $arrival  = Carbon::parse($validated['destinationArrivalPlanned'])->timezone(config('app.timezone'));

--- a/app/Http/Controllers/API/v1/TransportController.php
+++ b/app/Http/Controllers/API/v1/TransportController.php
@@ -19,6 +19,7 @@ use App\Http\Resources\StationResource;
 use App\Http\Resources\TripResource;
 use App\Hydrators\CheckinRequestHydrator;
 use App\Models\Station;
+use App\Models\Status;
 use App\Models\User;
 use App\Notifications\YouHaveBeenCheckedIn;
 use Carbon\Carbon;
@@ -355,6 +356,8 @@ class TransportController extends Controller
      * @return JsonResponse
      */
     public function create(Request $request): JsonResponse {
+        $this->authorize('create', Status::class);
+
         $validated = $request->validate([
                                             'body'        => ['nullable', 'max:280'],
                                             'business'    => ['nullable', new Enum(Business::class)],

--- a/app/Http/Controllers/FrontendUserController.php
+++ b/app/Http/Controllers/FrontendUserController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Exceptions\AlreadyFollowingException;
 use App\Http\Controllers\Backend\UserController as UserControllerAlias;
 use App\Http\Controllers\UserController as UserBackend;
+use App\Models\Follow;
 use App\Models\User;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Support\Renderable;
@@ -49,6 +50,7 @@ class FrontendUserController extends Controller
         $userToFollow = User::find($validated['follow_id']);
 
         try {
+            $this->authorize('create', Follow::class);
             $createFollowResponse = UserBackend::createFollow(Auth::user(), $userToFollow);
         } catch (AlreadyFollowingException) {
             return response()->json(['message' => __('controller.user.follow-error')], 409);

--- a/app/Policies/LikePolicy.php
+++ b/app/Policies/LikePolicy.php
@@ -6,15 +6,11 @@ use App\Models\Follow;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
-class FollowPolicy
+class LikePolicy
 {
     use HandlesAuthorization;
 
     public function create(User $user): bool {
         return $user->cannot('disallow-social-interaction');
-    }
-
-    public function delete(User $user, Follow $follow): bool {
-        return $user->id == $follow->follow_id;
     }
 }

--- a/app/Policies/StatusPolicy.php
+++ b/app/Policies/StatusPolicy.php
@@ -73,6 +73,10 @@ class StatusPolicy
         return Response::deny('Congratulations! You\'ve found an edge-case!');
     }
 
+    public function create(User $user): bool {
+        return $user->cannot('disallow-status-creation');
+    }
+
     /**
      * Determine whether the user can update the model.
      *

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -6,12 +6,14 @@ use App\Http\Controllers\Backend\Auth\AccessTokenController;
 use App\Http\Controllers\Backend\Auth\ApproveAuthorizationController;
 use App\Http\Controllers\Backend\Auth\AuthorizationController;
 use App\Models\Follow;
+use App\Models\Like;
 use App\Models\OAuthClient;
 use App\Models\Status;
 use App\Models\StatusTag;
 use App\Models\User;
 use App\Models\Webhook;
 use App\Policies\FollowPolicy;
+use App\Policies\LikePolicy;
 use App\Policies\StatusPolicy;
 use App\Policies\StatusTagPolicy;
 use App\Policies\TokenPolicy;
@@ -33,6 +35,7 @@ class AuthServiceProvider extends ServiceProvider
         Status::class    => StatusPolicy::class,
         User::class      => UserPolicy::class,
         Follow::class    => FollowPolicy::class,
+        Like::class      => LikePolicy::class,
         Webhook::class   => WebhookPolicy::class,
         StatusTag::class => StatusTagPolicy::class,
         Token::class     => TokenPolicy::class,

--- a/database/seeders/Constants/PermissionSeeder.php
+++ b/database/seeders/Constants/PermissionSeeder.php
@@ -14,27 +14,31 @@ class PermissionSeeder extends Seeder
 {
     public function run(): void {
         //Create roles
-        $roleAdmin               = Role::updateOrCreate(['name' => 'admin']);
-        $roleEventModerator      = Role::updateOrCreate(['name' => 'event-moderator']);
-        $roleOpenBeta            = Role::updateOrCreate(['name' => 'open-beta']);
-        $roleClosedBeta          = Role::updateOrCreate(['name' => 'closed-beta']);
-        $roleDisallowManualTrips = Role::updateOrCreate(['name' => 'disallow-manual-trips']);
+        $roleAdmin                  = Role::updateOrCreate(['name' => 'admin']);
+        $roleEventModerator         = Role::updateOrCreate(['name' => 'event-moderator']);
+        $roleOpenBeta               = Role::updateOrCreate(['name' => 'open-beta']);
+        $roleClosedBeta             = Role::updateOrCreate(['name' => 'closed-beta']);
+        $roleDisallowManualTrips    = Role::updateOrCreate(['name' => 'disallow-manual-trips']);
+        $roleDeactivateAccountUsage = Role::updateOrCreate(['name' => 'deactivate-account-usage']);
 
         //Create permissions
-        $permissionViewBackend         = Permission::updateOrCreate(['name' => 'view-backend']);
-        $permissionViewEvents          = Permission::updateOrCreate(['name' => 'view-events']);
-        $permissionAcceptEvents        = Permission::updateOrCreate(['name' => 'accept-events']);
-        $permissionDenyEvents          = Permission::updateOrCreate(['name' => 'deny-events']);
-        $permissionCreateEvents        = Permission::updateOrCreate(['name' => 'create-events']);
-        $permissionUpdateEvents        = Permission::updateOrCreate(['name' => 'update-events']);
-        $permissionDeleteEvents        = Permission::updateOrCreate(['name' => 'delete-events']);
-        $permissionCreateManualTrip    = Permission::updateOrCreate(['name' => 'create-manual-trip']);
-        $permissionViewActivity        = Permission::updateOrCreate(['name' => 'view activity']);
-        $permissionViewEventHistory    = Permission::updateOrCreate(['name' => 'view event history']);
-        $permissionCreateStations      = Permission::updateOrCreate(['name' => 'create stations']);
-        $permissionUpdateStations      = Permission::updateOrCreate(['name' => 'update stations']);
-        $permissionDeleteStations      = Permission::updateOrCreate(['name' => 'delete stations']);
-        $permissionDisallowManualTrips = Permission::updateOrCreate(['name' => 'disallow-manual-trips']);
+        $permissionViewBackend                    = Permission::updateOrCreate(['name' => 'view-backend']);
+        $permissionViewEvents                     = Permission::updateOrCreate(['name' => 'view-events']);
+        $permissionAcceptEvents                   = Permission::updateOrCreate(['name' => 'accept-events']);
+        $permissionDenyEvents                     = Permission::updateOrCreate(['name' => 'deny-events']);
+        $permissionCreateEvents                   = Permission::updateOrCreate(['name' => 'create-events']);
+        $permissionUpdateEvents                   = Permission::updateOrCreate(['name' => 'update-events']);
+        $permissionDeleteEvents                   = Permission::updateOrCreate(['name' => 'delete-events']);
+        $permissionCreateManualTrip               = Permission::updateOrCreate(['name' => 'create-manual-trip']);
+        $permissionViewActivity                   = Permission::updateOrCreate(['name' => 'view activity']);
+        $permissionViewEventHistory               = Permission::updateOrCreate(['name' => 'view event history']);
+        $permissionCreateStations                 = Permission::updateOrCreate(['name' => 'create stations']);
+        $permissionUpdateStations                 = Permission::updateOrCreate(['name' => 'update stations']);
+        $permissionDeleteStations                 = Permission::updateOrCreate(['name' => 'delete stations']);
+        $permissionDisallowManualTrips            = Permission::updateOrCreate(['name' => 'disallow-manual-trips']);
+        $permissionDisallowStatusCreation         = Permission::updateOrCreate(['name' => 'disallow-status-creation']);
+        $permissionDisallowStatusVisibilityChange = Permission::updateOrCreate(['name' => 'disallow-status-visibility-change']);
+        $permissionDisallowSocialInteraction      = Permission::updateOrCreate(['name' => 'disallow-social-interaction']);
 
         //Assign permissions to admin role
         $roleAdmin->givePermissionTo($permissionViewBackend);
@@ -50,7 +54,15 @@ class PermissionSeeder extends Seeder
         $roleAdmin->givePermissionTo($permissionCreateStations);
         $roleAdmin->givePermissionTo($permissionUpdateStations);
         $roleAdmin->givePermissionTo($permissionDeleteStations);
+
+        //Assign permissions to disallow-manual-trips role
         $roleDisallowManualTrips->givePermissionTo($permissionDisallowManualTrips);
+
+        //Assign permissions to deactivate-account-usage role
+        $roleDeactivateAccountUsage->givePermissionTo($permissionDisallowManualTrips);
+        $roleDeactivateAccountUsage->givePermissionTo($permissionDisallowStatusCreation);
+        $roleDeactivateAccountUsage->givePermissionTo($permissionDisallowStatusVisibilityChange);
+        $roleDeactivateAccountUsage->givePermissionTo($permissionDisallowSocialInteraction);
 
         //Assign permissions to event-moderator role
         $roleEventModerator->givePermissionTo($permissionViewBackend);


### PR DESCRIPTION
With the new role `deactivate-account-usage` we can now:

- disallow the creation of manual trips
- disallow the creation of checkins/statuses
- disallow the updating of non-private statuses (user can still set existing statuses to private)
- disallow social interaction (following, liking)

This role is a step we don't want to take, but we have to. We actually want to intervene as little as possible in users' accounts, but the past has shown that this is unfortunately sometimes necessary. We try to use this intervention as rarely as possible and use less stringent interventions first.

Deactivating the basic account functions represents the greatest possible restriction for us before deleting user accounts.