### PR TITLE
:bug: load missing relationships for daily stats

### DIFF
--- a/app/Http/Controllers/Backend/Support/LocationController.php
+++ b/app/Http/Controllers/Backend/Support/LocationController.php
@@ -41,6 +41,8 @@ class LocationController
     }
 
     public static function forStatus(Status $status, ?GeoService $geoService = null): LocationController {
+        $status->checkin->loadMissing(['originStopover', 'destinationStopover']);
+
         return new self(
             $status->checkin->trip,
             $status->checkin->originStopover,


### PR DESCRIPTION
This commit fixes a bug where the trip diary page would fail to load for certain dates. The issue was caused by the  and  relationships not being loaded on the  model, which resulted in a null pointer exception when trying to access the stopover data.

Fixes #3939