### PR TITLE
:bug: Fix loading js on stats page and fix start/end of day bug

### DIFF
--- a/app/Http/Controllers/Backend/StatisticController.php
+++ b/app/Http/Controllers/Backend/StatisticController.php
@@ -67,6 +67,9 @@ abstract class StatisticController extends Controller
         Carbon $until,
         int    $limit = 10
     ): Collection {
+        $from->startOfDay();
+        $until->endOdDay();
+
         if ($from->isAfter($until)) {
             throw new InvalidArgumentException('since cannot be after until');
         }
@@ -109,6 +112,9 @@ abstract class StatisticController extends Controller
         Carbon $until,
         int    $limit = 10
     ): Collection {
+        $from->startOfDay();
+        $until->endOdDay();
+
         if ($from->isAfter($until)) {
             throw new InvalidArgumentException('since cannot be after until');
         }
@@ -146,11 +152,12 @@ abstract class StatisticController extends Controller
      * @api v1
      */
     public static function getDailyTravelTimeByUser(User $user, Carbon $from, Carbon $until): Collection {
+        $from->startOfDay();
+        $until->endOdDay();
+
         if ($from->isAfter($until)) {
             throw new InvalidArgumentException('since cannot be after until');
         }
-        $from->setTime(0, 0);
-        $until->setTime(0, 0);
 
         $dateList = collect();
         for ($date = $from->clone(); $date->isBefore($until); $date->addDay()) {
@@ -204,6 +211,9 @@ abstract class StatisticController extends Controller
      * @api v1
      */
     public static function getTravelPurposes(User $user, Carbon $from, Carbon $until): Collection {
+        $from->startOfDay();
+        $until->endOdDay();
+
         if ($from->isAfter($until)) {
             throw new InvalidArgumentException('since cannot be after until');
         }

--- a/resources/views/stats/includes/chart_categories.blade.php
+++ b/resources/views/stats/includes/chart_categories.blade.php
@@ -14,31 +14,33 @@
     @parent
     @if($topCategories->count() > 0)
         <script>
-            new ApexCharts(document.querySelector("#chart_favourite_types"), {
-                chart: {
-                    type: 'pie'
-                },
-                series: [
-                    @foreach($topCategories as $category)
-                        {{$category->duration}},
-                    @endforeach
-                ],
-                labels: [
-                    @foreach($topCategories as $category)
-                        '{{$category->name}}',
-                    @endforeach
-                ],
-                legend: {
-                    position: 'bottom'
-                },
-                tooltip: {
-                    y: {
-                        formatter: function (value) {
-                            return value + ' {{__('time.minutes')}}';
+            document.addEventListener('DOMContentLoaded', function() {
+                new ApexCharts(document.querySelector("#chart_favourite_types"), {
+                    chart: {
+                        type: 'pie'
+                    },
+                    series: [
+                        @foreach($topCategories as $category)
+                            {{$category->duration}},
+                        @endforeach
+                    ],
+                    labels: [
+                        @foreach($topCategories as $category)
+                            '{{$category->name}}',
+                        @endforeach
+                    ],
+                    legend: {
+                        position: 'bottom'
+                    },
+                    tooltip: {
+                        y: {
+                            formatter: function (value) {
+                                return value + ' {{__('time.minutes')}}';
+                            }
                         }
-                    }
-                },
-            }).render();
+                    },
+                }).render();
+            });
         </script>
     @endif
 @endsection

--- a/resources/views/stats/includes/chart_companies.blade.php
+++ b/resources/views/stats/includes/chart_companies.blade.php
@@ -13,31 +13,33 @@
     @parent
     @if($topOperators->count() > 0)
         <script>
-            new ApexCharts(document.querySelector("#chart_companies"), {
-                chart: {
-                    type: 'pie'
-                },
-                series: [
-                    @foreach($topOperators as $operator)
-                        {{$operator->duration}},
-                    @endforeach
-                ],
-                labels: [
-                    @foreach($topOperators as $operator)
-                        '{{$operator->name ?? __('other')}}',
-                    @endforeach
-                ],
-                legend: {
-                    position: 'bottom'
-                },
-                tooltip: {
-                    y: {
-                        formatter: function (value) {
-                            return value + ' {{__('time.minutes')}}';
+            document.addEventListener('DOMContentLoaded', function() {
+                new ApexCharts(document.querySelector("#chart_companies"), {
+                    chart: {
+                        type: 'pie'
+                    },
+                    series: [
+                        @foreach($topOperators as $operator)
+                            {{$operator->duration}},
+                        @endforeach
+                    ],
+                    labels: [
+                        @foreach($topOperators as $operator)
+                            '{{$operator->name ?? __('other')}}',
+                        @endforeach
+                    ],
+                    legend: {
+                        position: 'bottom'
+                    },
+                    tooltip: {
+                        y: {
+                            formatter: function (value) {
+                                return value + ' {{__('time.minutes')}}';
+                            }
                         }
-                    }
-                },
-            }).render();
+                    },
+                }).render();
+            });
         </script>
     @endif
 @endsection

--- a/resources/views/stats/includes/chart_purpose.blade.php
+++ b/resources/views/stats/includes/chart_purpose.blade.php
@@ -13,31 +13,33 @@
     @parent
     @if($travelPurposes->count() > 0)
         <script>
-            new ApexCharts(document.querySelector("#chart_purpose"), {
-                chart: {
-                    type: 'pie'
-                },
-                series: [
-                    @foreach($travelPurposes as $row)
-                        {{$row->duration}},
-                    @endforeach
-                ],
-                labels: [
-                    @foreach($travelPurposes as $row)
-                        '{{$row->reason}}',
-                    @endforeach
-                ],
-                legend: {
-                    position: 'bottom'
-                },
-                tooltip: {
-                    y: {
-                        formatter: function (value) {
-                            return value + ' {{__('time.minutes')}}';
+            document.addEventListener('DOMContentLoaded', function() {
+                new ApexCharts(document.querySelector("#chart_purpose"), {
+                    chart: {
+                        type: 'pie'
+                    },
+                    series: [
+                        @foreach($travelPurposes as $row)
+                            {{$row->duration}},
+                        @endforeach
+                    ],
+                    labels: [
+                        @foreach($travelPurposes as $row)
+                            '{{$row->reason}}',
+                        @endforeach
+                    ],
+                    legend: {
+                        position: 'bottom'
+                    },
+                    tooltip: {
+                        y: {
+                            formatter: function (value) {
+                                return value + ' {{__('time.minutes')}}';
+                            }
                         }
-                    }
-                },
-            }).render();
+                    },
+                }).render();
+            });
         </script>
     @endif
 @endsection

--- a/resources/views/stats/includes/chart_volume.blade.php
+++ b/resources/views/stats/includes/chart_volume.blade.php
@@ -13,75 +13,77 @@
     @parent
     @if($travelTime->count() > 0)
         <script>
-            new ApexCharts(document.querySelector("#chart_triptime_calendar"), {
-                series: [
-                    {
-                        name: '{{__('stats.time-in-minutes')}}',
-                        data: [
-                                @foreach($travelTime as $row)
-                            {
-                                x: new Date('{{$row->date->toIso8601String()}}').getTime(),
-                                y: {{$row->duration ?? 0}}
-                            },
-                            @endforeach
-                        ]
-                    }
-                ],
-                chart: {
-                    type: 'area',
-                    stacked: false,
-                    height: 350,
-                    zoom: {
-                        type: 'x',
-                        enabled: true,
-                        autoScaleYaxis: true
-                    },
-                    toolbar: {
-                        autoSelected: 'zoom'
-                    }
-                },
-                dataLabels: {
-                    enabled: false
-                },
-                markers: {
-                    size: 0,
-                },
-                fill: {
-                    type: 'gradient',
-                    gradient: {
-                        shadeIntensity: 1,
-                        inverseColors: false,
-                        opacityFrom: 0.5,
-                        opacityTo: 0,
-                        stops: [0, 90, 100]
-                    },
-                },
-                yaxis: {
-                    labels: {
-                        formatter: function (value) {
-                            return value + ' {{__('time.minutes')}}';
+            document.addEventListener('DOMContentLoaded', function() {
+                new ApexCharts(document.querySelector("#chart_triptime_calendar"), {
+                    series: [
+                        {
+                            name: '{{__('stats.time-in-minutes')}}',
+                            data: [
+                                    @foreach($travelTime as $row)
+                                {
+                                    x: new Date('{{$row->date->toIso8601String()}}').getTime(),
+                                    y: {{$row->duration ?? 0}}
+                                },
+                                @endforeach
+                            ]
+                        }
+                    ],
+                    chart: {
+                        type: 'area',
+                        stacked: false,
+                        height: 350,
+                        zoom: {
+                            type: 'x',
+                            enabled: true,
+                            autoScaleYaxis: true
+                        },
+                        toolbar: {
+                            autoSelected: 'zoom'
                         }
                     },
-                },
-                xaxis: {
-                    type: 'datetime',
-                    labels: {
-                        datetimeUTC: false,
-                        datetimeFormatter: {
-                            year: 'yyyy',
-                            month: 'MMM \'yy',
-                            day: 'dd MMM',
-                            hour: 'HH:mm'
+                    dataLabels: {
+                        enabled: false
+                    },
+                    markers: {
+                        size: 0,
+                    },
+                    fill: {
+                        type: 'gradient',
+                        gradient: {
+                            shadeIntensity: 1,
+                            inverseColors: false,
+                            opacityFrom: 0.5,
+                            opacityTo: 0,
+                            stops: [0, 90, 100]
+                        },
+                    },
+                    yaxis: {
+                        labels: {
+                            formatter: function (value) {
+                                return value + ' {{__('time.minutes')}}';
+                            }
+                        },
+                    },
+                    xaxis: {
+                        type: 'datetime',
+                        labels: {
+                            datetimeUTC: false,
+                            datetimeFormatter: {
+                                year: 'yyyy',
+                                month: 'MMM \'yy',
+                                day: 'dd MMM',
+                                hour: 'HH:mm'
+                            }
+                        }
+                    },
+                    tooltip: {
+                        shared: false,
+                        x: {
+                            format: 'dd MMM yyyy HH:mm'
                         }
                     }
-                },
-                tooltip: {
-                    shared: false,
-                    x: {
-                        format: 'dd MMM yyyy HH:mm'
-                    }
-                }
-            }).render();
+                }).render();
+            });
         </script>
     @endif
 @endsection

--- a/resources/views/stats/stats.blade.php
+++ b/resources/views/stats/stats.blade.php
@@ -4,7 +4,7 @@
 
 @section('head')
     @parent
-    <script src="{{ asset('js/stats.js') }}"></script>
+    @vite(['resources/js/stats.js'])
 @endsection
 
 @section('content')


### PR DESCRIPTION
- Charts on stats page were not working on local build, due to missing .js file, the page attempted to load `/js/stats.js` while other pages load js from `/build/assets/<name>-<hash>.js`. It works on production cause on `/js/stats.js` the correct js file is served (even though other pages use the long path with hash).
- This required a small change in the moment inline js is executed, to wait for loading of js - ideally this should be rewritten to use API.
- Fix in rounding up/down dates - some stats didn't include same day trips, cause `until` time was rounded down to start of day, I changed those to reference end of day and unified behaviour for all stat panels.