### PR TITLE
:card_file_box: change polyline column type to text in route_segments table

### DIFF
--- a/database/migrations/2026_03_14_000000_change_polyline_to_text_in_route_segments.php
+++ b/database/migrations/2026_03_14_000000_change_polyline_to_text_in_route_segments.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('route_segments', function (Blueprint $table): void {
+            $table->text('polyline')->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('route_segments', function (Blueprint $table): void {
+            $table->string('polyline', 10000)->change();
+        });
+    }
+};


### PR DESCRIPTION
Some long-distance polylines were too large, such as the TGV, which runs nonstop from Saarbrücken to Paris (cc @marhei). At first, I considered simply reducing the precision from 1 meter to 11 meters, but I wasn't satisfied with the result.