### PR TITLE
:sparkles: Add journey numbers from MOTIS source

### DIFF
--- a/app/DataProviders/Hydrators/MotisHydrator.php
+++ b/app/DataProviders/Hydrators/MotisHydrator.php
@@ -235,8 +235,6 @@ class MotisHydrator
         $shortTripName      = !empty($leg['tripShortName']) ? $leg['tripShortName'] : null;
         $shortTripName      = $shortTripName !== null ? preg_replace('/\D/', '', $shortTripName) : null;
 
-        echo $shortTripName;
-
         return [
             'category'                => $category,
             'number'                  => $tripLineName,

--- a/app/DataProviders/Hydrators/MotisHydrator.php
+++ b/app/DataProviders/Hydrators/MotisHydrator.php
@@ -320,7 +320,7 @@ class MotisHydrator
                                       tripId:        $tripId,
                                       direction:     $rawDeparture['headsign'],
                                       lineName:      $tripLineName,
-                                      number:        $tripId,
+                                      number:        $tripShortName,
                                       category:      $hafasTravelType,
                                       journeyNumber: $tripShortName,
                                       operator:      $this->parseOperator($rawDeparture, $source),

--- a/app/DataProviders/Hydrators/MotisHydrator.php
+++ b/app/DataProviders/Hydrators/MotisHydrator.php
@@ -232,12 +232,16 @@ class MotisHydrator
         $license            = $this->motisRepository->getActiveLicense($leg['source'], $source);
         $operator           = $this->parseOperator($leg, $source);
         $polyline           = $this->getPolylineFromLeg($leg);
+        $shortTripName      = !empty($leg['tripShortName']) ? $leg['tripShortName'] : null;
+        $shortTripName      = $shortTripName !== null ? preg_replace('/\D/', '', $shortTripName) : null;
+
+        echo $shortTripName;
 
         return [
             'category'                => $category,
             'number'                  => $tripLineName,
             'linename'                => $tripLineName,
-            'journey_number'          => null,
+            'journey_number'          => $shortTripName,
             'operator_id'             => $operator?->id,
             'origin_id'               => $originStation->id,
             'destination_id'          => $destinationStation->id,
@@ -288,6 +292,7 @@ class MotisHydrator
 
             //trip
             $tripId              = $rawDeparture['tripId'];
+            $tripShortName       = $rawDeparture['tripShortName'] ?? '';
             $rawDepartureStation = $rawDeparture['place'];
             $tripLineName        = $rawDeparture['routeShortName'] ?? '';
             $hafasTravelType     = $this->getCategoryFromLeg($rawDeparture);
@@ -317,7 +322,7 @@ class MotisHydrator
                                       lineName:      $tripLineName,
                                       number:        $tripId,
                                       category:      $hafasTravelType,
-                                      journeyNumber: $tripId,
+                                      journeyNumber: $tripShortName,
                                       operator:      $this->parseOperator($rawDeparture, $source),
                                   ),
                 plannedPlatform:  $platformPlanned,

--- a/app/Hydrators/DepartureHydrator.php
+++ b/app/Hydrators/DepartureHydrator.php
@@ -51,7 +51,7 @@ class DepartureHydrator
             "line"                => [
                 "type"        => "line",
                 "id"          => $request->trip->lineName,
-                "fahrtNr"     => $request->trip->number,
+                "fahrtNr"     => $request->trip->journeyNumber,
                 "name"        => $request->trip->lineName,
                 "public"      => true,
                 "adminCode"   => "80____",

--- a/app/Hydrators/DepartureHydrator.php
+++ b/app/Hydrators/DepartureHydrator.php
@@ -51,7 +51,7 @@ class DepartureHydrator
             "line"                => [
                 "type"        => "line",
                 "id"          => $request->trip->lineName,
-                "fahrtNr"     => $request->trip->journeyNumber,
+                "fahrtNr"     => $request->trip->number,
                 "name"        => $request->trip->lineName,
                 "public"      => true,
                 "adminCode"   => "80____",


### PR DESCRIPTION
This PR adds the journey numbers which are now available in the MOTIS `shortTripName` field.
For compatibility reasons (journeyNumber is a number in Träwelling), I'm filtering all non-numeric characters.