### PR TITLE
:wastebasket: deprecate ibnr and rilIdentifier fields in StationResource

### DIFF
--- a/app/Http/Resources/StationResource.php
+++ b/app/Http/Resources/StationResource.php
@@ -15,6 +15,22 @@ use OpenApi\Attributes as OA;
         new OA\Property(property: 'latitude', type: 'number', example: '48.993207'),
         new OA\Property(property: 'longitude', type: 'number', example: '8.400977'),
         new OA\Property(
+            property: 'ibnr',
+            description: 'Deprecated. Always null. Use identifiers with type "de_db_ibnr" instead.',
+            type: 'integer',
+            example: null,
+            nullable: true,
+            deprecated: true,
+        ),
+        new OA\Property(
+            property: 'rilIdentifier',
+            description: 'Deprecated. Always null. Use identifiers with type "de_db_ril100" instead.',
+            type: 'string',
+            example: null,
+            nullable: true,
+            deprecated: true,
+        ),
+        new OA\Property(
             property: 'areas',
             type: 'array',
             items: new OA\Items(ref: '#/components/schemas/AreaResource'),
@@ -36,8 +52,8 @@ class StationResource extends JsonResource
             'name' => $this->name,
             'latitude' => $this->latitude,
             'longitude' => $this->longitude,
-            'ibnr' => $this->ibnr, // @deprecated - see identifiers
-            'rilIdentifier' => $this->rilIdentifier, // @deprecated - see identifiers
+            'ibnr' => null, // @deprecated - see identifiers
+            'rilIdentifier' => null, // @deprecated - see identifiers
             'areas' => AreaResource::collection($this->whenLoaded('areas')),
             'identifiers' => StationIdentifierResource::collection($this->whenLoaded('stationIdentifiers')),
         ];

--- a/resources/types/Api.gen.ts
+++ b/resources/types/Api.gen.ts
@@ -1065,6 +1065,18 @@ export interface StationResource {
   latitude: number;
   /** @example "8.400977" */
   longitude: number;
+  /**
+   * Deprecated. Always null. Use identifiers with type "de_db_ibnr" instead.
+   * @deprecated
+   * @example null
+   */
+  ibnr: number | null;
+  /**
+   * Deprecated. Always null. Use identifiers with type "de_db_ril100" instead.
+   * @deprecated
+   * @example null
+   */
+  rilIdentifier: string | null;
   areas: AreaResource[];
   identifiers?: StationIdentifierResource[];
 }

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -7059,6 +7059,20 @@
                         "type": "number",
                         "example": "8.400977"
                     },
+                    "ibnr": {
+                        "description": "Deprecated. Always null. Use identifiers with type \"de_db_ibnr\" instead.",
+                        "type": "integer",
+                        "example": null,
+                        "nullable": true,
+                        "deprecated": true
+                    },
+                    "rilIdentifier": {
+                        "description": "Deprecated. Always null. Use identifiers with type \"de_db_ril100\" instead.",
+                        "type": "string",
+                        "example": null,
+                        "nullable": true,
+                        "deprecated": true
+                    },
                     "areas": {
                         "type": "array",
                         "items": {


### PR DESCRIPTION
step by step migration of https://github.com/Traewelling/traewelling/pull/4357

(API developers will be informed in a bundle after this big migration process. this is not breaking.)