### PR TITLE
:zap: remove `mastodonUrl` from LightUser model

### DIFF
--- a/app/Http/Resources/LightUserResource.php
+++ b/app/Http/Resources/LightUserResource.php
@@ -10,12 +10,11 @@ use OpenApi\Annotations as OA;
  * @OA\Schema(
  *      title="LightUser",
  *      description="User model with just basic information",
- *      required={"id", "displayName", "username", "profilePicture", "mastodonUrl", "preventIndex"},
+ *      required={"id", "displayName", "username", "profilePicture", "preventIndex"},
  *      @OA\Property(property="id", type="integer", example=1),
  *      @OA\Property(property="displayName", type="string", example="Gertrud"),
  *      @OA\Property(property="username", type="string", example="Gertrud123"),
  *      @OA\Property(property="profilePicture", type="string", example="https://traewelling.de/@Gertrud123/picture"),
- *      @OA\Property(property="mastodonUrl", type="string", example="https://traewelling.social/@Gertrud123"),
  *      @OA\Property(property="preventIndex", type="boolean", example=false)
  * )
  */
@@ -27,7 +26,7 @@ class LightUserResource extends JsonResource
             'displayName'    => (string) $this->name,
             'username'       => (string) $this->username,
             'profilePicture' => ProfilePictureController::getUrl($this->resource),
-            'mastodonUrl'    => $this->mastodonUrl ?? null,
+            'mastodonUrl'    => null, // TODO: remove after 2026-07 (this is not lightweight enough for a LightResource)
             'preventIndex'   => (bool) $this->prevent_index,
         ];
     }

--- a/resources/types/Api.gen.ts
+++ b/resources/types/Api.gen.ts
@@ -521,8 +521,6 @@ export interface LightUserResource {
   username: string;
   /** @example "https://traewelling.de/@Gertrud123/picture" */
   profilePicture: string;
-  /** @example "https://traewelling.social/@Gertrud123" */
-  mastodonUrl: string;
   /** @example false */
   preventIndex: boolean;
 }
@@ -767,6 +765,11 @@ export interface TransportResource {
    * @example "FFEE00"
    */
   routeColor?: string | null;
+  /**
+   * Hex color code of the route text, if available
+   * @example "FFFFFF"
+   */
+  routeTextColor?: string | null;
   /** @example 85639 */
   journeyNumber: number;
   /**
@@ -2679,6 +2682,62 @@ export class Api<
         path: `/status/${id}/like`,
         method: "DELETE",
         secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Returns paginated list of statuses, filtered by given parameters
+     *
+     * @tags Status
+     * @name ListStatuses
+     * @summary [Auth optional] List and filter statuses
+     * @request GET:/status
+     */
+    listStatuses: (
+      query?: {
+        /**
+         * Filter by text in status body
+         * @example "Having a great trip!"
+         */
+        body?: string;
+        /**
+         * Filter by user ID
+         * @example 42
+         */
+        user_id?: number;
+        /**
+         * Filter by origin station name
+         * @example "Central Station"
+         */
+        origin_text?: string;
+        /**
+         * Filter by origin station ID
+         * @example 5
+         */
+        origin_id?: number;
+        /**
+         * Filter by destination station name
+         * @example "Main Square"
+         */
+        destination_text?: string;
+        /**
+         * Filter by destination station ID
+         * @example 10
+         */
+        destination_id?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        {
+          data?: StatusResource[];
+        },
+        any
+      >({
+        path: `/status`,
+        method: "GET",
+        query: query,
         format: "json",
         ...params,
       }),

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -5472,7 +5472,6 @@
                     "displayName",
                     "username",
                     "profilePicture",
-                    "mastodonUrl",
                     "preventIndex"
                 ],
                 "properties": {
@@ -5491,10 +5490,6 @@
                     "profilePicture": {
                         "type": "string",
                         "example": "https://traewelling.de/@Gertrud123/picture"
-                    },
-                    "mastodonUrl": {
-                        "type": "string",
-                        "example": "https://traewelling.social/@Gertrud123"
                     },
                     "preventIndex": {
                         "type": "boolean",

--- a/tests/Feature/APIv1/StatusTest.php
+++ b/tests/Feature/APIv1/StatusTest.php
@@ -53,7 +53,6 @@ class StatusTest extends ApiTestCase
                                                    'displayName',
                                                    'username',
                                                    'profilePicture',
-                                                   'mastodonUrl',
                                                    'preventIndex',
                                                ],
                                                'train'       => [


### PR DESCRIPTION
For performance reasons, I have removed the `mastodonUrl` from the LightUserModel. The URL does not belong there and causes unnecessary resources, as the URL is regularly regenerated from the ID and creates request to the mastodon instance. To ensure that the change is not immediately breaking for you, the field now returns `null`. It will be completely removed after July 2026. The LightUserModel is only used in places where I assume that no one needs the Mastodon URL.

!!! **The normal UserModel is not affected.** !!!

Affected API endpoints:
- GET /leaderboard
- GET /leaderboard/distance
- GET /leaderboard/friends
- GET /leaderboard/{month}
- GET /event/{slug}/statuses
- GET /statistics/daily/{date}
- GET /dashboard
- GET /dashboard/future
- GET /statuses
- GET /status
- GET /status/{id}
- PUT /status/{id}
- GET /user/statuses/active
- GET /user/{username}/statuses
- POST /trains/checkin
- GET /user/{user}/trusted
- GET /user/self/trusted-by

( @Traewelling/api-consumer )