### PR TITLE
:sparkles: add parameter `withIdentifiers` for including station identifiers

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -36,6 +36,10 @@ Check back here regularly to stay ahead of removals.
 
 ---
 
+# 2026-03-21
+
+- `GET /api/v1/status/{id}`: New optional query parameter `withIdentifiers`. When `true`, includes `identifiers` in origin and destination stopovers (`StopoverResource`)
+
 # 2026-03-20
 
 Added `moderation_notes` (string, nullable), `lock_visibility` (boolean, nullable) and `hide_body` (boolean, nullable)

--- a/app/Http/Controllers/API/v1/StatusController.php
+++ b/app/Http/Controllers/API/v1/StatusController.php
@@ -398,6 +398,14 @@ class StatusController extends Controller
                 schema: new OA\Schema(type: 'integer'),
                 example: 1337,
             ),
+            new OA\Parameter(
+                name: 'withIdentifiers',
+                description: 'Include station identifiers in origin and destination stopovers',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'boolean'),
+                example: true,
+            ),
         ],
         responses: [
             new OA\Response(
@@ -412,13 +420,18 @@ class StatusController extends Controller
             new OA\Response(response: 403, description: 'User not authorized to access this status'),
         ],
     )]
-    public function show(int $id): StatusResource|JsonResponse
+    public function show(Request $request, int $id): StatusResource|JsonResponse
     {
         $status = StatusBackend::getStatus($id);
         try {
             $this->authorize('view', $status);
         } catch (AuthorizationException) {
             return response()->json(['message' => 'Status invisible to you.'], 403);
+        }
+
+        if ($request->boolean('withIdentifiers')) {
+            $status->checkin->originStopover->station->load('stationIdentifiers');
+            $status->checkin->destinationStopover->station->load('stationIdentifiers');
         }
 
         return new StatusResource($status);

--- a/resources/types/Api.gen.ts
+++ b/resources/types/Api.gen.ts
@@ -3759,7 +3759,17 @@ export class Api<
      * @request GET:/status/{id}
      * @secure
      */
-    getSingleStatus: (id?: number, params: RequestParams = {}) =>
+    getSingleStatus: (
+      id?: number,
+      query?: {
+        /**
+         * Include station identifiers in origin and destination stopovers
+         * @example true
+         */
+        withIdentifiers?: boolean;
+      },
+      params: RequestParams = {},
+    ) =>
       this.request<
         {
           data?: StatusResource;
@@ -3768,6 +3778,7 @@ export class Api<
       >({
         path: `/status/${id}`,
         method: "GET",
+        query: query,
         secure: true,
         format: "json",
         ...params,

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -4149,6 +4149,16 @@
                             "type": "integer"
                         },
                         "example": 1337
+                    },
+                    {
+                        "name": "withIdentifiers",
+                        "in": "query",
+                        "description": "Include station identifiers in origin and destination stopovers",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "example": true
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
see #4511