### PR TITLE
🎨 Return Station objects in getLatestArrivals

### DIFF
--- a/app/Http/Controllers/Backend/Transport/StationController.php
+++ b/app/Http/Controllers/Backend/Transport/StationController.php
@@ -32,6 +32,7 @@ class StationController extends Controller
      * @return Collection
      */
     public static function getLatestArrivals(User $user, int $maxCount = 5): Collection {
+        $groupAndSelect = [
             'train_stations.id', 'train_stations.ibnr', 'train_stations.name',
             'train_stations.latitude', 'train_stations.longitude', 'train_stations.rilIdentifier',
         ];

--- a/app/Http/Controllers/Backend/Transport/StationController.php
+++ b/app/Http/Controllers/Backend/Transport/StationController.php
@@ -32,19 +32,17 @@ class StationController extends Controller
      * @return Collection
      */
     public static function getLatestArrivals(User $user, int $maxCount = 5): Collection {
-        $groupAndSelect = [
-            'train_stations.id', 'train_stations.ibnr', 'train_stations.name',
-            'train_stations.latitude', 'train_stations.longitude', 'train_stations.rilIdentifier',
-        ];
-        return DB::table('train_checkins') //TODO: return Station objects
-                 ->join('train_stopovers', 'train_checkins.destination_stopover_id', '=', 'train_stopovers.id')
-                 ->join('train_stations', 'train_stopovers.train_station_id', '=', 'train_stations.id')
-                 ->where('train_checkins.user_id', $user->id)
-                 ->groupBy($groupAndSelect)
-                 ->select($groupAndSelect)
-                 ->orderByDesc(DB::raw('MAX(train_checkins.arrival)'))
-                 ->limit($maxCount)
-                 ->get();
+        return DB::table('train_checkins')
+                ->join('train_stopovers', 'train_checkins.destination_stopover_id', '=', 'train_stopovers.id')
+                ->select('train_stopovers.train_station_id as station_id')
+                ->where('train_checkins.user_id', $user->id)
+                ->groupBy('station_id')
+                ->orderByDesc(DB::raw('MAX(train_checkins.arrival)'))
+                ->limit($maxCount)
+                ->pluck('station_id')
+                ->map(function (int $id) {
+                    return Station::where('id', $id)->first();
+                });
     }
 
     /**

--- a/app/Http/Controllers/Backend/Transport/StationController.php
+++ b/app/Http/Controllers/Backend/Transport/StationController.php
@@ -32,16 +32,29 @@ class StationController extends Controller
      * @return Collection
      */
     public static function getLatestArrivals(User $user, int $maxCount = 5): Collection {
+            'train_stations.id', 'train_stations.ibnr', 'train_stations.name',
+            'train_stations.latitude', 'train_stations.longitude', 'train_stations.rilIdentifier',
+        ];
+
         return DB::table('train_checkins')
                 ->join('train_stopovers', 'train_checkins.destination_stopover_id', '=', 'train_stopovers.id')
-                ->select('train_stopovers.train_station_id as station_id')
+                ->join('train_stations', 'train_stopovers.train_station_id', '=', 'train_stations.id')
                 ->where('train_checkins.user_id', $user->id)
-                ->groupBy('station_id')
+                ->groupBy($groupAndSelect)
+                ->select($groupAndSelect)
                 ->orderByDesc(DB::raw('MAX(train_checkins.arrival)'))
                 ->limit($maxCount)
-                ->pluck('station_id')
-                ->map(function (int $id) {
-                    return Station::where('id', $id)->first();
+                ->get()
+                ->map(function (object $station) {
+                    $instance = new Station([
+                        "ibnr" => $station->ibnr,
+                        "name" => $station->name,
+                        "latitude" => $station->latitude,
+                        "longitude" => $station->longitude,
+                        "rilIdentifier" => $station->rilIdentifier
+                    ]);
+                    $instance->id = $station->id;
+                    return $instance;
                 });
     }
 


### PR DESCRIPTION
Originally meant to have this add areas to station history (thus having area in autocomplete before typing a destination) and even though it seems that attribute would just need accessing in order to write itself into the output object, it seemed kinda iffy.. 

So at least it now returns Station objects as commented in TODO.