### PR TITLE
✨Add Trusted User Status/tag visibility

### DIFF
--- a/app/Enum/StatusVisibility.php
+++ b/app/Enum/StatusVisibility.php
@@ -8,10 +8,10 @@ use App\Interfaces\IconEnumInterface;
 /**
  * @OA\Schema(
  *      title="visibility",
- *      description="What type of visibility (0=public, 1=unlisted, 2=followers, 3=private, 4=authenticated) did the
+ *      description="What type of visibility (0=public, 1=unlisted, 2=followers, 3=private, 4=authenticated, 5=trusted) did the
  *      user specify?",
  *      type="integer",
- *      enum={0,1,2,3,4},
+ *      enum={0,1,2,3,4,5},
  *      example=0
  *  )
  */
@@ -22,6 +22,7 @@ enum StatusVisibility: int implements IconEnumInterface
     case FOLLOWERS     = 2;
     case PRIVATE       = 3;
     case AUTHENTICATED = 4;
+    case TRUSTED       = 5;
 
     public function faIcon(): string {
         return match ($this) {
@@ -29,7 +30,8 @@ enum StatusVisibility: int implements IconEnumInterface
             self::UNLISTED      => 'fa-lock-open',
             self::FOLLOWERS     => 'fa-user-friends',
             self::PRIVATE       => 'fa-lock',
-            self::AUTHENTICATED => 'fa-user-check'
+            self::AUTHENTICATED => 'fa-user-check',
+            self::TRUSTED       => 'fa-user-shield'
         };
     }
 
@@ -39,7 +41,8 @@ enum StatusVisibility: int implements IconEnumInterface
             self::UNLISTED      => __('status.visibility.1'),
             self::FOLLOWERS     => __('status.visibility.2'),
             self::PRIVATE       => __('status.visibility.3'),
-            self::AUTHENTICATED => __('status.visibility.4')
+            self::AUTHENTICATED => __('status.visibility.4'),
+            self::TRUSTED       => __('status.visibility.5')
         };
     }
 
@@ -49,7 +52,8 @@ enum StatusVisibility: int implements IconEnumInterface
             self::UNLISTED      => __('status.visibility.1.detail'),
             self::FOLLOWERS     => __('status.visibility.2.detail'),
             self::PRIVATE       => __('status.visibility.3.detail'),
-            self::AUTHENTICATED => __('status.visibility.4.detail')
+            self::AUTHENTICATED => __('status.visibility.4.detail'),
+            self::TRUSTED       => __('status.visibility.5.detail')
         };
     }
 }

--- a/app/Http/Controllers/Backend/Transport/StatusController.php
+++ b/app/Http/Controllers/Backend/Transport/StatusController.php
@@ -11,6 +11,7 @@ use App\Models\Stopover;
 use App\Models\User;
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
 
 abstract class StatusController extends Controller
 {
@@ -66,13 +67,29 @@ abstract class StatusController extends Controller
                 //Option 2: Status is from oneself
                 $query->orWhere('users.id', $viewingUser->id);
 
-                //Option 3: Status is from a followed BUT not unlisted or private
+                //Option 3: Status is from a followed BUT not unlisted or private or trusted users only
                 $query->orWhere(function(Builder $query) use ($viewingUser) {
                     $query->whereIn('users.id', $viewingUser->follows()->select('follow_id'))
                           ->whereNotIn('statuses.visibility', [
                               StatusVisibility::UNLISTED->value,
                               StatusVisibility::PRIVATE->value,
+                              StatusVisibility::TRUSTED->value,
                           ]);
+                });
+
+                //Option 4: Status is from a user who trusts the viewing user
+                $query->orWhere(function(Builder $query) use ($viewingUser) {
+                    $query->where('statuses.visibility', StatusVisibility::TRUSTED->value)
+                          ->whereExists(function($subQuery) use ($viewingUser) {
+                              $subQuery->select(\DB::raw(1))
+                                      ->from('trusted_users')
+                                      ->whereColumn('trusted_users.user_id', 'statuses.user_id')
+                                      ->where('trusted_users.trusted_id', $viewingUser->id)
+                                      ->where(function($expireQuery) {
+                                          $expireQuery->whereNull('trusted_users.expires_at')
+                                                     ->orWhere('trusted_users.expires_at', '>', now());
+                                      });
+                          });
                 });
             }
         };

--- a/app/Http/Controllers/Backend/User/DashboardController.php
+++ b/app/Http/Controllers/Backend/User/DashboardController.php
@@ -9,6 +9,7 @@ use App\Models\Status;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Contracts\Pagination\Paginator;
+use Illuminate\Support\Facades\DB;
 
 abstract class DashboardController extends Controller
 {
@@ -33,11 +34,26 @@ abstract class DashboardController extends Controller
                      ->where('train_checkins.departure', '<', Carbon::now()->addMinutes(20))
                      ->whereIn('statuses.user_id', $followingIDs)
                      ->whereNotIn('statuses.user_id', $user->mutedUsers->pluck('id'))
-                     ->whereIn('statuses.visibility', [
-                         StatusVisibility::PUBLIC->value,
-                         StatusVisibility::FOLLOWERS->value,
-                         StatusVisibility::AUTHENTICATED->value
-                     ])
+                     ->where(function($query) use ($user) {
+                         $query->whereIn('statuses.visibility', [
+                             StatusVisibility::PUBLIC->value,
+                             StatusVisibility::FOLLOWERS->value,
+                             StatusVisibility::AUTHENTICATED->value
+                         ])
+                         ->orWhere(function($trustedQuery) use ($user) {
+                             $trustedQuery->where('statuses.visibility', StatusVisibility::TRUSTED->value)
+                                         ->whereExists(function($subQuery) use ($user) {
+                                             $subQuery->select(\DB::raw(1))
+                                                     ->from('trusted_users')
+                                                     ->whereColumn('trusted_users.user_id', 'statuses.user_id')
+                                                     ->where('trusted_users.trusted_id', $user->id)
+                                                     ->where(function($expireQuery) {
+                                                         $expireQuery->whereNull('trusted_users.expires_at')
+                                                                    ->orWhere('trusted_users.expires_at', '>', now());
+                                                     });
+                                         });
+                         });
+                     })
                      ->orWhere(function($query) use ($user) {
                          $query->where('statuses.user_id', $user->id)
                                ->where('train_checkins.departure', '<', Carbon::now()->addMinutes(20));

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -18,6 +18,7 @@ use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 
 /**
@@ -62,6 +63,20 @@ class UserController extends Controller
                                   if (Auth::check()) {
                                       $query->orWhere(function($query) {
                                           $query->where('statuses.visibility', StatusVisibility::AUTHENTICATED->value);
+                                      })
+                                      ->orWhere(function($query) {
+                                          $currentUserId = auth()->user()->id;
+                                          $query->where('statuses.visibility', StatusVisibility::TRUSTED->value)
+                                                ->whereExists(function($subQuery) use ($currentUserId) {
+                                                    $subQuery->select(\DB::raw(1))
+                                                            ->from('trusted_users')
+                                                            ->whereColumn('trusted_users.user_id', 'statuses.user_id')
+                                                            ->where('trusted_users.trusted_id', $currentUserId)
+                                                            ->where(function($expireQuery) {
+                                                                $expireQuery->whereNull('trusted_users.expires_at')
+                                                                           ->orWhere('trusted_users.expires_at', '>', now());
+                                                            });
+                                                });
                                       });
                                   }
                               });

--- a/app/Policies/StatusPolicy.php
+++ b/app/Policies/StatusPolicy.php
@@ -57,14 +57,19 @@ class StatusPolicy
             return $user->follows->contains('id', $status->user_id);
         }
 
-        // Case 6: Status is unlisted
+        // Case 6: Status is trusted users only
+        if ($status->visibility === StatusVisibility::TRUSTED) {
+            return $status->user->trustedUsers->contains('trusted_id', $user->id);
+        }
+
+        // Case 7: Status is unlisted
         if ($status->visibility === StatusVisibility::UNLISTED) {
             //This isn't checked here. This is done in the query from the (global/private) dashboard.
             //But in general, unlisted statuses are visible to everyone.
             return Response::allow();
         }
 
-        // Case 7: Status is public or authenticated
+        // Case 8: Status is public or authenticated
         if ($status->visibility === StatusVisibility::PUBLIC || $status->visibility === StatusVisibility::AUTHENTICATED) {
             return Response::allow(); //TODO: How to handle with private profile?
         }

--- a/app/Policies/StatusTagPolicy.php
+++ b/app/Policies/StatusTagPolicy.php
@@ -39,7 +39,12 @@ class StatusTagPolicy
             return $user->follows->contains('id', $statusTag->status->user_id);
         }
 
-        // Case 6: StatusTag is for authenticated users only
+        // Case 6: StatusTag is trusted users only
+        if ($statusTag->visibility === StatusVisibility::TRUSTED && $user !== null) {
+            return $statusTag->status->user->trustedUsers->contains('trusted_id', $user->id);
+        }
+
+        // Case 7: StatusTag is for authenticated users only
         if ($user !== null && $statusTag->visibility === StatusVisibility::AUTHENTICATED) {
             return Response::allow('StatusTag is for authenticated users');
         }

--- a/lang/de.json
+++ b/lang/de.json
@@ -485,6 +485,8 @@
   "status.visibility.3.detail": "Nur für dich sichtbar",
   "status.visibility.4": "Nur angemeldete Nutzer",
   "status.visibility.4.detail": "Nur für angemeldete Nutzer sichtbar",
+  "status.visibility.5": "Vertraute Nutzer",
+  "status.visibility.5.detail": "Nur für von dir vertrauten Nutzern sichtbar",
   "status.update.success": "Dein Status wurde erfolgreich aktualisiert.",
   "status.manual_journey_number": "Fahrtennummer manuell eingeben",
   "status.show_more": "Mehr anzeigen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -451,6 +451,8 @@
   "status.visibility.3.detail": "Only visible for you",
   "status.visibility.4": "Only logged-in users",
   "status.visibility.4.detail": "Only visible for logged-in users",
+  "status.visibility.5": "Trusted users",
+  "status.visibility.5.detail": "Only visible for your trusted users",
   "status.update.success": "Your Status has been updated successfully.",
   "status.manual_journey_number": "Journey number manually overwritten",
   "status.show_more": "Show more",

--- a/resources/types/Api.gen.ts
+++ b/resources/types/Api.gen.ts
@@ -39,7 +39,7 @@ export enum TravelType {
 
 /**
  * visibility
- * What type of visibility (0=public, 1=unlisted, 2=followers, 3=private, 4=authenticated) did the
+ * What type of visibility (0=public, 1=unlisted, 2=followers, 3=private, 4=authenticated, 5=trusted) did the
  *  *      user specify?
  * @example 0
  */
@@ -49,6 +49,7 @@ export enum StatusVisibility {
   Value2 = 2,
   Value3 = 3,
   Value4 = 4,
+  Value5 = 5,
 }
 
 /**

--- a/resources/views/includes/visibility-dropdown.blade.php
+++ b/resources/views/includes/visibility-dropdown.blade.php
@@ -6,13 +6,13 @@
             data-bs-toggle="dropdown"
             aria-expanded="false"
     >
-        <i class="fa fa-{{['globe-americas', 'lock-open', 'user-friends', 'lock', 'user-check'][auth()->user()?->default_status_visibility->value ?? 0]}}"
+        <i class="fa fa-{{['globe-americas', 'lock-open', 'user-friends', 'lock', 'user-check', 'user-shield'][auth()->user()?->default_status_visibility->value ?? 0]}}"
            aria-hidden="true"></i>
     </button>
     <ul class="dropdown-menu" aria-labelledby="visibilityDropdownButton">
         @foreach(\App\Enum\StatusVisibility::cases() as $visibility)
             <li class="dropdown-item trwl-visibility-item" data-trwl-visibility="{{$visibility->value}}">
-                <i class="fa fa-{{['globe-americas', 'lock-open', 'user-friends', 'lock', 'user-check'][$visibility->value]}}"
+                <i class="fa fa-{{['globe-americas', 'lock-open', 'user-friends', 'lock', 'user-check', 'user-shield'][$visibility->value]}}"
                    aria-hidden="true"></i> {{ __('status.visibility.' . $visibility->value) }}
                 <br/>
                 <span class="text-muted"> {{ __('status.visibility.' . $visibility->value . '.detail') }}</span>

--- a/resources/vue/components/VisibilityDropdown.vue
+++ b/resources/vue/components/VisibilityDropdown.vue
@@ -42,6 +42,8 @@ export default {
           return "fa fa-lock";
         case 4:
           return "fa fa-user-check";
+        case 5:
+          return "fa fa-user-shield";
       }
     }
   },
@@ -88,6 +90,11 @@ export default {
       <i class="fa fa-user-check" aria-hidden="true"></i> {{ trans("status.visibility.4") }}
       <br>
       <span class="text-muted"> {{ trans("status.visibility.4.detail") }}</span>
+    </li>
+    <li class="dropdown-item" @click="setVisibility(5)">
+      <i class="fa fa-user-shield" aria-hidden="true"></i> {{ trans("status.visibility.5") }}
+      <br>
+      <span class="text-muted"> {{ trans("status.visibility.5.detail") }}</span>
     </li>
   </ul>
 </template>

--- a/resources/vue/helpers/IconHelper.ts
+++ b/resources/vue/helpers/IconHelper.ts
@@ -6,6 +6,7 @@ const visibilityIcons = {
     2: 'fa-user-friends',
     3: 'fa-lock',
     4: 'fa-user-check',
+    5: 'fa-user-shield',
 }
 
 const businessIcons = {
@@ -34,6 +35,8 @@ export class IconHelper {
                 return 'Private';
             case 4:
                 return 'Restricted';
+            case 5:
+                return 'Trusted Users';
             default:
                 return 'Unknown Visibility';
         }

--- a/tests/Feature/Privacy/Status/ViewTest.php
+++ b/tests/Feature/Privacy/Status/ViewTest.php
@@ -8,6 +8,7 @@ use App\Models\Checkin;
 use App\Models\Event;
 use App\Models\Follow;
 use App\Models\Status;
+use App\Models\TrustedUser;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Passport\Passport;
@@ -206,5 +207,111 @@ class ViewTest extends ApiTestCase
 
         //check if status is not displayed
         $response->assertDontSee('/status/' . $checkin->status->id);
+    }
+
+    public function testUnauthenticatedViewTrustedStatus(): void {
+        $user   = User::factory()->create();
+        $status = Status::factory(['user_id' => $user->id, 'visibility' => StatusVisibility::TRUSTED])
+                        ->has(Checkin::factory())
+                        ->create();
+
+        $this->assertGuest();
+        $statusRequest = $this->get(route('status', ['id' => $status->id]));
+        $statusRequest->assertStatus(403);
+    }
+
+    public function testViewForeignTrustedStatusAndNotTrusted(): void {
+        $user        = User::factory()->create();
+        $foreignUser = User::factory()->create();
+        $status      = Status::factory([
+                                           'user_id'    => $foreignUser->id,
+                                           'visibility' => StatusVisibility::TRUSTED,
+                                       ])->create();
+        $this->assertFalse($user->can('view', $status));
+    }
+
+    public function testViewForeignTrustedStatusAndIsTrusted(): void {
+        $user        = User::factory()->create();
+        $foreignUser = User::factory()->create();
+        
+        TrustedUser::create([
+            'user_id' => $foreignUser->id,
+            'trusted_id' => $user->id,
+        ]);
+        
+        $status = Status::factory([
+                                      'user_id'    => $foreignUser->id,
+                                      'visibility' => StatusVisibility::TRUSTED,
+                                  ])->create();
+        $this->assertTrue($user->can('view', $status));
+    }
+
+    // Nötig?
+    public function testViewForeignTrustedStatusWithExpiredTrust(): void {
+        $user        = User::factory()->create();
+        $foreignUser = User::factory()->create();
+        
+        TrustedUser::create([
+            'user_id' => $foreignUser->id,
+            'trusted_id' => $user->id,
+            'expires_at' => now()->subDay(),
+        ]);
+        
+        $status = Status::factory([
+                                      'user_id'    => $foreignUser->id,
+                                      'visibility' => StatusVisibility::TRUSTED,
+                                  ])->create();
+        $this->assertFalse($user->can('view', $status));
+    }
+
+    public function testTrustedStatusProfileVisibility(): void {
+        $user        = User::factory()->create();
+        $foreignUser = User::factory()->create();
+        Passport::actingAs($user, ['*']);
+
+        $checkin = Checkin::factory(['user_id' => $foreignUser->id])->create();
+        $checkin->status->update(['visibility' => StatusVisibility::TRUSTED]);
+
+        // Non-trusted user should not see trusted status on foreign user's profile
+        $response = $this->get("/api/v1/user/{$foreignUser->username}/statuses");
+        $response->assertOk();
+        $response->assertJsonCount(0, 'data');
+
+        TrustedUser::create([
+            'user_id' => $foreignUser->id,
+            'trusted_id' => $user->id,
+        ]);
+
+        $response = $this->get("/api/v1/user/{$foreignUser->username}/statuses");
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+    }
+
+    public function testTrustedStatusDashboardVisibility(): void {
+        $user        = User::factory()->create();
+        $foreignUser = User::factory()->create();
+        Passport::actingAs($user, ['*']);
+
+        // Make foreignUser follow user so the status appears on their dashboard
+        FollowBackend::createOrRequestFollow($user, $foreignUser);
+        $user->refresh();
+        
+        $checkin = Checkin::factory(['user_id' => $foreignUser->id])->create();
+        $checkin->status->update(['visibility' => StatusVisibility::TRUSTED]);
+ 
+        // Non-trusted user should not see trusted status on their dashboard
+        $response = $this->get("/api/v1/dashboard");
+        $response->assertOk();
+        $response->assertJsonCount(0, 'data');
+        
+        TrustedUser::create([
+            'user_id' => $foreignUser->id,
+            'trusted_id' => $user->id,
+        ]);
+
+        // Trusted user should see trusted status on their dashboard
+        $response = $this->get("/api/v1/dashboard");
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
     }
 }

--- a/tests/Feature/Privacy/StatusTagPrivacyTest.php
+++ b/tests/Feature/Privacy/StatusTagPrivacyTest.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Backend\User\FollowController;
 use App\Models\Follow;
 use App\Models\Status;
 use App\Models\StatusTag;
+use App\Models\TrustedUser;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\ApiTestCase;
@@ -60,5 +61,29 @@ class StatusTagPrivacyTest extends ApiTestCase
     public function testOwnerCanViewPrivateStatusTag(): void {
         $statusTag = StatusTag::factory(['visibility' => StatusVisibility::PRIVATE])->create();
         $this->assertTrue($statusTag->status->user->can('view', $statusTag));
+    }
+
+    public function testTrustedUserCanViewTrustedStatusTag(): void {
+        $user        = User::factory()->create();
+        $trustedUser = User::factory()->create();
+        
+        $status    = Status::factory(['user_id' => $user->id, 'visibility' => StatusVisibility::TRUSTED])->create();
+        $statusTag = StatusTag::factory([
+                                            'status_id'  => $status->id,
+                                            'visibility' => StatusVisibility::TRUSTED,
+                                        ])->create();
+
+        TrustedUser::create([
+            'user_id' => $user->id,
+            'trusted_id' => $trustedUser->id,
+        ]);
+
+        $this->assertTrue($trustedUser->can('view', $statusTag));
+    }
+
+    public function testNonTrustedUserCantViewTrustedStatusTag(): void {
+        $statusTag  = StatusTag::factory(['visibility' => StatusVisibility::TRUSTED])->create();
+        $randomUser = User::factory()->create();
+        $this->assertFalse($randomUser->can('view', $statusTag));
     }
 }


### PR DESCRIPTION
This is related to these discussions: #2028 #2959 

While the discussion as to whether private profiles should be able to post publicly is still ongoing (I assume), I've gone ahead and implemented this Trusted User visibility as proposed by @0AgentSmith in the discussions. This is shouldn't interfere with the "private profiles should not be able to post anything public" idea and it also doesn't require some sort of "migration" for current public check-ins of private profiles.

Tests have been added, I've tried to match them to the already existing ones (in terms of what to test/how to name things). Manual test with a dev instance was also done. 
Still, it'd be my first contribution to Träwelling, so I'm sorry if I forgot something somewhere. 