### PR TITLE
:bug: Trusted Users Fix: Alt 1, Add Index to Trusted users

### DIFF
--- a/database/migrations/2025_09_18_000001_add_trusted_users_performance_indexes.php
+++ b/database/migrations/2025_09_18_000001_add_trusted_users_performance_indexes.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('trusted_users', function (Blueprint $table) {
+            $table->index(['trusted_id', 'user_id', 'expires_at'], 'idx_trusted_users_lookup');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('trusted_users', function (Blueprint $table) {
+            $table->dropIndex('idx_trusted_users_lookup');
+        });
+    }
+};


### PR DESCRIPTION
This is a commit to be merged into the revert-revert branch, not develop directly (for now). 

This just adds an index to decrease loading time to the trusted users table. This shouldn't be a big problem when modifying trusted users since this is not done very often, so building the index itself should be okay - the question simply is whether one wants to include this. @MrKrisKrisu added this temporarily and then removed it, so I separated it from alternative solutions. 

