### PR TITLE
:bug: Fix journey cache with no realtime

### DIFF
--- a/app/DataProviders/CachedDataProvider.php
+++ b/app/DataProviders/CachedDataProvider.php
@@ -70,7 +70,7 @@ class CachedDataProvider implements DataProviderInterface
 
         // filter entries by when and duration
         return $departures->filter(function($departure) use ($filterWhen, $duration) {
-            $depWhen = Carbon::parse($departure->when);
+            $depWhen = Carbon::parse($departure->when ?? $departure->plannedWhen);
             return $depWhen->between($filterWhen, $filterWhen->copy()->addMinutes($duration));
         });
     }


### PR DESCRIPTION
This PR fixes the issue that journeys from too far in history / future with no realtime data are purged in the departure board, when caching is active.

Fixes #3161