### PR TITLE
:bug: Fix: use correct deletion function for inactive users

### DIFF
--- a/app/Http/Controllers/Backend/User/AccountDeletionController.php
+++ b/app/Http/Controllers/Backend/User/AccountDeletionController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Backend\User;
 
 use App\Helpers\CacheKey;
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\Backend\UserController;
 use App\Mail\AccountDeletionNotificationTwoWeeksBefore;
 use App\Models\User;
 use Exception;
@@ -67,7 +68,7 @@ abstract class AccountDeletionController extends Controller
                 }
 
                 Log::info('Deleting inactive user ' . $user->id . ' (' . $user->email . ')');
-                $user->delete();
+                UserController::deleteUserAccount($user);
             } catch (Exception $e) {
                 Log::error('Error deleting inactive user ' . $user->id . ' (' . $user->email . '): ' . $e->getMessage());
             }


### PR DESCRIPTION
I have seen the code deleting inactive users in the `AccountDeletionController`. It misses the parts of deleting a user as seen in `UserController::deleteUserAccount` (ProfilePicture and DatabaseNotification).

Im not a laravel expert, but i believe this might be a bug keeping ProfilePictures and Notifications for deleted users. If this problem is real, we may need to create a migration that checks the Database for non deleted profile pictures and notification objects, as this might be a privacy concern.