### PR TITLE
🐛 Fix name missing in beta status view

### DIFF
--- a/app/Http/Controllers/FrontendStatusController.php
+++ b/app/Http/Controllers/FrontendStatusController.php
@@ -69,6 +69,7 @@ class FrontendStatusController extends Controller
         if (\auth()->user()?->hasRole('open-beta')) {
             return view('beta.vue-status', [
                 'statusId' => $statusId,
+                'title'    => __('status.ogp-title', ['name' => $status->user->username]),
             ]);
         }
 

--- a/resources/views/beta/vue-status.blade.php
+++ b/resources/views/beta/vue-status.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', __('status.ogp-title', ['name' => '']))
+@section('title', $title)
 
 @section('content')
     <div class="container">


### PR DESCRIPTION
fixes #3810 

This PR aims to fix the title of the experimental status view, which currently doesn't show the username.

<img width="174" height="31" alt="grafik" src="https://github.com/user-attachments/assets/96b179a6-1067-4225-918d-39f20cad2ea9" />
