### PR TITLE
🐛 Fix serialization of missing values

### DIFF
--- a/app/Http/Controllers/Backend/WebhookController.php
+++ b/app/Http/Controllers/Backend/WebhookController.php
@@ -148,7 +148,8 @@ abstract class WebhookController extends Controller
         // Missing values actually cannot be frozen, because toArray fails on them
         // Sidenote: Signer fails on them as well
         $relevant = array_filter($data, function ($value) {
-            return !($value instanceof JsonResource && $value->resource instanceof MissingValue);
+            return !($value instanceof JsonResource && $value->resource instanceof MissingValue)
+                   && !($value instanceof MissingValue);
         });
 
         return array_map(function ($value) {


### PR DESCRIPTION
https://github.com/Traewelling/traewelling/blob/9fbb1c02a5a98e91ecde2d795b7f702e0bb6b0cb/app/Http/Resources/OperatorResource.php#L49-L54

Some functions like `when` returned `MissingValue` directly causing invalid json being rendered

<img width="619" height="238" alt="image" src="https://github.com/user-attachments/assets/ccea525e-55c4-481f-a4bd-463e5e08d742" />


#HSFDPMUW