### PR TITLE
:wastebasket: deprecate `evaIdentifier` and `rilIdentifier` fields in StopoverResource

### DIFF
--- a/app/Http/Resources/StopoverResource.php
+++ b/app/Http/Resources/StopoverResource.php
@@ -38,17 +38,19 @@ use OpenApi\Attributes as OA;
         ),
         new OA\Property(
             property: 'rilIdentifier',
-            description: 'Identifier specified in \'Richtline 100\' of the Deutsche Bahn',
+            description: 'Deprecated. Always null. Use the station identifiers endpoint instead.',
             type: 'string',
-            example: 'RK',
+            example: null,
             nullable: true,
+            deprecated: true,
         ),
         new OA\Property(
             property: 'evaIdentifier',
-            description: 'IBNR identifier of Deutsche Bahn',
+            description: 'Deprecated. Always null. Use the station identifiers endpoint instead.',
             type: 'string',
-            example: '8000191',
+            example: null,
             nullable: true,
+            deprecated: true,
         ),
         new OA\Property(
             property: 'arrival',
@@ -155,8 +157,8 @@ class StopoverResource extends JsonResource
         return [
             'id' => (int) $this->train_station_id,
             'name' => $this->station->name,
-            'rilIdentifier' => $this->station->rilIdentifier ?? null,
-            'evaIdentifier' => $this->station->ibnr ?? null,
+            'rilIdentifier' => null, // @deprecated
+            'evaIdentifier' => null, // @deprecated
             'arrival' => $this->arrival?->toIso8601String(), // TODO: not necessary if planned and real are available
             'arrivalPlanned' => $this->arrival_planned?->toIso8601String(),
             'arrivalReal' => $this->arrival_real?->toIso8601String(),

--- a/resources/tailwind-app/pages/Contribute/SuggestEvent.vue
+++ b/resources/tailwind-app/pages/Contribute/SuggestEvent.vue
@@ -101,9 +101,6 @@
                                     <div class="badge badge-lg badge-primary gap-2">
                                         <MapPin class="h-3 w-3" />
                                         {{ selectedStation.name }}
-                                        <span v-if="selectedStation.rilIdentifier" class="opacity-70">
-                                            ({{ selectedStation.rilIdentifier }})
-                                        </span>
                                         <button
                                             type="button"
                                             class="btn btn-ghost btn-xs btn-circle"
@@ -157,10 +154,18 @@
                                                         <span>
                                                             {{ station.name }}
                                                             <span
-                                                                v-if="station.rilIdentifier"
+                                                                v-if="
+                                                                    station.identifiers?.find(
+                                                                        (i) => i.type === 'de_db_ril100',
+                                                                    )
+                                                                "
                                                                 class="badge badge-xs badge-ghost ml-1"
                                                             >
-                                                                {{ station.rilIdentifier }}
+                                                                {{
+                                                                    station.identifiers?.find(
+                                                                        (i) => i.type === 'de_db_ril100',
+                                                                    )?.identifier
+                                                                }}
                                                             </span>
                                                         </span>
                                                         <span v-if="getStationArea(station)" class="text-xs opacity-50">
@@ -215,14 +220,18 @@ interface StationArea {
     adminLevel: number;
 }
 
+interface StationIdentifier {
+    type: string;
+    identifier: string;
+}
+
 interface Station {
     id: number;
     name: string;
     latitude: number;
     longitude: number;
-    ibnr: number;
-    rilIdentifier: string | null;
     areas?: StationArea[];
+    identifiers?: StationIdentifier[];
 }
 
 const form = reactive({

--- a/resources/types/Api.gen.ts
+++ b/resources/types/Api.gen.ts
@@ -1154,13 +1154,15 @@ export interface StopoverResource {
    */
   name: string;
   /**
-   * Identifier specified in 'Richtline 100' of the Deutsche Bahn
-   * @example "RK"
+   * Deprecated. Always null. Use the station identifiers endpoint instead.
+   * @deprecated
+   * @example null
    */
   rilIdentifier: string | null;
   /**
-   * IBNR identifier of Deutsche Bahn
-   * @example "8000191"
+   * Deprecated. Always null. Use the station identifiers endpoint instead.
+   * @deprecated
+   * @example null
    */
   evaIdentifier: string | null;
   /**

--- a/resources/vue/components/Checkin/CheckinInterface.vue
+++ b/resources/vue/components/Checkin/CheckinInterface.vue
@@ -24,11 +24,6 @@ export default {
             type: Object,
             required: true,
         },
-        useInternalIdentifiers: {
-            type: Boolean,
-            required: false,
-            default: false,
-        },
     },
     setup() {
         const userStore = useUserStore();
@@ -96,13 +91,11 @@ export default {
                 chainPost: this.toot && this.chainPost,
                 visibility: this.visibility,
                 business: this.business,
-                ibnr: !this.useInternalIdentifiers,
+                ibnr: false,
                 tripId: this.selectedTrain.tripId,
                 lineName: this.selectedTrain.line.name ?? this.selectedTrain.line.fahrtNr,
                 start: this.selectedTrain.stop.id,
-                destination: this.useInternalIdentifiers
-                    ? this.selectedDestination.id
-                    : this.selectedDestination.evaIdentifier,
+                destination: this.selectedDestination.id,
                 departure: DateTime.fromISO(this.selectedTrain.plannedWhen).setZone('UTC').toISO(),
                 arrival: DateTime.fromISO(this.selectedDestination.arrivalPlanned).setZone('UTC').toISO(),
                 force: this.collision,

--- a/resources/vue/components/CheckinLineRun.vue
+++ b/resources/vue/components/CheckinLineRun.vue
@@ -21,11 +21,6 @@ export default {
             required: false,
             default: null,
         },
-        useInternalIdentifiers: {
-            type: Boolean,
-            required: false,
-            default: false,
-        },
     },
     emits: ['update:destination'],
     data() {
@@ -83,10 +78,7 @@ export default {
                                     return true; // Keep future stops
                                 } else if (departure.equals(givenDeparture)) {
                                     // Check if the stop is the selected train's stop at the given time
-                                    const identifier = this.useInternalIdentifiers
-                                        ? Number(item.id)
-                                        : Number(item.evaIdentifier);
-                                    return Number(this.$props.selectedTrain.stop.id) !== identifier;
+                                    return Number(this.$props.selectedTrain.stop.id) !== Number(item.id);
                                 }
                             }
 
@@ -103,16 +95,9 @@ export default {
                 });
         },
         fastCheckin() {
-            let destination;
-            if (this.useInternalIdentifiers) {
-                destination = this.lineRun.stopovers.find((item) => {
-                    return Number(item.id) === Number(this.fastCheckinId);
-                });
-            } else {
-                destination = this.lineRun.stopovers.find((item) => {
-                    return Number(item.evaIdentifier) === Number(this.fastCheckinId);
-                });
-            }
+            const destination = this.lineRun.stopovers.find((item) => {
+                return Number(item.id) === Number(this.fastCheckinId);
+            });
 
             if (destination) {
                 this.handleSetDestination(destination);

--- a/resources/vue/components/Stationboard.vue
+++ b/resources/vue/components/Stationboard.vue
@@ -38,7 +38,6 @@ export default {
             firstFetchTime: null,
             pushState: null,
             fastCheckinIbnr: null,
-            useInternalIdentifiers: true,
             removedLicenses: [],
         };
     },
@@ -67,7 +66,7 @@ export default {
                 window.history.back();
             } else {
                 const params = new URLSearchParams(window.location.search);
-                const destination = this.useInternalIdentifiers ? value.id : value.evaIdentifier;
+                const destination = value.id;
                 params.set('destination', destination);
                 this.pushHistory(params);
             }
@@ -106,7 +105,7 @@ export default {
             const data = new URLSearchParams({
                 tripId: selectedItem.tripId,
                 lineName: selectedItem.line.name,
-                start: this.useInternalIdentifiers ? this.selectedTrain.stop.id : this.meta.station.ibnr,
+                start: this.selectedTrain.stop.id,
                 departure: selectedItem.when,
                 category: selectedItem.line.product,
             });
@@ -214,9 +213,6 @@ export default {
                 };
                 if (urlParams.has('destination')) {
                     this.fastCheckinIbnr = urlParams.get('destination');
-                }
-                if (urlParams.has('idType')) {
-                    this.useInternalIdentifiers = urlParams.get('idType') === 'trwl';
                 }
                 this.show = true;
                 this.$refs?.modal?.show();
@@ -349,13 +345,11 @@ export default {
                 v-model:destination="selectedDestination"
                 :selected-train="selectedTrain"
                 :fast-checkin-id="fastCheckinIbnr"
-                :use-internal-identifiers="useInternalIdentifiers"
             />
             <CheckinInterface
                 v-if="showCheckinInterface"
                 :selected-train="selectedTrain"
                 :selected-destination="selectedDestination"
-                :use-internal-identifiers="useInternalIdentifiers"
             />
         </template>
         <template v-if="showCheckinInterface" #close>

--- a/resources/vue/components/TripCreation/TripCreationMap.vue
+++ b/resources/vue/components/TripCreation/TripCreationMap.vue
@@ -60,7 +60,7 @@ export default defineComponent({
         addMarker(data, index, length) {
             const marker = L.marker([data.latitude, data.longitude], { icon: trainIcon }).addTo(this.map);
 
-            marker.bindPopup(`<strong>${data.name}</strong> <i>${data.rilIdentifier || ''}</i>`);
+            marker.bindPopup(`<strong>${data.name}</strong>`);
 
             if (index === 'origin') {
                 if (this.origin) {

--- a/resources/vue/helpers/StatusHelper.ts
+++ b/resources/vue/helpers/StatusHelper.ts
@@ -62,16 +62,12 @@ export class StatusHelper {
     }
 
     public getDescription(): string {
-        const originRil = this.status.train.origin.rilIdentifier ? ` (${this.status.train.origin.rilIdentifier})` : '';
-        const destinationRil = this.status.train.destination.rilIdentifier
-            ? ` (${this.status.train.destination.rilIdentifier})`
-            : '';
         const departure = getDepartureForStatus(this.status);
 
         return trans('description.status', {
             username: this.status.userDetails.username,
-            origin: this.status.train.origin.name + originRil,
-            destination: this.status.train.destination.name + destinationRil,
+            origin: this.status.train.origin.name,
+            destination: this.status.train.destination.name,
             date: departure.toLocaleString({
                 year: 'numeric',
                 month: 'numeric',

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -7256,16 +7256,18 @@
                         "example": "Karlsruhe Hbf"
                     },
                     "rilIdentifier": {
-                        "description": "Identifier specified in 'Richtline 100' of the Deutsche Bahn",
+                        "description": "Deprecated. Always null. Use the station identifiers endpoint instead.",
                         "type": "string",
-                        "example": "RK",
-                        "nullable": true
+                        "example": null,
+                        "nullable": true,
+                        "deprecated": true
                     },
                     "evaIdentifier": {
-                        "description": "IBNR identifier of Deutsche Bahn",
+                        "description": "Deprecated. Always null. Use the station identifiers endpoint instead.",
                         "type": "string",
-                        "example": "8000191",
-                        "nullable": true
+                        "example": null,
+                        "nullable": true,
+                        "deprecated": true
                     },
                     "arrival": {
                         "description": "currently known arrival time. Equal to arrivalReal if known. Else equal to arrivalPlanned.",


### PR DESCRIPTION
step by step migration of https://github.com/Traewelling/traewelling/pull/4357

(API developers will be informed in a bundle after this big migration process. this is not breaking.)