### PR TITLE
🩹 Proper plurals for stats.trip

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -490,7 +490,7 @@
     "stats.volume": "Dein Reisevolumen",
     "stats.time": "Deine tägliche Reisezeit",
     "stats.per-week": "pro Kalenderwoche",
-    "stats.trips": ":count Fahrt | :count Fahrten",
+    "stats.trips": ":count Fahrt|:count Fahrten",
     "stats.no-data": "Es sind keine Daten in dem Zeitraum vorhanden.",
     "stats.time-in-minutes": "Reisezeit in Minuten",
     "stats.purpose": "Zwecke deiner Reisen",

--- a/lang/de.json
+++ b/lang/de.json
@@ -490,7 +490,7 @@
     "stats.volume": "Dein Reisevolumen",
     "stats.time": "Deine tägliche Reisezeit",
     "stats.per-week": "pro Kalenderwoche",
-    "stats.trips": "Fahrten",
+    "stats.trips": ":count Fahrt | :count Fahrten",
     "stats.no-data": "Es sind keine Daten in dem Zeitraum vorhanden.",
     "stats.time-in-minutes": "Reisezeit in Minuten",
     "stats.purpose": "Zwecke deiner Reisen",

--- a/lang/de_by.json
+++ b/lang/de_by.json
@@ -67,7 +67,7 @@
     "dates.Tuesday": "Dinnschtig",
     "user.not-received-before": "Wenn du dia E-Mail id kriagt hosch, ",
     "user.invalid-mastodon": ":domain isch wohl koa Maschtodon-Inschtanz.",
-    "stats.trips": "Fahrta",
+    "stats.trips": ":count Fahrta",
     "user.reset-pw-link": "Wiadrherstellungs-Link verschicka",
     "dates.-on-": " um ",
     "notifications.mark-all-read": "All ois gleasa markiera",

--- a/lang/de_he.json
+++ b/lang/de_he.json
@@ -344,7 +344,7 @@
     "stats.per-week": "pro Kalennerwoche",
     "dashboard.future": "Dei Scheck-ins inde Zukunft",
     "user.muted.text": "Du koannschd die Scheck-Ins vunn :username nedd seje, doa du denn Benutzer stummgeschaltet hoaschd.",
-    "stats.trips": "Fahrte",
+    "stats.trips": ":count Fahrte",
     "stats.personal": "Persönlich Statistike vum :fromDate bis :toDate",
     "stats.global.duration": "Reisedauer aller Träweller",
     "controller.user.follow-error": "Du koannschd dieser Person nedd folge.",

--- a/lang/de_pfl.json
+++ b/lang/de_pfl.json
@@ -336,7 +336,7 @@
     "stats.global": "Globale Statistike",
     "stats.companies": "Dei Lieblingsverkehrsunnernehme",
     "stats.per-week": "pro Kalennerwoch",
-    "stats.trips": "Fahrte",
+    "stats.trips": ":count Fahrte",
     "controller.user.follow-error": "Du kannsch dere Person ned folche.",
     "date-format": "DD.MM.YYYY",
     "transport_types.regionalExp": "D-Zuuch",

--- a/lang/en.json
+++ b/lang/en.json
@@ -457,7 +457,7 @@
     "stats.volume": "Your travel volume",
     "stats.time": "Your daily travel time",
     "stats.per-week": "per week",
-    "stats.trips": ":count Journey | :count Journeys",
+    "stats.trips": ":count Journey|:count Journeys",
     "stats.no-data": "There is no data available in the period.",
     "stats.time-in-minutes": "Travel time in minutes",
     "stats.purpose": "Purpose of your travels",

--- a/lang/en.json
+++ b/lang/en.json
@@ -457,7 +457,7 @@
     "stats.volume": "Your travel volume",
     "stats.time": "Your daily travel time",
     "stats.per-week": "per week",
-    "stats.trips": "Journeys",
+    "stats.trips": ":count Journey | :count Journeys",
     "stats.no-data": "There is no data available in the period.",
     "stats.time-in-minutes": "Travel time in minutes",
     "stats.purpose": "Purpose of your travels",

--- a/lang/es.json
+++ b/lang/es.json
@@ -437,7 +437,7 @@
     "notifications.mastodon-server.exception": "No se ha podido establecer una conexión con tu instancia de Mastodon :domain. Por favor, verifica los ajustes o reconecta la cuenta. Si el problema continua, contacta con nuestro soporte.",
     "stationboard.timezone": "Hemos detectado que tu zona horaria es diferente a la de la estación. Las horas aqui mostradas son en tu zona horaria <i>:timezone</i>.",
     "stats.time": "Tu tiempo de viaje diario",
-    "stats.trips": "Viajes",
+    "stats.trips": ":count Viajes",
     "go-to-settings": "Ir a los ajustes",
     "experimental-features": "Funciones experimentales",
     "settings.delete-webhook.success": "El webhook ha sido eliminado",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -344,7 +344,7 @@
     "stats.no-data": "Il n'y a pas de données disponibles pour la période.",
     "stats": "Statistiques",
     "dashboard.future": "Tes enregistrements à venir",
-    "stats.trips": "trajets",
+    "stats.trips": ":count trajets",
     "stats.per-week": "par semaine",
     "stats.time-in-minutes": "Temps de parcours en minutes",
     "stats.week-short": "S",

--- a/lang/it.json
+++ b/lang/it.json
@@ -404,7 +404,7 @@
     "stats.companies": "Aziende di trasporto",
     "stats.volume": "Il tuo numero di viaggi",
     "stats.per-week": "per settimana",
-    "stats.trips": "Viaggi",
+    "stats.trips": ":count Viaggi",
     "stats.time-in-minutes": "Tempo di viaggio in minuti",
     "stats.purpose": "Scopo dei tuoi viaggi",
     "stats.week-short": "set.",

--- a/lang/nb_NO.json
+++ b/lang/nb_NO.json
@@ -405,7 +405,7 @@
     "transport_types.tram": "trikk",
     "stats.volume": "Reisevolumet ditt",
     "stats.per-week": "per kalenderuke",
-    "stats.trips": "Rides",
+    "stats.trips": ":count Rides",
     "stats.no-data": "Det er ingen data i perioden.",
     "stats.categories": "Transportmidler for dine reiser",
     "stats.time-in-minutes": "Reisetid i minutter",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -510,7 +510,7 @@
     "stationboard.check-chainPost": "Toevoegen aan recentste check-in",
     "status.visibility.0": "Openbaar",
     "status.visibility.2.detail": "Alleen zichtbaar voor (goedgekeurde) volgers",
-    "stats.trips": "Ritten",
+    "stats.trips": ":count Ritten",
     "stats.no-data": "Er zijn gegevens over deze periode beschikbaar.",
     "stats.purpose": "Reisdoelen",
     "description.status": "De reis van :username van :origin naar :destination op :date in :lineName.",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -244,7 +244,7 @@
     "stats": "Statystyki",
     "stats.personal": "Statystyki osobiste od :fromDate do :toDate",
     "stats.global": "Statystyki globalne",
-    "stats.trips": "podróż(-e/-y)",
+    "stats.trips": ":count podróż | :count podróże | :count podróży",
     "stats.week-short": "tydz.",
     "stats.global.distance": "Dystans podróży wszystkich użytkowników",
     "stats.global.active": "Aktywni podróżnicy",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -244,7 +244,7 @@
     "stats": "Statystyki",
     "stats.personal": "Statystyki osobiste od :fromDate do :toDate",
     "stats.global": "Statystyki globalne",
-    "stats.trips": ":count podróż | :count podróże | :count podróży",
+    "stats.trips": ":count podróż|:count podróże|:count podróży",
     "stats.week-short": "tydz.",
     "stats.global.distance": "Dystans podróży wszystkich użytkowników",
     "stats.global.active": "Aktywni podróżnicy",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -376,7 +376,7 @@
     "stats.time-in-minutes": "Restid i minuter",
     "stats.companies": "trafikföretag",
     "stats.week-short": "v.",
-    "stats.trips": "Resor",
+    "stats.trips": ":count Resor",
     "stats.global.explain": "De globala statistiker avser till incheckningar av alla Träweller under perioden från :fromDate till :toDate.",
     "dashboard.future": "Dina Check-Ins i framtiden",
     "description.status": "Resan från :username från :origin till :destination på :datum i :lineName.",

--- a/resources/views/stats/daily.blade.php
+++ b/resources/views/stats/daily.blade.php
@@ -62,8 +62,7 @@
                     <div class="row text-center fs-5" id="daily-stats-statsbar">
                         <div class="col-6 mb-3 col-lg-3">
                             <i class="fa-solid fa-train"></i>
-                            {{$statuses->count()}}
-                            {{__('stats.trips')}}
+                            {{ trans_choice('stats.trips', $statuses->count()) }}
                         </div>
                         <div class="col-6 mb-3 col-lg-3">
                             <i class="fa-solid fa-route"></i>


### PR DESCRIPTION
- Translations of string stats.trip can now use the amount to select proper form
- Polish, German and English translation of stats.trip is corrected to use plural vs singular form (rest should _eventualy_ flow from weblate/codeberg)