### PR TITLE
:card_file_box: add `uuid` for trips and stopovers

### DIFF
--- a/app/Models/Stopover.php
+++ b/app/Models/Stopover.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Str;
 
 /**
  * @todo rename table to "Stopover" (without Train - we have more than just trains)
@@ -17,6 +18,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  *       to think about this.
  *
  * @property int $id
+ * @property string|null $uuid
  * @property string $trip_id
  * @property int $train_station_id
  * @property $arrival_planned
@@ -66,6 +68,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Stopover whereTrainStationId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Stopover whereTripId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Stopover whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Stopover whereUuid($value)
  *
  * @mixin \Eloquent
  */
@@ -74,6 +77,18 @@ class Stopover extends Model
     use HasFactory;
 
     protected $table = 'train_stopovers';
+
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        // UUID is not yet the primary key, so we can't use the HasUuids trait here.
+        static::creating(function (self $stopover): void {
+            if (empty($stopover->uuid)) {
+                $stopover->uuid = Str::uuid()->toString();
+            }
+        });
+    }
 
     protected $fillable = [
         'trip_id', 'train_station_id',
@@ -91,6 +106,7 @@ class Stopover extends Model
 
     protected $casts = [
         'id' => 'integer',
+        'uuid' => 'string',
         'trip_id' => 'string',
         'train_station_id' => 'integer',
         'arrival_planned' => UTCDateTime::class,

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 
 /**
  * @todo rename table only to "Trip" (without Hafas)
@@ -20,6 +21,7 @@ use Illuminate\Support\Carbon;
  * @todo drop origin and destination, when origin_id and destination_id are added
  *
  * @property int $id
+ * @property string|null $uuid
  * @property string $trip_id
  * @property HafasTravelType $category
  * @property string $number
@@ -80,6 +82,7 @@ use Illuminate\Support\Carbon;
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Trip whereTripId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Trip whereUpdatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Trip whereUserId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Trip whereUuid($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Trip whereContinuationTripId($value)
  *
  * @mixin \Eloquent
@@ -89,6 +92,18 @@ class Trip extends Model
     use HasFactory;
 
     protected $table = 'hafas_trips';
+
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        // UUID is not yet the primary key, so we can't use the HasUuids trait here.
+        static::creating(function (self $trip): void {
+            if (empty($trip->uuid)) {
+                $trip->uuid = Str::uuid()->toString();
+            }
+        });
+    }
 
     protected $fillable = [
         'trip_id', 'category', 'number', 'linename', 'route_color', 'route_text_color', 'journey_number', 'operator_id', 'origin_id',
@@ -100,6 +115,7 @@ class Trip extends Model
 
     protected $casts = [
         'id' => 'integer',
+        'uuid' => 'string',
         'trip_id' => 'string',
         'category' => HafasTravelType::class,
         'number' => 'string',

--- a/app/Services/PersonalDataSelection/Exporters/TripsExporter.php
+++ b/app/Services/PersonalDataSelection/Exporters/TripsExporter.php
@@ -16,7 +16,7 @@ class TripsExporter extends AbstractExporter
     protected string $tableName = 'hafas_trips';
 
     protected array $columns = [
-        'id', 'trip_id', 'category', 'number', 'linename', 'journey_number',
+        'id', 'uuid', 'trip_id', 'category', 'number', 'linename', 'journey_number',
         'operator_id', 'origin_id', 'destination_id', 'polyline_id', 'departure', 'arrival',
         'source', 'motis_source', 'user_id', 'last_refreshed', 'created_at', 'updated_at', 'route_color', 'mode', 'route_text_color', 'continuation_trip_id', 'motis_source_license_id',
     ];

--- a/database/migrations/2026_08_02_000000_add_uuid_to_hafas_trips.php
+++ b/database/migrations/2026_08_02_000000_add_uuid_to_hafas_trips.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        if (in_array(DB::getDriverName(), ['mysql', 'mariadb'], true)) {
+            DB::statement('ALTER TABLE hafas_trips ADD COLUMN uuid CHAR(36) NULL, ALGORITHM=INPLACE, LOCK=NONE');
+
+            return;
+        }
+
+        Schema::table('hafas_trips', function (Blueprint $table): void {
+            $table->uuid('uuid')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('hafas_trips', function (Blueprint $table): void {
+            $table->dropColumn('uuid');
+        });
+    }
+};

--- a/database/migrations/2026_08_02_000001_add_uuid_to_train_stopovers.php
+++ b/database/migrations/2026_08_02_000001_add_uuid_to_train_stopovers.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        if (in_array(DB::getDriverName(), ['mysql', 'mariadb'], true)) {
+            DB::statement('ALTER TABLE train_stopovers ADD COLUMN uuid CHAR(36) NULL, ALGORITHM=INPLACE, LOCK=NONE');
+
+            return;
+        }
+
+        Schema::table('train_stopovers', function (Blueprint $table): void {
+            $table->uuid('uuid')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('train_stopovers', function (Blueprint $table): void {
+            $table->dropColumn('uuid');
+        });
+    }
+};

--- a/database/migrations/2026_08_02_000002_backfill_uuid_in_hafas_trips.php
+++ b/database/migrations/2026_08_02_000002_backfill_uuid_in_hafas_trips.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class() extends Migration
+{
+    private const CHUNK_SIZE = 1_000;
+
+    public function up(): void
+    {
+        if (in_array(DB::getDriverName(), ['mysql', 'mariadb'], true)) {
+            DB::statement('UPDATE hafas_trips SET uuid = UUID()');
+
+            return;
+        }
+
+        DB::table('hafas_trips')
+            ->select('id')
+            ->orderBy('id')
+            ->chunkById(self::CHUNK_SIZE, function (iterable $rows): void {
+                foreach ($rows as $row) {
+                    DB::table('hafas_trips')
+                        ->where('id', $row->id)
+                        ->update(['uuid' => Str::uuid()->toString()]);
+                }
+            });
+    }
+};

--- a/database/migrations/2026_08_02_000003_backfill_uuid_in_train_stopovers.php
+++ b/database/migrations/2026_08_02_000003_backfill_uuid_in_train_stopovers.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Str;
 
 return new class() extends Migration
 {
-    private const CHUNK_SIZE = 10_000;
+    private const CHUNK_SIZE = 30_000;
 
     public function up(): void
     {

--- a/database/migrations/2026_08_02_000003_backfill_uuid_in_train_stopovers.php
+++ b/database/migrations/2026_08_02_000003_backfill_uuid_in_train_stopovers.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class() extends Migration
+{
+    private const CHUNK_SIZE = 10_000;
+
+    public function up(): void
+    {
+        if (in_array(DB::getDriverName(), ['mysql', 'mariadb'], true)) {
+            $minId = (int) DB::table('train_stopovers')->min('id');
+            $maxId = (int) DB::table('train_stopovers')->max('id');
+
+            for ($start = $minId; $start <= $maxId; $start += self::CHUNK_SIZE) {
+                DB::affectingStatement(
+                    'UPDATE train_stopovers SET uuid = UUID() WHERE id >= ? AND id < ? AND uuid IS NULL',
+                    [$start, $start + self::CHUNK_SIZE]
+                );
+            }
+
+            return;
+        }
+
+        DB::table('train_stopovers')
+            ->select('id')
+            ->orderBy('id')
+            ->chunkById(self::CHUNK_SIZE, function (iterable $rows): void {
+                foreach ($rows as $row) {
+                    DB::table('train_stopovers')
+                        ->where('id', $row->id)
+                        ->update(['uuid' => Str::uuid()->toString()]);
+                }
+            });
+    }
+};

--- a/database/migrations/2026_08_02_000004_add_unique_index_to_hafas_trips_uuid.php
+++ b/database/migrations/2026_08_02_000004_add_unique_index_to_hafas_trips_uuid.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        if (in_array(DB::getDriverName(), ['mysql', 'mariadb'], true)) {
+            DB::statement('ALTER TABLE hafas_trips ADD UNIQUE INDEX hafas_trips_uuid_unique (uuid), ALGORITHM=INPLACE, LOCK=NONE');
+
+            return;
+        }
+
+        Schema::table('hafas_trips', function (Blueprint $table): void {
+            $table->unique('uuid', 'hafas_trips_uuid_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('hafas_trips', function (Blueprint $table): void {
+            $table->dropUnique('hafas_trips_uuid_unique');
+        });
+    }
+};

--- a/database/migrations/2026_08_02_000005_add_unique_index_to_train_stopovers_uuid.php
+++ b/database/migrations/2026_08_02_000005_add_unique_index_to_train_stopovers_uuid.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        if (in_array(DB::getDriverName(), ['mysql', 'mariadb'], true)) {
+            DB::statement('ALTER TABLE train_stopovers ADD UNIQUE INDEX train_stopovers_uuid_unique (uuid), ALGORITHM=INPLACE, LOCK=NONE');
+
+            return;
+        }
+
+        Schema::table('train_stopovers', function (Blueprint $table): void {
+            $table->unique('uuid', 'train_stopovers_uuid_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('train_stopovers', function (Blueprint $table): void {
+            $table->dropUnique('train_stopovers_uuid_unique');
+        });
+    }
+};


### PR DESCRIPTION
This migration will take about 30 minutes on our database size. It's not required to do it while maintenance mode as this is not breaking on runtine. Backfill of UUIDs are batched, so there are no big database locks.