### PR TITLE
🐛 Fix looking for default area

### DIFF
--- a/resources/types/Station.ts
+++ b/resources/types/Station.ts
@@ -10,6 +10,8 @@ export type ShortStation = {
 
 export type Area = {
     name: string;
-    default: boolean;
     adminLevel: number;
+    pivot: {
+        default: boolean;
+    }
 };

--- a/resources/vue/components/Checkin/AutocompleteListEntry.vue
+++ b/resources/vue/components/Checkin/AutocompleteListEntry.vue
@@ -21,7 +21,7 @@ export default defineComponent({
   methods: {
     getArea(): string {
       if (this.$props.station?.areas) {
-        let defaultArea: null | Area = this.$props.station.areas.find((area: Area) => area.default);
+        let defaultArea: null | Area = this.$props.station.areas.find((area: Area) => area.pivot.default);
         let country: null | Area = this.$props.station.areas.find((area: Area) => area.adminLevel === 2);
         if (defaultArea) {
           return country ? `${defaultArea.name}, ${country.name}` : defaultArea.name;


### PR DESCRIPTION
Noticed that city names have recently disappeared from areas in autocomplete and it seems that default boolean has been moved