### PR TITLE
:sparkles: Get trip number from first stop of journey

### DIFF
--- a/app/DataProviders/Bahn.php
+++ b/app/DataProviders/Bahn.php
@@ -318,10 +318,14 @@ class Bahn extends Controller implements DataProviderInterface
         }
 
         $tripLineName = $cachedData['lineName'] ?? '';
-        preg_match('/#ZE#(\d+)/', $tripID, $matches);
-        $tripNumber = 0;
-        if (count($matches) > 1) {
-            $tripNumber = $matches[1];
+
+        // get trip number from first stop
+        $tripNumber = isset($rawJourney['halte'][0]['nummer']) ? (int) $rawJourney['halte'][0]['nummer'] : 0;
+        if ($tripNumber === 0) {
+            preg_match('/#ZE#(\d+)/', $tripID, $matches);
+            if (count($matches) > 1) {
+                $tripNumber = $matches[1];
+            }
         }
 
         $stopovers = collect();


### PR DESCRIPTION
Hey, the journey ids of the new bahn.de API don't have the trip number ("Zugnummer") as `ZE` value for local transports (including suburban trains). Instead they just provide the line number (e.g. "8" for a suburban train with line "S 8").

Instead every stop has a field with the actual transport number which I implemented in this PR :)
![chrome_8QeyaqmI89](https://github.com/user-attachments/assets/3c703e28-81c2-460e-9467-ee0c106e629f)
