### PR TITLE
feat(ui): add _Update Station Wikidata_ button

### DIFF
--- a/app/Http/Controllers/API/v1/ExperimentalController.php
+++ b/app/Http/Controllers/API/v1/ExperimentalController.php
@@ -23,8 +23,10 @@ class ExperimentalController extends Controller
             return response()->json(['error' => 'This station was already requested recently. Please try again later.'], 429);
         }
 
+        $allowUpdate = request()->boolean('allowUpdate');
+        // TODO: there will be an error when updating non-exsiting stations.
         $station = Station::findOrFail($stationId);
-        if ($station->wikidata_id) {
+        if ($station->wikidata_id && !$allowUpdate) {
             return response()->json(['error' => 'This station already has a wikidata id.'], 400);
         }
 

--- a/resources/views/includes/station-infos.blade.php
+++ b/resources/views/includes/station-infos.blade.php
@@ -96,20 +96,50 @@
                     </table>
 
                     <div class="mx-4 mb-3">
-                        <a href="https://www.wikidata.org/wiki/{{ $station->wikidata_id }}"
-                           target="_blank"
-                           class="btn btn-sm btn-outline-secondary float-end">
-                            <i class="fa-solid fa-edit"></i>
-                            Bearbeiten
-                        </a>
-
                         <small>
                             Fehler gefunden? Auf Wikidata bearbeiten!
                             Derzeit aktualisieren wir die Daten von Wikidata nur sehr unregelmäßig.
                             Es kann daher lange dauern, bis deine Änderungen hier angezeigt
                             werden.
                         </small>
+                        <div>
+                            <a href="https://www.wikidata.org/wiki/{{ $station->wikidata_id }}"
+                               target="_blank"
+                               class="btn btn-sm btn-outline-secondary">
+                                <i class="fa-solid fa-edit"></i>
+                                Bearbeiten
+                            </a>
+                            <button class="btn btn-sm btn-outline-secondary" title="Neue Daten von Wikidata fetchen und damit die lokalen Daten hier aktualisieren." onclick="fetchWikidata({{$station->id}})">
+                                <i class="fa-solid fa-edit"></i>
+                                Stationsdaten refreshen
+                            </button>
+                        </div>
                     </div>
+
+                <script>
+                    // TODO: prevent duplicate code with `wikidata/index.blade.php` (by adding a `allowUpdate` parameter)
+                    function fetchWikidata(stationId) {
+                        console.log('Fetching Wikidata for station ' + stationId);
+                        fetch('/api/v1/experimental/station/' + stationId + '/wikidata?allowUpdate=1', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                            }
+                        })
+                            .then(response => response.json())
+                            .then(data => {
+                                console.log('wikidata result:', data);
+                                if (data.error) {
+                                    notyf.error(data.error || 'Error fetching Wikidata');
+                                } else {
+                                    notyf.success(data.message || 'Wikidata fetched');
+                                    document.getElementById('station-' + stationId).remove();
+                                }
+                            })
+                            .catch(error => notyf.error(error || 'Error during Wikidata fetch'))
+                    }
+                </script>
                 @else
                     <div class="mx-4 mb-3">
                         <p>


### PR DESCRIPTION
This PR aims to help with updating existing station information. If there is new data in Wikidata, there is no way of updating this data in the (normal) user UI.

Solution/idea:
This PR adds another button with the ability to re-fetch and update the station information with new data from Wikidata.


To achieve this the GET parameter `allowUpdate` (`boolean`) was added to the `POST /api/v1/experimental/wikidata?allowUpdate=1` endpoint. This parameter prevents the early exit (because the `wikidata_id` already exists) and so `WikidataImportService::searchStation` is invoked, which updates the Station database with fresh data from Wikidata.

I could locally test this feature successfully.

There are some more questions:

- is this feature (request) useful? (if not, just stop reading and close the PR)
- is a GET parameter the correct choice here? (or would another endpoint suit better)
   - is the name `allowUpdate` alright?
- is the `allowUpdate` parameter even required or can it's behaviour be the default?
- what is the best way to prevent code duplication for the JS function `fetchWikidata` (and where to put it then)?

I'm looking forward for some input. This PR could be a starting point, it this feature is desired and I would be open to work it, if desired.