### PR TITLE
:sparkles: Use rel="me" on profile links

### DIFF
--- a/resources/views/profile/partials/info.blade.php
+++ b/resources/views/profile/partials/info.blade.php
@@ -62,7 +62,7 @@
                            class="text-muted fs-4"
                            aria-label="{{ $link->name->getName() }}"
                            target="_blank"
-                           rel="noopener">
+                           rel="me">
                             <i class="{{ $link->name->getIcon() }}"></i>
                         </a>
                     @endforeach


### PR DESCRIPTION
Use rel="me" since target="_blank" has the same effect as rel="noopener" and rel="me" is needed i.e. for Mastodon link verification

<img width="795" height="80" alt="image" src="https://github.com/user-attachments/assets/a6eb8873-03da-4985-a042-219203e24dfe" />

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/noopener