### PR TITLE
🐛 Define the type cast of the number attribute in trip model

### DIFF
--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -48,6 +48,7 @@ class Trip extends Model
     protected $casts    = [
         'id'             => 'integer',
         'trip_id'        => 'string',
+        'number'         => 'string',
         'category'       => HafasTravelType::class,
         'journey_number' => 'integer',
         'operator_id'    => 'integer',


### PR DESCRIPTION
Currently, the type of the number attribute is not defined in the trip model, which leads to undocumented API returns as integer. To follow the documentation which defines number as a string, I added a type cast to the model.