### PR TITLE
:rewind: join interlined trip legs again

### DIFF
--- a/app/DataProviders/Motis.php
+++ b/app/DataProviders/Motis.php
@@ -364,7 +364,6 @@ class Motis extends Controller implements DataProviderInterface
         try {
             $response = Http::withUserAgent(VersionController::getUserAgent())->get(self::API_URL . '/v6/trip', [
                 'tripId' => $tripId,
-                'joinInterlinedLegs' => 'false',
             ]);
 
             if ($response->ok()) {
@@ -409,39 +408,13 @@ class Motis extends Controller implements DataProviderInterface
             throw new DataProviderException(__('messages.exception.motis.trip-not-found'));
         }
 
-        $legs = $rawJourney['legs'];
-
-        $matchingIndex = 0;
-        foreach ($legs as $index => $leg) {
-            if ($leg['tripId'] === $tripID) {
-                $matchingIndex = $index;
-                break;
-            }
+        $leg = $rawJourney['legs'][0] ?? null;
+        if ($leg === null) {
+            throw new DataProviderException(__('messages.exception.motis.trip-not-found'));
         }
 
-        $primaryLeg = $legs[$matchingIndex];
-        $journey = Trip::updateOrCreate(['trip_id' => $tripID], $this->hydrator->getTripData($primaryLeg, $lineName, $this->source));
-        $this->tripRepository->tryToSaveStopovers($journey, $this->hydrator->parseLegToNewStopovers($primaryLeg, $this->source));
-
-        $seenTripIds = [$tripID];
-        $previousTrip = $journey;
-        foreach (array_slice($legs, $matchingIndex + 1) as $interlinedLeg) {
-            if (!($interlinedLeg['interlineWithPreviousLeg'] ?? false)) {
-                break;
-            }
-            if (in_array($interlinedLeg['tripId'], $seenTripIds, true)) {
-                break;
-            }
-            $interlinedTrip = Trip::updateOrCreate(
-                ['trip_id' => $interlinedLeg['tripId']],
-                $this->hydrator->getTripData($interlinedLeg, $interlinedLeg['displayName'] ?? $lineName, $this->source)
-            );
-            $this->tripRepository->tryToSaveStopovers($interlinedTrip, $this->hydrator->parseLegToNewStopovers($interlinedLeg, $this->source));
-
-            $seenTripIds[] = $interlinedLeg['tripId'];
-            $previousTrip->update(['continuation_trip_id' => $interlinedTrip->id]);
-            $previousTrip = $interlinedTrip;
-        }
+        $journey = Trip::updateOrCreate(['trip_id' => $tripID], $this->hydrator->getTripData($leg, $lineName, $this->source));
+        $this->tripRepository->tryToSaveStopovers($journey, $this->hydrator->parseLegToNewStopovers($leg, $this->source));
 
         return $journey;
     }

--- a/app/Http/Controllers/API/v1/TransportController.php
+++ b/app/Http/Controllers/API/v1/TransportController.php
@@ -270,7 +270,7 @@ class TransportController extends Controller
                     tripID: $validated['hafasTripId'],
                     lineName: $validated['lineName']
                 )
-                ->loadMissing(['stopovers', 'originStation', 'destinationStation', 'continuationTrip.destinationStation']);
+                ->loadMissing(['stopovers', 'originStation', 'destinationStation']);
 
             return $this->sendResponse(data: new TripResource($trip));
         } catch (DataProviderException $exception) {

--- a/app/Http/Resources/TripResource.php
+++ b/app/Http/Resources/TripResource.php
@@ -9,7 +9,7 @@ use OpenApi\Attributes as OA;
 
 #[OA\Schema(
     title: 'TripResource',
-    required: ['id', 'uuid', 'tripId', 'category', 'mode', 'number', 'lineName', 'journeyNumber', 'origin', 'destination', 'operator', 'stopovers', 'checkinCount', 'dataSource', 'continuationTrip'],
+    required: ['id', 'uuid', 'tripId', 'category', 'mode', 'number', 'lineName', 'journeyNumber', 'origin', 'destination', 'operator', 'stopovers', 'checkinCount', 'dataSource'],
     properties: [
         new OA\Property(property: 'id', type: 'int', example: 1),
         new OA\Property(property: 'uuid', description: 'Stable identifier of this trip. Will become the primary key later.', type: 'string', format: 'uuid', example: '00000000-0000-0000-0000-000000000000', nullable: true),
@@ -38,21 +38,10 @@ use OpenApi\Attributes as OA;
             ref: '#/components/schemas/DataSourceResource',
             nullable: true,
         ),
-        new OA\Property(
-            property: 'continuationTrip',
-            ref: TripResource::class,
-            description: 'If this trip is an interlined through-running service, this contains the immediately following trip (different line name/color, no transfer required).',
-            nullable: true,
-        ),
     ],
 )]
 class TripResource extends JsonResource
 {
-    public function __construct($resource, private readonly bool $includeContinuation = true)
-    {
-        parent::__construct($resource);
-    }
-
     /**
      * Transform the resource into an array.
      *
@@ -78,10 +67,6 @@ class TripResource extends JsonResource
             'stopovers' => StopoverResource::collection($this->stopovers),
             'checkinCount' => (int) ($this->checkins_count ?? $this->checkins()->count()),
             'dataSource' => $this->motisSourceLicense ? new DataSourceResource($this->motisSourceLicense) : null,
-            'continuationTrip' => $this->when(
-                $this->includeContinuation && $this->continuation_trip_id !== null,
-                fn () => new TripResource($this->continuationTrip, includeContinuation: false),
-            ),
         ];
     }
 }

--- a/app/Jobs/CleanupUnusedTrip.php
+++ b/app/Jobs/CleanupUnusedTrip.php
@@ -48,8 +48,7 @@ class CleanupUnusedTrip implements ShouldQueue
         $polylineId = $trip->polyline_id;
 
         try {
-            // stopovers and carriage sequences are deleted via cascade,
-            // continuation_trip_id references are set to null via FK
+            // stopovers and carriage sequences are deleted via cascade
             $trip->delete();
         } catch (QueryException) {
             // a new checkin referenced the trip in the meantime, the restrict FK protects it

--- a/app/Jobs/RefreshTrip.php
+++ b/app/Jobs/RefreshTrip.php
@@ -65,22 +65,16 @@ class RefreshTrip implements ShouldBeUnique, ShouldQueue
                 return;
             }
 
-            $matchingLeg = null;
-            foreach ($rawJourney['legs'] as $leg) {
-                if (($leg['tripId'] ?? null) === $this->trip->trip_id) {
-                    $matchingLeg = $leg;
-                    break;
-                }
-            }
+            $leg = $rawJourney['legs'][0] ?? null;
 
-            if ($matchingLeg === null || !($matchingLeg['realTime'] ?? false)) {
+            if ($leg === null || !($leg['realTime'] ?? false)) {
                 Log::debug('RefreshTrip Job skipped: no real-time data available', ['trip_id' => $this->trip->trip_id]);
 
                 return;
             }
 
             $stopovers = $motisHydrator->parseLegToUpdateStopovers(
-                $matchingLeg,
+                $leg,
                 $this->trip,
                 DataProvider::TRANSITOUS
             );

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -43,8 +43,6 @@ use Illuminate\Support\Str;
  * @property string|null $route_color
  * @property MotisCategory|null $mode
  * @property string|null $route_text_color
- * @property int|null $continuation_trip_id
- * @property-read Trip|null $continuationTrip
  * @property-read Collection<int, Checkin> $checkins
  * @property-read int|null $checkins_count
  * @property-read Station|null $destinationStation
@@ -108,7 +106,7 @@ class Trip extends Model
     protected $fillable = [
         'trip_id', 'category', 'number', 'linename', 'route_color', 'route_text_color', 'journey_number', 'operator_id', 'origin_id',
         'destination_id', 'polyline_id', 'departure', 'arrival', 'source', 'motis_source', 'user_id', 'last_refreshed',
-        'motis_source_license_id', 'mode', 'continuation_trip_id',
+        'motis_source_license_id', 'mode',
     ];
 
     protected $hidden = ['created_at', 'updated_at'];
@@ -133,7 +131,6 @@ class Trip extends Model
         'source' => TripSource::class,
         'user_id' => 'integer',
         'mode' => MotisCategory::class,
-        'continuation_trip_id' => 'integer',
     ];
 
     public function polyline(): HasOne
@@ -179,10 +176,5 @@ class Trip extends Model
     public function motisSourceLicense(): BelongsTo
     {
         return $this->belongsTo(MotisSourceLicense::class, 'motis_source_license_id', 'id');
-    }
-
-    public function continuationTrip(): BelongsTo
-    {
-        return $this->belongsTo(Trip::class, 'continuation_trip_id', 'id');
     }
 }

--- a/app/Repositories/TripRepository.php
+++ b/app/Repositories/TripRepository.php
@@ -98,62 +98,10 @@ class TripRepository
 
         if (is_numeric($tripID)) {
             $trip = Trip::where('id', $tripID)->where('linename', $lineName)->first();
-
-            return $trip ?? $dataProvider->fetchHafasTrip($tripID, $lineName);
-        }
-        $trip = Trip::where('trip_id', $tripID)->first();
-
-        if ($trip === null) {
-            return $dataProvider->fetchHafasTrip($tripID, $lineName);
+        } else {
+            $trip = Trip::where('trip_id', $tripID)->where('linename', $lineName)->first();
         }
 
-        if ($trip->linename === $lineName) {
-            return $trip;
-        }
-
-        if ($trip->continuation_trip_id !== null) {
-            $match = $this->findInContinuationChainByLineName($trip, $lineName);
-            if ($match !== null) {
-                return $match;
-            }
-        }
-
-        $trip = $dataProvider->fetchHafasTrip($tripID, $lineName);
-
-        if ($trip->linename === $lineName) {
-            return $trip;
-        }
-
-        if ($trip->continuation_trip_id !== null) {
-            $match = $this->findInContinuationChainByLineName($trip, $lineName);
-            if ($match !== null) {
-                return $match;
-            }
-        }
-
-        return $trip;
-    }
-
-    private function findInContinuationChainByLineName(Trip $trip, string $lineName): ?Trip
-    {
-        $seenIds = [$trip->id];
-        $continuationId = $trip->continuation_trip_id;
-
-        while ($continuationId !== null) {
-            if (in_array($continuationId, $seenIds, true)) {
-                break;
-            }
-            $continuation = Trip::find($continuationId);
-            if ($continuation === null) {
-                break;
-            }
-            if ($continuation->linename === $lineName) {
-                return $continuation;
-            }
-            $seenIds[] = $continuation->id;
-            $continuationId = $continuation->continuation_trip_id;
-        }
-
-        return null;
+        return $trip ?? $dataProvider->fetchHafasTrip($tripID, $lineName);
     }
 }

--- a/app/Services/PersonalDataSelection/Exporters/TripsExporter.php
+++ b/app/Services/PersonalDataSelection/Exporters/TripsExporter.php
@@ -18,7 +18,7 @@ class TripsExporter extends AbstractExporter
     protected array $columns = [
         'id', 'uuid', 'trip_id', 'category', 'number', 'linename', 'journey_number',
         'operator_id', 'origin_id', 'destination_id', 'polyline_id', 'departure', 'arrival',
-        'source', 'motis_source', 'user_id', 'last_refreshed', 'created_at', 'updated_at', 'route_color', 'mode', 'route_text_color', 'continuation_trip_id', 'motis_source_license_id',
+        'source', 'motis_source', 'user_id', 'last_refreshed', 'created_at', 'updated_at', 'route_color', 'mode', 'route_text_color', 'motis_source_license_id',
     ];
 
     protected string $whereColumn = 'user_id';

--- a/database/migrations/2026_08_11_000000_drop_continuation_trip_id_from_hafas_trips.php
+++ b/database/migrations/2026_08_11_000000_drop_continuation_trip_id_from_hafas_trips.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+// end experiment with interlined legs -> joined again (back to defaul tbehaviour)
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        if (in_array(DB::getDriverName(), ['mysql', 'mariadb'], true)) {
+            DB::statement('ALTER TABLE hafas_trips DROP FOREIGN KEY hafas_trips_continuation_trip_id_foreign');
+            DB::statement('ALTER TABLE hafas_trips DROP COLUMN continuation_trip_id, ALGORITHM=INPLACE, LOCK=NONE');
+
+            return;
+        }
+
+        Schema::table('hafas_trips', function (Blueprint $table): void {
+            $table->dropForeign(['continuation_trip_id']);
+            $table->dropColumn('continuation_trip_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('hafas_trips', function (Blueprint $table): void {
+            $table->unsignedBigInteger('continuation_trip_id')->nullable();
+            $table->foreign('continuation_trip_id')->references('id')->on('hafas_trips')->nullOnDelete();
+        });
+    }
+};

--- a/lang/de.json
+++ b/lang/de.json
@@ -776,7 +776,6 @@
     "stationboard.hidden-departures.detail3": "Wenn du mehr über die Lizenzen erfahren möchtest, klicke hier:",
     "stationboard.label-message": "Status-Nachricht:",
     "stationboard.last-stations": "Letzte Stationen",
-    "stationboard.continues-as": "Fährt weiter als",
     "stationboard.line": "Linie",
     "stationboard.minus-15": "-15 Minuten",
     "stationboard.new-checkin": "Neuer Check-in",

--- a/lang/en.json
+++ b/lang/en.json
@@ -776,7 +776,6 @@
   "stationboard.hidden-departures.detail3": "If you would like to learn more about the licenses, please click here:",
   "stationboard.label-message": "Message:",
   "stationboard.last-stations": "Last stations",
-  "stationboard.continues-as": "Continues as",
   "stationboard.line": "Line",
   "stationboard.minus-15": "-15 Minutes",
   "stationboard.new-checkin": "New check-in",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -779,7 +779,6 @@
     "stationboard.hidden-departures.detail3": "Si tu souhaites en savoir plus sur les licences, clique ici :",
     "stationboard.label-message": "Message d’enregistrement :",
     "stationboard.last-stations": "Derniers points d'arrêt",
-    "stationboard.continues-as": "Continue en tant que",
     "stationboard.line": "Ligne",
     "stationboard.minus-15": "-15 minutes",
     "stationboard.new-checkin": "Nouvel enregistrement",

--- a/resources/tailwind-app/components/Checkin/LineRun.vue
+++ b/resources/tailwind-app/components/Checkin/LineRun.vue
@@ -4,8 +4,6 @@ import { DateTime } from 'luxon';
 import { onMounted, ref, watch } from 'vue';
 import { Api, StopoverResource, TripResource } from '../../../types/Api.gen';
 
-type ContinuationTrip = NonNullable<TripResource['continuationTrip']>;
-
 const api = new Api({ baseUrl: window.location.origin + '/api/v1' });
 
 const props = defineProps<{
@@ -21,7 +19,6 @@ const emit = defineEmits<{
 }>();
 
 const stopovers = ref<StopoverResource[]>([]);
-const continuationTrip = ref<ContinuationTrip | null>(null);
 const attribution = ref<string | null>(null);
 const loading = ref(false);
 const error = ref(false);
@@ -80,7 +77,6 @@ async function fetchLineRun(): Promise<void> {
         });
         stopovers.value = startIndex !== -1 ? allStopovers.slice(startIndex + 1) : allStopovers;
 
-        continuationTrip.value = (trip.continuationTrip as ContinuationTrip) ?? null;
         attribution.value = trip.dataSource?.attribution ?? null;
 
         if (props.fastCheckinId) {
@@ -136,19 +132,6 @@ watch(() => props.tripId, fetchLineRun);
             </button>
         </li>
     </ul>
-
-    <p v-if="continuationTrip" class="px-4 py-2 text-sm text-base-content/50 text-center mb-0">
-        {{ trans('stationboard.continues-as') }}
-        <span
-            class="badge badge-sm font-mono ml-1"
-            :style="{
-                backgroundColor: continuationTrip.routeColor ? `#${continuationTrip.routeColor}` : undefined,
-                color: continuationTrip.routeTextColor ? `#${continuationTrip.routeTextColor}` : undefined,
-            }"
-            >{{ continuationTrip.lineName }}</span
-        >
-        {{ continuationTrip.destination?.name }}
-    </p>
 
     <div v-if="attribution" class="px-4 pb-4 pt-2">
         <!-- eslint-disable-next-line vue/no-v-html -->

--- a/resources/types/Api.gen.ts
+++ b/resources/types/Api.gen.ts
@@ -2575,8 +2575,6 @@ export interface TripResource {
    */
   checkinCount: number;
   dataSource: DataSourceResource | null;
-  /** If this trip is an interlined through-running service, this contains the immediately following trip (different line name/color, no transfer required). */
-  continuationTrip: TripResource | null;
 }
 
 /** TrustedUser */

--- a/resources/vue/components/CheckinLineRun.vue
+++ b/resources/vue/components/CheckinLineRun.vue
@@ -148,22 +148,6 @@ export default {
             </a>
         </li>
     </ul>
-    <p v-if="lineRun?.continuationTrip" class="text-muted small mb-0 py-2 text-center">
-        {{ $t('stationboard.continues-as') }}
-        <span
-            class="badge ms-1"
-            :style="{
-                backgroundColor: lineRun.continuationTrip.routeColor
-                    ? `#${lineRun.continuationTrip.routeColor}`
-                    : undefined,
-                color: lineRun.continuationTrip.routeTextColor
-                    ? `#${lineRun.continuationTrip.routeTextColor}`
-                    : undefined,
-            }"
-            >{{ lineRun.continuationTrip.lineName }}</span
-        >
-        {{ lineRun.continuationTrip.destination.name }}
-    </p>
     <div v-if="lineRun?.dataSource?.attribution" class="pt-5 pb-2">
         <!-- eslint-disable-next-line vue/no-v-html -->
         <span class="text-xs text-muted" v-html="lineRun.dataSource?.attribution" />

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -15549,8 +15549,7 @@
                     "operator",
                     "stopovers",
                     "checkinCount",
-                    "dataSource",
-                    "continuationTrip"
+                    "dataSource"
                 ],
                 "properties": {
                     "id": {
@@ -15624,15 +15623,6 @@
                             }
                         ],
                         "nullable": true
-                    },
-                    "continuationTrip": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/TripResource"
-                            }
-                        ],
-                        "nullable": true,
-                        "description": "If this trip is an interlined through-running service, this contains the immediately following trip (different line name/color, no transfer required)."
                     }
                 },
                 "type": "object"

--- a/tests/Unit/Jobs/RefreshTripTest.php
+++ b/tests/Unit/Jobs/RefreshTripTest.php
@@ -45,57 +45,13 @@ class RefreshTripTest extends UnitTestCase
         return $trip;
     }
 
-    public function test_uses_first_leg_when_it_matches_trip_id(): void
+    public function test_skips_when_leg_has_no_realtime(): void
     {
-        $trip = $this->mockTrip('trip-A', 'ICE 1');
+        $trip = $this->mockTrip('trip-A', 'ECE 7');
 
         Http::fake([
             'https://api.transitous.org/api/*/trip*' => Http::response([
-                'legs' => [$this->makeLeg('trip-A', true)],
-            ], 200),
-        ]);
-
-        $hydrator = Mockery::mock(MotisHydrator::class);
-        $hydrator->shouldReceive('parseLegToUpdateStopovers')
-            ->once()
-            ->withArgs(fn (array $leg) => $leg['tripId'] === 'trip-A')
-            ->andReturn(new Collection());
-
-        new RefreshTrip($trip)->handle($hydrator);
-    }
-
-    public function test_finds_matching_leg_when_not_the_first_leg(): void
-    {
-        $trip = $this->mockTrip('trip-B', 'ECE 7');
-
-        Http::fake([
-            'https://api.transitous.org/api/*/trip*' => Http::response([
-                'legs' => [
-                    $this->makeLeg('trip-A', true),  // first leg belongs to a different trip
-                    $this->makeLeg('trip-B', true),  // second leg is the one we want
-                ],
-            ], 200),
-        ]);
-
-        $hydrator = Mockery::mock(MotisHydrator::class);
-        $hydrator->shouldReceive('parseLegToUpdateStopovers')
-            ->once()
-            ->withArgs(fn (array $leg) => $leg['tripId'] === 'trip-B')
-            ->andReturn(new Collection());
-
-        new RefreshTrip($trip)->handle($hydrator);
-    }
-
-    public function test_skips_when_matching_leg_has_no_realtime(): void
-    {
-        $trip = $this->mockTrip('trip-B', 'ECE 7');
-
-        Http::fake([
-            'https://api.transitous.org/api/*/trip*' => Http::response([
-                'legs' => [
-                    $this->makeLeg('trip-A', true),
-                    $this->makeLeg('trip-B', false),
-                ],
+                'legs' => [$this->makeLeg('trip-A', false)],
             ], 200),
         ]);
 
@@ -105,17 +61,12 @@ class RefreshTripTest extends UnitTestCase
         new RefreshTrip($trip)->handle($hydrator);
     }
 
-    public function test_skips_when_no_matching_leg_found(): void
+    public function test_skips_when_journey_has_no_legs(): void
     {
-        $trip = $this->mockTrip('trip-unknown', 'ECE 7');
+        $trip = $this->mockTrip('trip-A', 'ECE 7');
 
         Http::fake([
-            'https://api.transitous.org/api/*/trip*' => Http::response([
-                'legs' => [
-                    $this->makeLeg('trip-A', true),
-                    $this->makeLeg('trip-B', true),
-                ],
-            ], 200),
+            'https://api.transitous.org/api/*/trip*' => Http::response(['legs' => []], 200),
         ]);
 
         $hydrator = Mockery::mock(MotisHydrator::class);


### PR DESCRIPTION
fixes #5007, reverts #4809

A few months ago, we started fetching the individual legs of a trip separately. This resulted in more negative feedback than actual benefit (such as correct line numbers). Therefore, I would prefer to revert this change.