### PR TITLE
:page_facing_up: Add support for Etalab Open License 2.0

### DIFF
--- a/app/Models/MotisSourceLicense.php
+++ b/app/Models/MotisSourceLicense.php
@@ -64,6 +64,10 @@ class MotisSourceLicense extends Model
             'name' => 'Creative Commons Attribution 3.0 Unported (CC BY 3.0)',
             'url'  => 'https://spdx.org/licenses/CC-BY-3.0.html'
         ],
+        'etalab-2.0'   => [
+            'name' => 'Etalab Open License 2.0',
+            'url'  => 'https://spdx.org/licenses/etalab-2.0.html'
+        ],
     ];
 
     public function trips(): HasMany {


### PR DESCRIPTION
This is needed to fetch more data in FR from Transitous, should further improve #3338.