### PR TITLE
:sparkles: add page for information about trips

### DIFF
--- a/app/Http/Controllers/FrontendTransportController.php
+++ b/app/Http/Controllers/FrontendTransportController.php
@@ -5,7 +5,9 @@ namespace App\Http\Controllers;
 use App\DataProviders\Hafas;
 use App\Exceptions\HafasException;
 use App\Http\Controllers\TransportController as TransportBackend;
+use App\Models\Trip;
 use Illuminate\Http\JsonResponse;
+use Illuminate\View\View;
 
 /**
  * @deprecated Content will be moved to the backend/frontend/API packages soon, please don't add new functions here!
@@ -21,5 +23,11 @@ class FrontendTransportController extends Controller
         } catch (HafasException $e) {
             abort(503, $e->getMessage());
         }
+    }
+
+    public function getTrip(int $tripId): View {
+        return view('trip-info', [
+            'trip' => Trip::findOrFail($tripId)
+        ]);
     }
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -819,5 +819,14 @@
     "welcome.stats.million": "Millionen",
     "welcome.stats.distance": "kilometer gereist",
     "welcome.stats.registered": "Registrierte user",
-    "welcome.stats.duration": "Jahre Reisezeit"
+    "welcome.stats.duration": "Jahre Reisezeit",
+    "trip-info.title": ":linename am :date",
+    "trip-info.stopovers": "Zwischenhalte",
+    "trip-info.stopover": "Zwischenhalt",
+    "trip-info.departure": "Abfahrt",
+    "trip-info.arrival": "Ankunft",
+    "trip-info.in-this-connection": "In dieser Verbindung",
+    "trip-info.user": "User",
+    "trip-info.origin": "Abfahrtsort",
+    "trip-info.destination": "Zielort"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -819,5 +819,14 @@
     "welcome.stats.million": "Million",
     "welcome.stats.distance": "kilometers travelled",
     "welcome.stats.registered": "users registered",
-    "welcome.stats.duration": "years travel time"
+    "welcome.stats.duration": "years travel time",
+    "trip-info.title": ":linename at :date",
+    "trip-info.stopovers": "Stopovers",
+    "trip-info.stopover": "Stopover",
+    "trip-info.departure": "Departure",
+    "trip-info.arrival": "Arrival",
+    "trip-info.in-this-connection": "In this connection",
+    "trip-info.user": "User",
+    "trip-info.origin": "Origin",
+    "trip-info.destination": "Destination"
 }

--- a/resources/views/trip-info.blade.php
+++ b/resources/views/trip-info.blade.php
@@ -1,0 +1,75 @@
+@extends('layouts.app')
+
+@section('title', __('trip-info.title', ['linename' => $trip->linename, 'date' => $trip->departure->format('d.m.Y')]))
+
+@section('content')
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <h1>{{__('trip-info.title', ['linename' => $trip->linename, 'date' => $trip->departure->format('d.m.Y')])}}</h1>
+
+                <div class="alert alert-info">
+                    Diese Seite gehört zu den experimentellen Features von Träwelling.
+                    Daher sieht sie auch nicht schön aus, zeigt nur generische Infos und ist nirgends verlinkt.
+                    Du kannst sie gerne verbessern und einen PullRequest schicken.
+                </div>
+            </div>
+
+            <div class="col-md-7">
+                <h2>{{__('trip-info.stopovers')}}</h2>
+
+                <table class="table table-striped table-bordered">
+                    <thead>
+                        <tr>
+                            <th>{{__('trip-info.stopover')}}</th>
+                            <th>{{__('trip-info.arrival')}}</th>
+                            <th>{{__('trip-info.departure')}}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($trip->stopovers as $stopover)
+                            <tr>
+                                <td>{{$stopover->station->name}}</td>
+                                <td>{{$stopover->arrival->format('H:i')}}</td>
+                                <td>{{$stopover->departure->format('H:i')}}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="col-md-5">
+                <h2>{{__('trip-info.in-this-connection')}}</h2>
+                <table class="table table-striped table-bordered">
+                    <thead>
+                        <tr>
+                            <th>{{__('trip-info.user')}}</th>
+                            <th>{{__('trip-info.origin')}}</th>
+                            <th>{{__('trip-info.destination')}}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($trip->checkins as $checkin)
+                            @can('view', $checkin->status)
+                                <tr>
+                                    <td>
+                                        <a href="{{route('profile', ['username' => $checkin->user->username])}}">
+                                            <img
+                                                src="{{\App\Http\Controllers\Backend\User\ProfilePictureController::getUrl($checkin->user)}}"
+                                                alt="{{$checkin->user->name}}" style="max-height: 1em;"
+                                                class="avatar">
+                                            {{$checkin->user->name}}
+                                        </a>
+                                    </td>
+                                    <td>{{$checkin->originStopover->station->name}}</td>
+                                    <td>{{$checkin->destinationStopover->station->name}}</td>
+                                </tr>
+                            @endcan
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+@endsection

--- a/resources/views/trip-info.blade.php
+++ b/resources/views/trip-info.blade.php
@@ -38,37 +38,39 @@
                 </table>
             </div>
 
-            <div class="col-md-5">
-                <h2>{{__('trip-info.in-this-connection')}}</h2>
-                <table class="table table-striped table-bordered">
-                    <thead>
-                        <tr>
-                            <th>{{__('trip-info.user')}}</th>
-                            <th>{{__('trip-info.origin')}}</th>
-                            <th>{{__('trip-info.destination')}}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach($trip->checkins as $checkin)
-                            @can('view', $checkin->status)
-                                <tr>
-                                    <td>
-                                        <a href="{{route('profile', ['username' => $checkin->user->username])}}">
-                                            <img
-                                                src="{{\App\Http\Controllers\Backend\User\ProfilePictureController::getUrl($checkin->user)}}"
-                                                alt="{{$checkin->user->name}}" style="max-height: 1em;"
-                                                class="avatar">
-                                            {{$checkin->user->name}}
-                                        </a>
-                                    </td>
-                                    <td>{{$checkin->originStopover->station->name}}</td>
-                                    <td>{{$checkin->destinationStopover->station->name}}</td>
-                                </tr>
-                            @endcan
-                        @endforeach
-                    </tbody>
-                </table>
-            </div>
+            @if($trip->checkins->count() > 0)
+                <div class="col-md-5">
+                    <h2>{{__('trip-info.in-this-connection')}}</h2>
+                    <table class="table table-striped table-bordered">
+                        <thead>
+                            <tr>
+                                <th>{{__('trip-info.user')}}</th>
+                                <th>{{__('trip-info.origin')}}</th>
+                                <th>{{__('trip-info.destination')}}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($trip->checkins as $checkin)
+                                @can('view', $checkin->status)
+                                    <tr>
+                                        <td>
+                                            <a href="{{route('profile', ['username' => $checkin->user->username])}}">
+                                                <img
+                                                    src="{{\App\Http\Controllers\Backend\User\ProfilePictureController::getUrl($checkin->user)}}"
+                                                    alt="{{$checkin->user->name}}" style="max-height: 1em;"
+                                                    class="avatar">
+                                                {{$checkin->user->name}}
+                                            </a>
+                                        </td>
+                                        <td>{{$checkin->originStopover->station->name}}</td>
+                                        <td>{{$checkin->destinationStopover->station->name}}</td>
+                                    </tr>
+                                @endcan
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
         </div>
     </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -85,6 +85,9 @@ Route::get('/status/{id}', [FrontendStatusController::class, 'getStatus'])
      ->whereNumber('id')
      ->name('status');
 
+Route::get('/trip/{id}', [FrontendTransportController::class, 'getTrip'])
+     ->whereNumber('id');
+
 /**
  * These routes can be used by logged in users although they have not signed the privacy policy yet.
  */


### PR DESCRIPTION
Route hinzugefügt `/trip/{id}`.

Man sieht dort nur den Fahrtverlauf und alle eingecheckten User (dessen Status für einen Sichtbar sind).

Die Seite ist nirgends verlinkt und sieht nicht schön aus. Hat aber ganz praktische Infos. Kann man mal fix releasen und nach und nach vlt mal etwas schöner machen.

![image](https://github.com/user-attachments/assets/9079a061-219a-4d08-981c-e11fd69c097f)
