### PR TITLE
🐛 Trusted Users Fix: Alt 2, Use cache system

### DIFF
--- a/app/Http/Controllers/Backend/Transport/StatusController.php
+++ b/app/Http/Controllers/Backend/Transport/StatusController.php
@@ -78,20 +78,33 @@ abstract class StatusController extends Controller
                 });
 
                 //Option 4: Status is from a user who trusts the viewing user
-                $query->orWhere(function(Builder $query) use ($viewingUser) {
-                    $query->where('statuses.visibility', StatusVisibility::TRUSTED->value)
-                          ->whereExists(function($subQuery) use ($viewingUser) {
-                              $subQuery->select(\DB::raw(1))
-                                      ->from('trusted_users')
-                                      ->whereColumn('trusted_users.user_id', 'statuses.user_id')
-                                      ->where('trusted_users.trusted_id', $viewingUser->id)
-                                      ->where(function($expireQuery) {
-                                          $expireQuery->whereNull('trusted_users.expires_at')
-                                                     ->orWhere('trusted_users.expires_at', '>', now());
-                                      });
-                          });
-                });
+                $trustedUserIds = self::getTrustedUserIds($viewingUser->id);
+                if (!empty($trustedUserIds)) {
+                    $query->orWhere(function(Builder $query) use ($trustedUserIds) {
+                        $query->where('statuses.visibility', StatusVisibility::TRUSTED->value)
+                              ->whereIn('statuses.user_id', $trustedUserIds);
+                    });
+                }
             }
         };
+    }
+
+    /**
+     * Get user IDs who trust the given user (cached for performance)
+     *
+     * @param int $viewingUserId
+     * @return array
+     */
+    private static function getTrustedUserIds(int $viewingUserId): array {
+        return \Cache::remember("trusted_users_{$viewingUserId}", now()->addMinutes(5), function() use ($viewingUserId) {
+            return DB::table('trusted_users')
+                ->where('trusted_id', $viewingUserId)
+                ->where(function($query) {
+                    $query->whereNull('expires_at')
+                          ->orWhere('expires_at', '>', now());
+                })
+                ->pluck('user_id')
+                ->toArray();
+        });
     }
 }

--- a/app/Http/Controllers/Backend/User/DashboardController.php
+++ b/app/Http/Controllers/Backend/User/DashboardController.php
@@ -41,17 +41,11 @@ abstract class DashboardController extends Controller
                              StatusVisibility::AUTHENTICATED->value
                          ])
                          ->orWhere(function($trustedQuery) use ($user) {
-                             $trustedQuery->where('statuses.visibility', StatusVisibility::TRUSTED->value)
-                                         ->whereExists(function($subQuery) use ($user) {
-                                             $subQuery->select(\DB::raw(1))
-                                                     ->from('trusted_users')
-                                                     ->whereColumn('trusted_users.user_id', 'statuses.user_id')
-                                                     ->where('trusted_users.trusted_id', $user->id)
-                                                     ->where(function($expireQuery) {
-                                                         $expireQuery->whereNull('trusted_users.expires_at')
-                                                                    ->orWhere('trusted_users.expires_at', '>', now());
-                                                     });
-                                         });
+                             $trustedUserIds = self::getTrustedUserIds($user->id);
+                             if (!empty($trustedUserIds)) {
+                                 $trustedQuery->where('statuses.visibility', StatusVisibility::TRUSTED->value)
+                                             ->whereIn('statuses.user_id', $trustedUserIds);
+                             }
                          });
                      })
                      ->orWhere(function($query) use ($user) {
@@ -61,5 +55,24 @@ abstract class DashboardController extends Controller
                      ->orderBy('train_checkins.departure', 'desc')
                      ->latest()
                      ->simplePaginate(15);
+    }
+
+    /**
+     * Get user IDs who trust the given user (cached for performance)
+     *
+     * @param int $viewingUserId
+     * @return array
+     */
+    private static function getTrustedUserIds(int $viewingUserId): array {
+        return \Cache::remember("trusted_users_{$viewingUserId}", now()->addMinutes(5), function() use ($viewingUserId) {
+            return DB::table('trusted_users')
+                ->where('trusted_id', $viewingUserId)
+                ->where(function($query) {
+                    $query->whereNull('expires_at')
+                          ->orWhere('expires_at', '>', now());
+                })
+                ->pluck('user_id')
+                ->toArray();
+        });
     }
 }

--- a/tests/Feature/Privacy/Status/ViewTest.php
+++ b/tests/Feature/Privacy/Status/ViewTest.php
@@ -13,6 +13,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Passport\Passport;
 use Tests\ApiTestCase;
+use Illuminate\Support\Facades\Cache;
 
 class ViewTest extends ApiTestCase
 {
@@ -303,6 +304,8 @@ class ViewTest extends ApiTestCase
             'user_id' => $foreignUser->id,
             'trusted_id' => $user->id,
         ]);
+        
+        Cache::forget("trusted_users_{$user->id}");
 
         // Trusted user should see trusted status on their dashboard
         $response = $this->get("/api/v1/dashboard");


### PR DESCRIPTION
This is a commit to be merged into the revert-revert branch, not develop directly (for now).

This adds a cache based system to determine which users trust the current user. 

After the first row being evaluated, the relevant users should be cached and following rows/queries may be faster than having a subquery (depending on the cache system). 

The downside obviously is that effectively every active user that is fetching checkins in some way will have a cache entry for 5 minutes. I don't know whether the system is designed to or should handle this at all (based on the traffic Träwelling gets). The other downside is that there may be a delay when updating trusted users but that can be fixed with having the cache forget the entry of the to-be-trusted user.

Should be compatible with #3891, not compatible with #3893. 