### PR TITLE
:lipstick: Show line name instead of journey number

### DIFF
--- a/app/DataProviders/Bahn.php
+++ b/app/DataProviders/Bahn.php
@@ -172,7 +172,7 @@ class Bahn extends Controller implements DataProviderInterface
             CacheKey::increment(HCK::DEPARTURES_SUCCESS);
             foreach ($entries as $rawDeparture) {
                 //trip
-                $tripLineName      = $rawDeparture['verkehrmittel']['name'] ?? '';
+                $tripLineName      = $rawDeparture['verkehrmittel']['mittelText'] ?? '';
                 $tripNumber        = preg_replace('/\s/', '-', strtolower($tripLineName)) ?? '';
                 $tripJourneyNumber = preg_replace('/\D/', '', $rawDeparture['verkehrmittel']['name']);
                 $category          = isset($rawDeparture['verkehrmittel']['produktGattung']) ? ReiseloesungCategory::tryFrom($rawDeparture['verkehrmittel']['produktGattung']) : ReiseloesungCategory::UNKNOWN;


### PR DESCRIPTION
This PR adds that the actual line name for regional trains is shown instead of the journey number

![image](https://github.com/user-attachments/assets/8363f546-1651-4172-8a5d-8ffa63f2b531)
