### PR TITLE
:sparkles: add tooltip to show exact meters

### DIFF
--- a/resources/tailwind-app/components/Stats/DistanceSpan.vue
+++ b/resources/tailwind-app/components/Stats/DistanceSpan.vue
@@ -32,7 +32,7 @@ const split = ref<SplitDistance>(metersToDistance(props.distance));
                 {{ trans('distance.megameters.short') }}
             </small>
         </span>
-        <span v-if="split.kilometers > 0" class="tooltip" :data-tip="trans('distance.kilometers')">
+        <span v-if="split.kilometers > 0" class="tooltip cursor-default" :data-tip="`${props.distance} m`">
             {{ split.kilometers }}
             <small class="opacity-65 me-1">
                 {{ trans('distance.kilometers.short') }}


### PR DESCRIPTION
see #4901

<img width="655" height="216" alt="grafik" src="https://github.com/user-attachments/assets/ad8030c4-0c35-42ec-8695-63bef2cab040" />
