### PR TITLE
🚸 Indicate, which departures have live data and which don't

### DIFF
--- a/resources/vue/components/Checkin/StationBoardEntry.vue
+++ b/resources/vue/components/Checkin/StationBoardEntry.vue
@@ -35,6 +35,21 @@ export default defineComponent({
         },
         cancelled(): boolean {
             return this.item.cancelled || false;
+        },
+        delayClass(): string {
+            if (this.item.delay === null) {
+                return '';
+            }
+
+            let color = 'text-success';
+
+            if (this.item.delay > 300) {
+                color = 'text-danger';
+            } else if (this.item.delay >= 60) {
+                color = 'text-warning';
+            }
+
+            return color;
         }
     },
 })
@@ -66,10 +81,10 @@ export default defineComponent({
                     <span class="text-muted text-decoration-line-through">
                         {{ formatTime(item.plannedWhen) }}<br>
                     </span>
-                    <span>{{ formatTime(item.when) }}</span>
+                    <span :class="delayClass">{{ formatTime(item.when) }}</span>
                 </div>
                 <div v-else>
-                    <span>{{ formatTime(item.plannedWhen) }}</span>
+                    <span :class="delayClass">{{ formatTime(item.plannedWhen) }}</span>
                 </div>
             </div>
         </div>
@@ -79,6 +94,7 @@ export default defineComponent({
 
 <style scoped lang="scss">
 @import "../../../sass/_variables.scss";
+
 .dep-card {
     min-height: 4.25rem;
 }


### PR DESCRIPTION
Green = <= 60 Seconds
Yellow = <= 300 Seconds
Red = >60 Seconds
Gray = no live data

![Screenshot 2024-11-20 at 22 20 06](https://github.com/user-attachments/assets/b1965c59-a8b2-40f6-a535-8323bf962881)

Closes #2916
